### PR TITLE
initial commit for apple notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-importer",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Import notes from other apps like Evernote.",
 	"main": "main.js",
 	"scripts": {
@@ -13,6 +13,8 @@
 	"author": "",
 	"license": "MIT",
 	"devDependencies": {
+    "@jxa/global-type": "^1.3.6",
+    "@jxa/run": "^1.3.6",
 		"@microsoft/microsoft-graph-types": "2.38.0",
 		"@types/node": "16.6.2",
 		"@types/xml-flow": "1.0.1",
@@ -26,6 +28,7 @@
 		"typescript": "4.7.4"
 	},
 	"dependencies": {
+    "2md": "^0.0.8",
 		"@zip.js/zip.js": "2.7.20",
 		"joplin-turndown-plugin-gfm": "1.0.12",
 		"xml-flow": "1.0.4"

--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -1,0 +1,179 @@
+import { CachedMetadata, Setting, TFile, TFolder } from 'obsidian';
+import { NodePickedFile, PickedFile, url as nodeUrl } from '../filesystem';
+import { ImportContext } from '../main';
+import { parseHTML, stringToUtf8 } from '../util';
+import { run } from '@jxa/run';
+import { exportNotes } from './apple-notes/export';
+import { fixDocumentUrls, HtmlImporter } from './html';
+import { toMd } from '2md';
+
+export class AppleNotesImporter extends HtmlImporter {
+	attachmentSizeLimit: number;
+	minimumImageSize: number;
+
+	init() {
+		this.exportNotes();
+		this.addFileChooserSetting('HTML', ['htm', 'html'], true);
+	}
+
+	exportNotes() {
+		new Setting(this.modal.contentEl)
+			.setName('Export')
+			.setDesc('This will export all your Apple Notes')
+			.addButton((button) =>
+				button.setButtonText('Export').onClick(async () => {
+					run(exportNotes);
+				})
+			);
+	}
+
+	override async processFile(
+		ctx: ImportContext,
+		folder: TFolder,
+		file: PickedFile
+	) {
+		ctx.status('Processing ' + file.name);
+		try {
+			const htmlContent = await file.readText();
+
+			const dom = parseHTML(htmlContent);
+			fixDocumentUrls(dom);
+
+			// Find all the attachments and download them
+			const baseUrl =
+				file instanceof NodePickedFile
+					? nodeUrl.pathToFileURL(file.filepath)
+					: undefined;
+			const attachments = new Map<string, TFile | null>();
+			const attachmentLookup = new Map<string, TFile>();
+			for (let el of dom.findAll('img, audio, video')) {
+				if (ctx.isCancelled()) return;
+
+				let src = el.getAttribute('src');
+				if (!src) continue;
+
+				try {
+					const url = new URL(
+						src.startsWith('//') ? `https:${src}` : src,
+						baseUrl
+					);
+
+					let key = url.href;
+					let attachmentFile = attachments.get(key);
+					if (!attachments.has(key)) {
+						ctx.status('Downloading attachment for ' + file.name);
+						attachmentFile = await this.downloadAttachment(
+							folder,
+							el,
+							url
+						);
+						attachments.set(key, attachmentFile);
+						if (attachmentFile) {
+							attachmentLookup.set(
+								attachmentFile.path,
+								attachmentFile
+							);
+							ctx.reportAttachmentSuccess(attachmentFile.name);
+						} else {
+							ctx.reportSkipped(src);
+						}
+					}
+
+					if (attachmentFile) {
+						// Convert the embed into a vault absolute path
+						el.setAttribute(
+							'src',
+							attachmentFile.path.replace(/ /g, '%20')
+						);
+
+						// Convert `<audio>` and `<video>` into `<img>` so that htmlToMarkdown can properly parse it.
+						if (!(el instanceof HTMLImageElement)) {
+							el.replaceWith(
+								createEl('img', {
+									attr: {
+										src: attachmentFile.path.replace(
+											/ /g,
+											'%20'
+										),
+										alt: el.getAttr('alt'),
+									},
+								})
+							);
+						}
+					}
+				} catch (e) {
+					ctx.reportFailed(src, e);
+				}
+			}
+
+			let mdContent = toMd(dom.innerHTML);
+			let mdFile = await this.saveAsMarkdownFile(
+				folder,
+				file.basename,
+				mdContent
+			);
+
+			// Because `htmlToMarkdown` always gets us markdown links, we'll want to convert them into wikilinks, or relative links depending on the user's preference.
+			if (!Object.isEmpty(attachments)) {
+				// Attempt to parse links using MetadataCache
+				let { metadataCache } = this.app;
+				let cache: CachedMetadata;
+				// @ts-ignore
+				if (metadataCache.computeMetadataAsync) {
+					// @ts-ignore
+					cache = (await metadataCache.computeMetadataAsync(
+						stringToUtf8(mdContent)
+					)) as CachedMetadata;
+				} else {
+					cache = await new Promise<CachedMetadata>((resolve) => {
+						let cache = metadataCache.getFileCache(mdFile);
+						if (cache) return resolve(cache);
+						const ref = metadataCache.on(
+							'changed',
+							(file, content, cache) => {
+								if (file === mdFile) {
+									metadataCache.offref(ref);
+									resolve(cache);
+								}
+							}
+						);
+					});
+				}
+
+				// Gather changes to make to the document
+				let changes = [];
+				if (cache.embeds) {
+					for (let { link, position } of cache.embeds) {
+						if (attachmentLookup.has(link)) {
+							let newLink =
+								this.app.fileManager.generateMarkdownLink(
+									attachmentLookup.get(link)!,
+									mdFile.path
+								);
+							changes.push({
+								from: position.start.offset,
+								to: position.end.offset,
+								text: newLink,
+							});
+						}
+					}
+				}
+
+				// Apply changes from last to first
+				changes.sort((a, b) => b.from - a.from);
+				for (let change of changes) {
+					mdContent =
+						mdContent.substring(0, change.from) +
+						change.text +
+						mdContent.substring(change.to);
+				}
+
+				await this.vault.modify(mdFile, mdContent);
+			}
+
+			ctx.reportNoteSuccess(file.fullpath);
+		} catch (e) {
+			ctx.reportFailed(file.fullpath, e);
+		}
+	}
+}

--- a/src/formats/apple-notes/export.ts
+++ b/src/formats/apple-notes/export.ts
@@ -1,0 +1,131 @@
+import '@jxa/global-type';
+import { Notes } from '@jxa/types/src/core/Notes';
+
+declare global {
+	interface String {
+		name(): string;
+	}
+	type ProgressType = {
+		totalUnitCount: number;
+		completedUnitCount: number;
+		description: string;
+		additionalDescription: string;
+	};
+	interface NotesItem extends Notes.Note, String {}
+}
+
+let Progress: ProgressType = {
+	totalUnitCount: 0,
+	completedUnitCount: 0,
+	description: '',
+	additionalDescription: '',
+};
+
+export const exportNotes = async () => {
+	const notesApp = Application('Notes');
+	notesApp.includeStandardAdditions = true;
+
+	const currentApp = Application.currentApplication();
+	currentApp.includeStandardAdditions = true;
+
+	const notesAccount = currentApp.chooseFromList(['iCloud', 'On My Mac'], {
+		withPrompt: 'Choose Notes Account',
+		defaultItems: ['iCloud'],
+	}) as unknown as Notes.Account[];
+
+	if (notesAccount.length <= 0) displayError('Notes Account not chosen');
+	const allNotesInAccount = notesApp.accounts.byName(notesAccount)
+		.notes as unknown as NotesItem;
+	if (allNotesInAccount.length <= 0) displayError('Notes Account not found');
+
+	const selectedNotes = currentApp.chooseFromList(allNotesInAccount.name(), {
+		withPrompt: 'Select Notes',
+		multipleSelectionsAllowed: true,
+	}) as unknown as Notes.Note[];
+
+	if (selectedNotes.length === 0) displayError('No note selected');
+
+	const outputFormat = 'Hypertext (.html) file';
+	const outputFileSuffix = '.html';
+
+	const savePath = currentApp
+		.chooseFolder({
+			withPrompt: 'Choose output location',
+		})
+		.toString();
+	if (savePath.length <= 0) displayError('No output location specified');
+
+	Progress.totalUnitCount = selectedNotes.length;
+	Progress.completedUnitCount = 0;
+	Progress.description = 'Exporting Notes...';
+	Progress.additionalDescription = `Exporting notes into ${outputFormat}s.`;
+
+	for (let i = 0; i < allNotesInAccount.length; i++) {
+		if (
+			selectedNotes.includes(
+				allNotesInAccount[i].name() as unknown as Notes.Note
+			)
+		) {
+			Progress.additionalDescription = `Exporting Note ${
+				Progress.completedUnitCount + 1
+			} of ${Progress.totalUnitCount}`;
+
+			const noteFilePath = `${savePath}/${allNotesInAccount[
+				i
+			].name()}${outputFileSuffix}`;
+
+			writeTextToFile(
+				noteFilePath,
+				(allNotesInAccount[i] as unknown as Notes.Note).body(),
+				false
+			);
+
+			Progress.completedUnitCount++;
+		}
+	}
+
+	currentApp.displayNotification('All selected notes have been exported.', {
+		withTitle: 'MacOS Notes Exporter',
+		subtitle: 'Export is complete.',
+		soundName: 'Glass',
+	});
+
+	function displayError(errorMessage: string) {
+		currentApp.displayDialog(errorMessage);
+	}
+
+	function writeTextToFile(
+		file: string,
+		text: string,
+		overwriteExistingContent = true
+	) {
+		try {
+			const fileString = file.toString();
+
+			const openedFile = currentApp.openForAccess(Path(fileString), {
+				writePermission: true,
+			});
+
+			if (overwriteExistingContent) {
+				currentApp.setEof(openedFile, { to: 0 });
+			}
+
+			currentApp.write(text, {
+				to: openedFile,
+				startingAt: currentApp.getEof(openedFile),
+			});
+
+			currentApp.closeAccess(openedFile);
+
+			return true;
+		} catch (error) {
+			try {
+				currentApp.closeAccess(file);
+			} catch (error) {
+				console.log(`Couldn't close file: ${error}`);
+			}
+
+			return false;
+		}
+	}
+};

--- a/src/formats/html.ts
+++ b/src/formats/html.ts
@@ -261,7 +261,7 @@ export class HtmlImporter extends FormatImporter {
 	}
 }
 
-function fixElementRef(element: Element, attribute: string) {
+export function fixElementRef(element: Element, attribute: string) {
 	const value = element.getAttribute(attribute);
 	if (value !== null) {
 		element.setAttribute(attribute, value.replace(/ /gu, '%20'));
@@ -269,16 +269,16 @@ function fixElementRef(element: Element, attribute: string) {
 }
 
 // Fix any links that happen to have spaces in them, since markdown links/embeds do not allow that.
-function fixDocumentUrls(el: Element) {
+export function fixDocumentUrls(el: Element) {
 	el.findAll('a').forEach(element => fixElementRef(element, 'href'));
 	el.findAll('audio, img, video').forEach(element => fixElementRef(element, 'src'));
 }
 
-function parseURL(url: URL) {
+export function parseURL(url: URL) {
 	return parseFilePath(normalizePath(decodeURIComponent(url.pathname)));
 }
 
-async function requestURL(url: URL): Promise<{ data: ArrayBuffer, mime: string }> {
+export async function requestURL(url: URL): Promise<{ data: ArrayBuffer, mime: string }> {
 	try {
 		const response = await fetch(url, {
 			mode: 'cors',
@@ -300,7 +300,7 @@ async function requestURL(url: URL): Promise<{ data: ArrayBuffer, mime: string }
 	};
 }
 
-async function getImageSize(data: ArrayBuffer): Promise<{ height: number, width: number }> {
+export async function getImageSize(data: ArrayBuffer): Promise<{ height: number, width: number }> {
 	const image = new Image();
 	const url = URL.createObjectURL(new Blob([data]));
 	try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { RoamJSONImporter } from './formats/roam-json';
 import { NotionImporter } from './formats/notion';
 import { OneNoteImporter } from './formats/onenote';
 import { truncateText } from './util';
+import { AppleNotesImporter } from 'formats/apple-notes';
 
 declare global {
 	interface Window {
@@ -19,7 +20,7 @@ declare global {
 interface ImporterDefinition {
 	name: string;
 	optionText: string;
-	helpPermalink: string;
+	helpPermalink?: string;
 	formatDescription?: string;
 	importer: new (app: App, modal: Modal) => FormatImporter;
 }
@@ -241,12 +242,11 @@ export default class ImporterPlugin extends Plugin {
 				helpPermalink: 'import/notion',
 				formatDescription: 'Export your Notion workspace to HTML format.',
 			},
-			'roam-json': {
-				name: 'Roam Research',
-				optionText: 'Roam Research (.json)',
-				importer: RoamJSONImporter,
-				helpPermalink: 'import/roam',
-				formatDescription: 'Export your Roam Research workspace to JSON format.',
+			'apple': {
+				name: 'Apple Notes',
+				optionText: 'Apple Notes',
+				importer: AppleNotesImporter,
+				formatDescription: 'Auto import Apple Notes.',
 			},
 		};
 
@@ -337,10 +337,12 @@ export class ImporterModal extends Modal {
 			descriptionFragment.createSpan({ text: selectedImporter.formatDescription });
 		}
 		descriptionFragment.createEl('br');
-		descriptionFragment.createEl('a', {
-			text: `Learn more about importing from ${selectedImporter.name}.`,
-			href: `https://help.obsidian.md/${selectedImporter.helpPermalink}`,
-		});
+		if (selectedImporter.helpPermalink) {	
+			descriptionFragment.createEl('a', {
+				text: `Learn more about importing from ${selectedImporter.name}.`,
+				href: `https://help.obsidian.md/${selectedImporter.helpPermalink}`,
+			});
+		}
 
 		new Setting(contentEl)
 			.setName('File format')


### PR DESCRIPTION
This approach uses Automator and Apple Script written in TypeScript that transpiles to Apple JXA (JavaScript for Automation) to export Apple Notes instead of full disk permission and messing around with SQLite instances.



https://github.com/obsidianmd/obsidian-importer/assets/62795688/34214cad-0b97-425f-a9ff-488ba3c05bd3




This requires Obsidian App to add `NSAppleEventsUsageDescription` to Info.plist

```xml
<key>NSAppleEventsUsageDescription</key>
<string>An application in Obsidian wants to use AppleScript.</string>
```



/closes #15 

