### PR TITLE
Replace illegal characters in filenames with Unicode lookalikes

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -8,15 +8,31 @@ let windowsTrailingRe = /[\. ]+$/;
 let startsWithDotRe = /^\./; // Regular expression to match filenames starting with "."
 let badLinkRe = /[\[\]#|^]/g; // Regular expression to match characters that interferes with links: [ ] # | ^
 
+const asciiLookalikes: {[key:string]: string} = {
+	'/' : '╱',
+	'?':'❓',
+	'<':'＜',
+	'>':'＞',
+	'\\':'╱',
+	':':'꞉',
+	'*':'✱',
+	'|':'∣',
+	'"':'\'',
+	'[':'⟦',
+	']':'⟧',
+	'#':'＃',
+	'^':'⌃'
+};
+
 export function sanitizeFileName(name: string) {
 	return name
-		.replace(illegalRe, '')
+	    .replace(illegalRe, c => asciiLookalikes[c] ?? '')
 		.replace(controlRe, '')
 		.replace(reservedRe, '')
 		.replace(windowsReservedRe, '')
 		.replace(windowsTrailingRe, '')
 		.replace(startsWithDotRe, '')
-		.replace(badLinkRe, '');
+		.replace(badLinkRe, c => asciiLookalikes[c] ?? '');
 }
 
 export function genUid(length: number): string {


### PR DESCRIPTION
This pull request addresses issue #321 and #291 complaining about special characters in filenames.

Filenames in Obsidian are of primary importance as they are also used as note titles. Therefore, the current brute force approach of filename sanitization destroys note titles whenever illegal characters are involved.  This cause unnecessary manual cleanup effort. 

This pull request upgrades `sanitizeFileName` to replace illegal characters with legal Unicode characters that look similar.