### PR TITLE
Bear: Organize assets in folders per note

### DIFF
--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -45,7 +45,7 @@ export class Bear2bkImporter extends FormatImporter {
 				for (let entry of entries) {
 					if (ctx.isCancelled()) return;
 					let { fullpath, filepath, parent, name, extension } = entry;
-					if (name === 'info.json') {
+					if (['info.json', 'tags.json'].includes(name)) {
 						continue
 					}
 					ctx.status('Processing ' + name);


### PR DESCRIPTION
To avoid name conflicts with assets having the same name across notes
just store the assets in one folder per note

Fixing #67