### PR TITLE
Bear attachments

### DIFF
--- a/src/format-importer.ts
+++ b/src/format-importer.ts
@@ -14,6 +14,9 @@ export abstract class FormatImporter {
 	outputLocation: string = '';
 	notAvailable: boolean = false;
 
+	/** Cached value for getOutputFolder. Do not use directly. */
+	private outputFolder: TFolder | null = null;
+
 	constructor(app: App, modal: ImporterModal) {
 		this.app = app;
 		this.vault = app.vault;
@@ -114,10 +117,17 @@ export abstract class FormatImporter {
 			.setDesc('Choose a folder in the vault to put the imported files. Leave empty to output to vault root.')
 			.addText(text => text
 				.setValue(defaultExportFolderName)
-				.onChange(value => this.outputLocation = value));
+				.onChange(value => {
+					this.outputLocation = value;
+					this.outputFolder = null;
+				}));
 	}
 
 	async getOutputFolder(): Promise<TFolder | null> {
+		if (this.outputFolder) {
+			return this.outputFolder;
+		}
+
 		let { vault } = this.app;
 
 		let folderPath = this.outputLocation;
@@ -133,6 +143,7 @@ export abstract class FormatImporter {
 		}
 
 		if (folder instanceof TFolder) {
+			this.outputFolder = folder;
 			return folder;
 		}
 

--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -52,7 +52,7 @@ export class Bear2bkImporter extends FormatImporter {
 			if (ctx.isCancelled()) return;
 			ctx.status('Processing ' + file.name);
 			await readZip(file, async (zip, entries) => {
-				const metadataLookup = await this.collectMetadata(entries);
+				const metadataLookup = await this.collectMetadata(ctx, entries);
 				const assetMap = await this.storeAssets(ctx, entries, outputFolder.path);
 				for (let entry of entries) {
 					if (ctx.isCancelled()) return;
@@ -122,9 +122,11 @@ export class Bear2bkImporter extends FormatImporter {
 		await this.vault.append(file, '', writeOptions);
 	}
 
-	private async collectMetadata(entries: ZipEntryFile[]): Promise<{ [key: string]: Metadata }> {
+	private async collectMetadata(ctx: ImportContext, entries: ZipEntryFile[]): Promise<{ [key: string]: Metadata }> {
 		let metaData: { [key: string]: Metadata } = {};
 		for (let entry of entries) {
+			if (ctx.isCancelled()) return metaData;
+
 			if (entry.name !== 'info.json') {
 				continue;
 			}
@@ -148,6 +150,8 @@ export class Bear2bkImporter extends FormatImporter {
 	private async storeAssets(ctx: ImportContext, entries: ZipEntryFile[], notesOutputFolderPath: string): Promise<AssetMap> {
 		const assetsMap: AssetMap = {};
 		for (let entry of entries) {
+			if (ctx.isCancelled()) return assetsMap;
+
 			if (!entry.filepath.match(/\/assets\//g)) {
 				continue;
 			}


### PR DESCRIPTION
This adds a new utility function to help with finding an available path for an attachment, with consideration for attachment paths that maybe be reserved but not yet created.

It also changes the Bear importer to make use of this new function instead of iterating through the zip files an additional time just to pull out the attachments.

If this looks good we can extend this pattern to the other importers as well.