### PR TITLE
Apple Notes: Fix older drawings, scans, and a few other things

### DIFF
--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -136,6 +136,8 @@ export class AppleNotesImporter extends FormatImporter {
 				this.ctx.reportFailed(n.ZTITLE1, e?.message); 
 			}
 		}
+		
+		this.database.close();
 	}
 	
 	async resolveAccount(id: number): Promise<void> {

--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -290,11 +290,18 @@ export class AppleNotesImporter extends FormatImporter {
 						AND z_pk = ${id} 
 				`;
 				
-				const filename = row.ZFALLBACKIMAGEGENERATION ? 'FallbackImage.png' : `${row.ZIDENTIFIER}.jpg`;
-				sourcePath = path.join(
-					this.resolvedAccounts[row.ZACCOUNT1].path, 
-					'FallbackImages', row.ZIDENTIFIER, row.ZFALLBACKIMAGEGENERATION || '', filename
-				);
+				if (row.ZFALLBACKIMAGEGENERATION) {
+					// macOS 14/iOS 17 and above
+					sourcePath = path.join(
+						this.resolvedAccounts[row.ZACCOUNT1].path, 
+						'FallbackImages', row.ZIDENTIFIER, row.ZFALLBACKIMAGEGENERATION, 'FallbackImage.png'
+					);
+				}
+				else {
+					sourcePath = path.join(
+						this.resolvedAccounts[row.ZACCOUNT1].path, 'FallbackImages', `${row.ZIDENTIFIER}.jpg`
+					);
+				}
 				
 				outName = 'Drawing';
 				outExt = 'png';

--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -150,7 +150,8 @@ export class AppleNotesImporter extends FormatImporter {
 			
 		this.resolvedAccounts[id] = {
 			name: account.ZNAME,
-			uuid: account.ZIDENTIFIER
+			uuid: account.ZIDENTIFIER,
+			path: path.join(os.homedir(), NOTE_FOLDER_PATH, 'Accounts', account.ZIDENTIFIER)
 		};
 	}
 	
@@ -251,7 +252,7 @@ export class AppleNotesImporter extends FormatImporter {
 				`;
 				
 				sourcePath = path.join(
-					os.homedir(), NOTE_FOLDER_PATH, 'Accounts', this.resolvedAccounts[row.ZACCOUNT1].uuid, 
+					this.resolvedAccounts[row.ZACCOUNT1].path, 
 					'FallbackPDFs', row.ZIDENTIFIER, row.ZFALLBACKPDFGENERATION || '', 'FallbackPDF.pdf'
 				);
 				outName = 'Scan';
@@ -269,7 +270,7 @@ export class AppleNotesImporter extends FormatImporter {
 				`;
 				
 				sourcePath = path.join(
-					os.homedir(), NOTE_FOLDER_PATH, 'Accounts', this.resolvedAccounts[row.ZACCOUNT1].uuid, 
+					this.resolvedAccounts[row.ZACCOUNT1].path, 
 					'Previews', `${row.ZIDENTIFIER}-1-${row.ZSIZEWIDTH}x${row.ZSIZEHEIGHT}-0.jpeg`
 				);
 				outName = 'Scan Page';
@@ -289,7 +290,7 @@ export class AppleNotesImporter extends FormatImporter {
 				
 				const filename = row.ZFALLBACKIMAGEGENERATION ? 'FallbackImage.png' : `${row.ZIDENTIFIER}.jpg`;
 				sourcePath = path.join(
-					os.homedir(), NOTE_FOLDER_PATH, 'Accounts', this.resolvedAccounts[row.ZACCOUNT1].uuid, 
+					this.resolvedAccounts[row.ZACCOUNT1].path, 
 					'FallbackImages', row.ZIDENTIFIER, row.ZFALLBACKIMAGEGENERATION || '', filename
 				);
 				
@@ -313,7 +314,7 @@ export class AppleNotesImporter extends FormatImporter {
 				
 				const account = row.ZACCOUNT6 || row.ZACCOUNT5;
 				sourcePath = path.join(
-					os.homedir(), NOTE_FOLDER_PATH, 'Accounts', this.resolvedAccounts[account].uuid, 
+					this.resolvedAccounts[account].path, 
 					'Media', row.ZIDENTIFIER, row.ZGENERATION1 || '', row.ZFILENAME
 				);
 				[outName, outExt] = splitext(row.ZFILENAME);

--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -287,10 +287,12 @@ export class AppleNotesImporter extends FormatImporter {
 						AND z_pk = ${id} 
 				`;
 				
+				const filename = row.ZFALLBACKIMAGEGENERATION ? 'FallbackImage.png' : `${row.ZIDENTIFIER}.jpg`;
 				sourcePath = path.join(
 					os.homedir(), NOTE_FOLDER_PATH, 'Accounts', this.resolvedAccounts[row.ZACCOUNT1].uuid, 
-					'FallbackImages', row.ZIDENTIFIER, row.ZFALLBACKIMAGEGENERATION || '', 'FallbackImage.png'
+					'FallbackImages', row.ZIDENTIFIER, row.ZFALLBACKIMAGEGENERATION || '', filename
 				);
+				
 				outName = 'Drawing';
 				outExt = 'png';
 				break;

--- a/src/formats/apple-notes/convert-scan.ts
+++ b/src/formats/apple-notes/convert-scan.ts
@@ -24,11 +24,14 @@ export class ScanConverter extends ANConverter {
 			const imageUuid = object.customMap.mapEntry[0].value.stringValue;
 			
 			const row = await this.importer.database.get`
-				SELECT z_pk FROM ziccloudsyncingobject 
+				SELECT z_pk, zmedia, ztypeuti FROM ziccloudsyncingobject 
 				WHERE zidentifier = ${imageUuid}`;
 			
-			const file = await this.importer.resolveAttachment(row.Z_PK, ANAttachment.Scan);
-			if (file) links.push(this.importer.app.fileManager.generateMarkdownLink(file, '/'));
+			// Try to get the nicely cropped version, but fallback to the raw image if that fails
+			let file = await this.importer.resolveAttachment(row.Z_PK, ANAttachment.Scan);
+			if (!file) file = await this.importer.resolveAttachment(row.ZMEDIA, row.ZTYPEUTI);
+			
+			links.push(this.importer.app.fileManager.generateMarkdownLink(file!, '/'));
 		}
 		
 		return `\n${links.join('\n')}\n`;

--- a/src/formats/apple-notes/convert-scan.ts
+++ b/src/formats/apple-notes/convert-scan.ts
@@ -31,7 +31,8 @@ export class ScanConverter extends ANConverter {
 			let file = await this.importer.resolveAttachment(row.Z_PK, ANAttachment.Scan);
 			if (!file) file = await this.importer.resolveAttachment(row.ZMEDIA, row.ZTYPEUTI);
 			
-			links.push(this.importer.app.fileManager.generateMarkdownLink(file!, '/'));
+			if (file) links.push(this.importer.app.fileManager.generateMarkdownLink(file!, '/'));
+			else return '**Cannot decode scan**';
 		}
 		
 		return `\n${links.join('\n')}\n`;

--- a/src/formats/apple-notes/models.ts
+++ b/src/formats/apple-notes/models.ts
@@ -26,6 +26,7 @@ export type ANConverterType<T extends ANConverter> = {
 export type ANAccount = {
 	name: string;
 	uuid: string;
+	path: string;
 };
 
 export type ANFragmentPair = { 

--- a/src/formats/apple-notes/sqlite-tag-spawned.d.ts
+++ b/src/formats/apple-notes/sqlite-tag-spawned.d.ts
@@ -3,6 +3,7 @@ declare module 'sqlite-tag-spawned' {
 		constructor(path: string, options?: Record<string, boolean>);
 		get(...query: any[]): Promise<SQLiteRow>;
 		all(...query: any[]): Promise<SQLiteTable>;
+		close(): void;
 		
 		version: number;
 	} 


### PR DESCRIPTION
Possibly fixes #134 and possibly fixes #135

Fixes the importer being unable to find the location of the drawing fallback image under certain circumstances (definitely pre-iOS 17 but a `ZGENERATION` may not be generated under other circumstances as well).

Fixes scans not being generated when the nicely cropped version of the image can't be found, by finding the camera photo and using that. (The cropped and flattened version may be stored somewhere else for older note versions but I never used the scan functionality before testing this, and the other Apple Notes importers just always use the camera photo so I can't see what they do. So short of me downgrading to an old macOS and iOS version I won't be able to determine that)

This also includes a few minor patches that didn't quite make it in #125 