### PR TITLE
Apple Notes: add compatibility with older unsupported versions of macOS

### DIFF
--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -233,10 +233,13 @@ export class AppleNotesImporter extends FormatImporter {
 		const row = await this.database.get`
 			SELECT 
 				nd.z_pk, hex(nd.zdata) as zhexdata, zcso.ztitle1, zfolder, 
-				zcreationdate2, zcreationdate3, zmodificationdate1, zispasswordprotected
+				zcreationdate1, zcreationdate2, zcreationdate3, zmodificationdate1, zispasswordprotected
 			FROM
 				zicnotedata AS nd, 
-				(SELECT *, NULL AS zcreationdate3 FROM ziccloudsyncingobject) AS zcso 
+				(SELECT 
+					*, NULL AS zcreationdate3, NULL AS zcreationdate2,
+					NULL AS zispasswordprotected FROM ziccloudsyncingobject
+				) AS zcso 
 			WHERE
 				zcso.z_pk = nd.znote
 				AND zcso.z_pk = ${id}
@@ -260,7 +263,7 @@ export class AppleNotesImporter extends FormatImporter {
 		const converter = this.decodeData(row.zhexdata, NoteConverter);
 		
 		this.vault.modify(file, await converter.format(), { 
-			ctime: this.decodeTime(row.ZCREATIONDATE3 || row.ZCREATIONDATE2),
+			ctime: this.decodeTime(row.ZCREATIONDATE3 || row.ZCREATIONDATE2 || row.ZCREATIONDATE1),
 			mtime: this.decodeTime(row.ZMODIFICATIONDATE1) 
 		});
 		

--- a/src/formats/apple-notes/sqlite/fallback.js
+++ b/src/formats/apple-notes/sqlite/fallback.js
@@ -19,7 +19,7 @@ export const sqlToJson = (sql) => {
 	while (i < sql.length) {
 		let token = '';
 		
-		if (sql[i] == '\'') {
+		if (sql[i] === '\'') {
 			// String/hex-encoded blob
 			i++;
 						

--- a/src/formats/apple-notes/sqlite/fallback.js
+++ b/src/formats/apple-notes/sqlite/fallback.js
@@ -1,0 +1,76 @@
+import { child_process } from './index.js';
+
+export const supportsJson = (bin) => {
+	const out = child_process.execSync(`${bin} --version`).toString();
+	const version = out.toString().match(/(\d+)\.(\d+).(\d+)/);
+	
+	return version?.[1] > 3 || version?.[2] > 32;
+};
+
+export const sqlToJson = (sql) => {
+	let json = [];
+	if (!sql) return json;
+	
+	const columnNames = [];
+	let i = 0;
+	let columnPos = -1;
+	let row = {};
+	
+	while (i < sql.length) {
+		let token = '';
+		
+		if (sql[i] == '\'') {
+			// String/hex-encoded blob
+			i++;
+						
+			while (i < sql.length) {
+				if (sql[i] != '\'') {
+					// Not quote
+					token += sql[i];
+					i++;
+				}
+				else if (sql[i + 1] == '\'') {
+					// Escaped quote 
+					token += sql[i];
+					i += 2;
+				}
+				else {
+					// Closing quote
+					i++;
+					break;
+				}
+			}
+		}
+		else if (sql[i] == 'N') { 
+			// Null
+			token = null;
+			i += 4;
+		}
+		else { 
+			// Number
+			while (i < sql.length) {
+				token += sql[i];
+				i++;
+				if (sql[i] == ',' || sql[i] == '\n') break;
+			}
+			
+			token = parseFloat(token);
+		}
+		
+		if (columnPos == -1) columnNames.push(token);
+		else {
+			row[columnNames[columnPos]] = token;
+			columnPos++;
+		}
+		
+		if (sql[i] == '\n' || columnNames.length < columnPos) {
+			if (columnPos !== -1) json.push(row);
+			columnPos = 0;
+			row = {};
+		}
+		
+		i++;
+	}
+	
+	return json;
+};

--- a/src/formats/apple-notes/sqlite/fallback.js
+++ b/src/formats/apple-notes/sqlite/fallback.js
@@ -30,7 +30,7 @@ export const sqlToJson = (sql) => {
 					token += sql.substring(i, offset);
 					i = offset;
 				}
-				else if (sql[i + 1] == '\'') {
+				else if (sql[i + 1] === '\'') {
 					// Escaped quote ('')
 					token += sql[i];
 					i += 2;

--- a/src/formats/apple-notes/sqlite/fallback.js
+++ b/src/formats/apple-notes/sqlite/fallback.js
@@ -26,11 +26,12 @@ export const sqlToJson = (sql) => {
 			while (i < sql.length) {
 				if (sql[i] != '\'') {
 					// Not quote
-					token += sql[i];
-					i++;
+					const offset = sql.indexOf('\'', i);
+					token += sql.substring(i, offset);
+					i = offset;
 				}
 				else if (sql[i + 1] == '\'') {
-					// Escaped quote 
+					// Escaped quote ('')
 					token += sql[i];
 					i += 2;
 				}
@@ -48,13 +49,13 @@ export const sqlToJson = (sql) => {
 		}
 		else { 
 			// Number
-			while (i < sql.length) {
-				token += sql[i];
-				i++;
-				if (sql[i] == ',' || sql[i] == '\n') break;
-			}
+			let offset = Math.min(
+				...[sql.indexOf(',', i), sql.indexOf('\n', i)].filter(a => a > 0),
+				sql.length - 1
+			);
 			
-			token = parseFloat(token);
+			token = parseFloat(sql.substring(i, offset));
+			i = offset;
 		}
 		
 		if (columnPos == -1) columnNames.push(token);

--- a/src/formats/apple-notes/sqlite/fallback.js
+++ b/src/formats/apple-notes/sqlite/fallback.js
@@ -42,7 +42,7 @@ export const sqlToJson = (sql) => {
 				}
 			}
 		}
-		else if (sql[i] == 'N') { 
+		else if (sql[i] === 'N') { 
 			// Null
 			token = null;
 			i += 4;

--- a/src/formats/apple-notes/sqlite/fallback.js
+++ b/src/formats/apple-notes/sqlite/fallback.js
@@ -24,7 +24,7 @@ export const sqlToJson = (sql) => {
 			i++;
 						
 			while (i < sql.length) {
-				if (sql[i] != '\'') {
+				if (sql[i] !== '\'') {
 					// Not quote
 					const offset = sql.indexOf('\'', i);
 					token += sql.substring(i, offset);


### PR DESCRIPTION
Closes #159 (at least the remainder of it that wasn't fixed in 1.5.4). 

Currently, SQLite transmits data to the Apple Notes importer via JSON. However, on older versions of macOS, JSON is not supported, so the importer fails on these. This PR makes it so it checks whether JSON is supported, and if not, it instead uses the SQL literal mode (which the importer then converts into JS objects manually). 

Note that this PR may not in fact be desirable to merge as this adds additional maintenance burden for versions that will eventually not be supported by Electron anyway, and further diverges the vendored SQLite dependency from the original version. On the other hand, it would be nice to support older OS versions and it's probably what users expect.