### PR TITLE
OneNote page creation time

### DIFF
--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -324,13 +324,11 @@ export class OneNoteImporter extends FormatImporter {
 			await this.fetchAttachmentQueue(progress, fileRef, this.outputFolder!, data.queue);
 
 			// Add the last modified and creation time metadata
+			const lastModified = page.lastModifiedDateTime ? Date.parse(page.lastModifiedDateTime) : null;
+			const created = page.createdDateTime ? Date.parse(page.createdDateTime) : null;
 			const writeOptions: DataWriteOptions = {
-				ctime: page?.lastModifiedDateTime ? Date.parse(page.lastModifiedDateTime.toString()) :
-					page?.createdDateTime ? Date.parse(page.createdDateTime.toString()) :
-						Date.now(),
-				mtime: page?.lastModifiedDateTime ? Date.parse(page.lastModifiedDateTime.toString()) :
-					page?.createdDateTime ? Date.parse(page.createdDateTime.toString()) :
-						Date.now(),
+				ctime: created ?? lastModified ?? Date.now(),
+				mtime: lastModified ?? created ?? Date.now(),
 			};
 			await this.vault.append(fileRef, '', writeOptions);
 			progress.reportNoteSuccess(page.title!);


### PR DESCRIPTION
File ctime was being set to the lastModified.
The typo was hard to see, so try to make the code more readable.

Tested manually on a page I manually set the creation date far in the past.