### PR TITLE
Replaces prettier formatting with eslint linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["plugin:@typescript-eslint/recommended"],
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "root": true
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,15 @@
 {
-  "extends": ["plugin:@typescript-eslint/recommended"],
-  "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint"],
-  "root": true
+    "extends": ["plugin:@typescript-eslint/recommended"],
+    "parser": "@typescript-eslint/parser",
+    "plugins": ["@typescript-eslint"],
+    "root": true,
+    "rules": {
+        "indent": ["error", 4],
+        "no-tabs": 0,
+        "@typescript-eslint/no-explicit-any": 0,
+        "@typescript-eslint/prefer-as-const": 0,
+        "@typescript-eslint/ban-ts-comment": 0,
+        "@typescript-eslint/no-unused-vars": 0,
+        "@typescript-eslint/ban-types": 0
+    }
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,9 +1,0 @@
-{
-	"printWidth": 120,
-	"bracketSameLine": true,
-	"useTabs": true,
-	"tabWidth": 2,
-	"semi": true,
-	"quoteProps": "consistent",
-	"arrowParens": "avoid"
-}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"version": "node version-bump.mjs && git add manifest.json versions.json",
-		"format": "prettier . --write"
+    "lint": "eslint . --ext .ts --ext .js --ext .mjs --ext .json --fix"
 	},
 	"keywords": [],
 	"author": "",
@@ -15,8 +15,11 @@
 	"devDependencies": {
 		"@types/node": "16.6.2",
 		"@types/xml-flow": "1.0.1",
+		"@typescript-eslint/eslint-plugin": "^6.2.1",
+		"@typescript-eslint/parser": "^6.2.1",
 		"builtin-modules": "3.3.0",
 		"esbuild": "0.17.3",
+		"eslint": "^8.46.0",
 		"obsidian": "latest",
 		"prettier": "3.0.1",
 		"tslib": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -15,13 +15,12 @@
 	"devDependencies": {
 		"@types/node": "16.6.2",
 		"@types/xml-flow": "1.0.1",
-		"@typescript-eslint/eslint-plugin": "^6.2.1",
-		"@typescript-eslint/parser": "^6.2.1",
+		"@typescript-eslint/eslint-plugin": "6.2.1",
+		"@typescript-eslint/parser": "6.2.1",
 		"builtin-modules": "3.3.0",
 		"esbuild": "0.17.3",
-		"eslint": "^8.46.0",
+		"eslint": "8.46.0",
 		"obsidian": "latest",
-		"prettier": "3.0.1",
 		"tslib": "2.4.0",
 		"typescript": "4.7.4"
 	},


### PR DESCRIPTION
- Removes prettier
- Adds eslint and a `npm run lint` command
- Includes plugins for typescript and extends typescript