### PR TITLE
Notion: Fix codeblocks being imported without line breaks

### DIFF
--- a/src/formats/notion/convert-to-md.ts
+++ b/src/formats/notion/convert-to-md.ts
@@ -287,10 +287,14 @@ function replaceTableOfContents(body: HTMLElement) {
 }
 
 function encodeNewlinesToBr(body: HTMLElement) {
-	body.innerHTML = body.innerHTML.replace(/\n/g, '<br />');
-	// Since <br /> is ignored in codeblocks, we replace with newlines
+	// Since <br /> is ignored in codeblocks, we preserve newlines inside codeblocks with a placeholder.
 	for (const block of body.findAll('code')) {
-		block.innerHTML = block.innerHTML.replace(/<br \/>/g, '\n');
+		block.innerHTML = block.innerHTML.replace(/\n/g, '##placeholder##');
+	}
+	body.innerHTML = body.innerHTML.replace(/\n/g, '<br />');
+	// Restore newlines inside codeblocks
+	for (const block of body.findAll('code')) {
+		block.innerHTML = block.innerHTML.replace(/##placeholder##/g, '\n');
 	}
 }
 


### PR DESCRIPTION
Fixes #107. (See https://github.com/obsidianmd/obsidian-importer/issues/107#issuecomment-1722272675)