### PR TITLE
Improve Bear import

### DIFF
--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -55,7 +55,7 @@ export class Bear2bkImporter extends FormatImporter {
 							const assetFileVaultPath = `${attachmentsFolderPath.path}/${name}`;
 							const existingFile = this.vault.getAbstractFileByPath(assetFileVaultPath);
 							if (existingFile) {
-								ctx.reportSkipped(fullpath);
+								ctx.reportSkipped(fullpath, 'asset with filename already exists');
 							}
 							else {
 								const assetData = await entry.read();
@@ -64,7 +64,7 @@ export class Bear2bkImporter extends FormatImporter {
 							}
 						}
 						else {
-							ctx.reportSkipped(fullpath);
+							ctx.reportSkipped(fullpath, 'unknown type of file');
 						}
 					}
 					catch (e) {

--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -35,6 +35,9 @@ export class Bear2bkImporter extends FormatImporter {
 				for (let entry of entries) {
 					if (ctx.isCancelled()) return;
 					let { fullpath, filepath, parent, name, extension } = entry;
+					if (name === 'info.json') {
+						continue
+					}
 					ctx.status('Processing ' + name);
 					try {
 						if (extension === 'md' || extension === 'markdown') {


### PR DESCRIPTION
Recently, I tried to import my Bear notes. I faced a few issues which this PR addresses:
* File timestamps are set to the import time, not the actual creation or modification of the note
* Roughly half of the files are marked as skipped (#181) without any explanation
* Notes from archive and trash are imported like normal notes