### PR TITLE
fixes #330 lead/trailing spaces in Notion math

### DIFF
--- a/src/formats/notion/convert-to-md.ts
+++ b/src/formats/notion/convert-to-md.ts
@@ -235,15 +235,21 @@ function fixEquations(body: HTMLElement) {
 	for (const figEqn of figEqnEls) {
 		const annotation = figEqn.find('annotation');
 		if (!annotation) continue;
-		figEqn.replaceWith(`$$${annotation.textContent}$$`);
+		figEqn.replaceWith(`$$${trimMath(annotation.textContent)}$$`);
 	}
 	// Inline Equations
 	const spanEqnEls = body.findAll('span.notion-text-equation-token');
 	for (const spanEqn of spanEqnEls) {
 		const annotation = spanEqn.find('annotation');
 		if (!annotation) continue;
-		spanEqn.replaceWith(`$${annotation.textContent}$`);
+		spanEqn.replaceWith(`$${trimMath(annotation.textContent)}$`);
 	}
+}
+
+function trimMath(math: string | null | undefined): string {
+	// Trim trailing spaces & newlines in LaTeX math experessions.
+	let regex = new RegExp(/^[\s\r\n\\]*(.*?)[\s\r\n\\]*$/, 's');
+	return math?.replace(regex, '$1') ?? '';
 }
 
 function stripToSentence(paragraph: string) {

--- a/src/formats/notion/convert-to-md.ts
+++ b/src/formats/notion/convert-to-md.ts
@@ -235,21 +235,22 @@ function fixEquations(body: HTMLElement) {
 	for (const figEqn of figEqnEls) {
 		const annotation = figEqn.find('annotation');
 		if (!annotation) continue;
-		figEqn.replaceWith(`$$${trimMath(annotation.textContent)}$$`);
+		figEqn.replaceWith(`$$${formatMath(annotation.textContent)}$$`);
 	}
 	// Inline Equations
 	const spanEqnEls = body.findAll('span.notion-text-equation-token');
 	for (const spanEqn of spanEqnEls) {
 		const annotation = spanEqn.find('annotation');
 		if (!annotation) continue;
-		spanEqn.replaceWith(`$${trimMath(annotation.textContent)}$`);
+		spanEqn.replaceWith(`$${formatMath(annotation.textContent, true)}$`);
 	}
 }
 
-function trimMath(math: string | null | undefined): string {
-	// Trim trailing spaces & newlines in LaTeX math experessions.
+function formatMath(math: string | null | undefined, inline: boolean=false): string {
+	// Trim lead/trailing space in LaTeX math experessions.
+	// Removes empty lines, which can cause equations to break.
 	let regex = new RegExp(/^(?:[\s\r\n]|\\\\|\\\s)*(.*?)[\s\r\n\\]*$/, 's');
-	return math?.replace(regex, '$1') ?? '';
+	return math?.replace(regex, '$1').replace(/[\r\n]+/g, (inline ? ' ' : '\n')) ?? '';
 }
 
 function stripToSentence(paragraph: string) {

--- a/src/formats/notion/convert-to-md.ts
+++ b/src/formats/notion/convert-to-md.ts
@@ -246,9 +246,14 @@ function fixEquations(body: HTMLElement) {
 	}
 }
 
+/**
+ * 1. Trims lead/trailing whitespace in LaTeX math experessions.
+ * 2. Removes empty lines which can cause equations to break.
+ *
+ * NOTE: "\\" and "\ " are the escapes for line-breaks and white-space,
+ * matched by "\\\\" and "\s" in the regex.
+ */
 function formatMath(math: string | null | undefined, inline: boolean=false): string {
-	// Trim lead/trailing space in LaTeX math experessions.
-	// Removes empty lines, which can cause equations to break.
 	let regex = new RegExp(/^(?:[\s\r\n]|\\\\|\\\s)*(.*?)[\s\r\n\\]*$/, 's');
 	return math?.replace(regex, '$1').replace(/[\r\n]+/g, (inline ? ' ' : '\n')) ?? '';
 }

--- a/src/formats/notion/convert-to-md.ts
+++ b/src/formats/notion/convert-to-md.ts
@@ -248,7 +248,7 @@ function fixEquations(body: HTMLElement) {
 
 function trimMath(math: string | null | undefined): string {
 	// Trim trailing spaces & newlines in LaTeX math experessions.
-	let regex = new RegExp(/^[\s\r\n\\]*(.*?)[\s\r\n\\]*$/, 's');
+	let regex = new RegExp(/^(?:[\s\r\n]|\\\\|\\\s)*(.*?)[\s\r\n\\]*$/, 's');
 	return math?.replace(regex, '$1') ?? '';
 }
 


### PR DESCRIPTION
Fixes issue #330 where leading/trailing spaces break LaTeX equations.

**Explanation:** This is due to the difference in math syntax in Notion, which allows leading/trailing spaces, unlike Obsidian-MD.

**Implementation:** Format math strings via regex that removes leading/trailing spaces and newlines.

# Example
**Before**
<img width="384" alt="before" src="https://github.com/user-attachments/assets/f8293f05-e9a5-444f-bebb-55bcc7e29106">

**After**
<img width="409" alt="after" src="https://github.com/user-attachments/assets/2b6f549f-64b4-4b23-8d12-31dddb11a994">
