### PR TITLE
Apple Notes: Don't skip first line when there is no second line

### DIFF
--- a/src/formats/apple-notes/convert-note.ts
+++ b/src/formats/apple-notes/convert-note.ts
@@ -78,7 +78,7 @@ export class NoteConverter extends ANConverter {
 
 	async format(table = false): Promise<string> {
 		let fragments = this.parseTokens();
-		let firstLineSkip = !table && this.importer.omitFirstLine;
+		let firstLineSkip = !table && this.importer.omitFirstLine && this.note.noteText.contains('\n');
 		let converted = '';
 
 		for (let j = 0; j < fragments.length; j++) {


### PR DESCRIPTION
This is a very simple patch that closes #153.