### PR TITLE
docs: add minor clarification for exporting evernote

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ First install Importer in Obsidian → Community Plugins
 
 ### Import notes from Evernote
 
-- Export your Evernote files to `.enex` format. You can export a whole notebook by going to the Notebooks screen, click on **More actions** (`...` icon) and choose **Export Notebook...** 
+- Export your Evernote files to `.enex` format. You can export a whole notebook in the desktop client by going to the Notebooks screen, click on **More actions** (`...` icon) and choose **Export Notebook...**
 - Open the **Importer** plugin in Obsidian via the command palette or ribbon icon
 - Under **File format** select **Evernote (.enex)**
 - Choose the `.enex` file you want to import


### PR DESCRIPTION
First thank you for releasing this plugin! I'm in the process of migrating notes from Evernote as I type :) 

This change adds a minor clarification that the ability to export a whole notebook is only available within the desktop client.