### PR TITLE
#341 Missing content on OneNote import

### DIFF
--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -674,6 +674,12 @@ export class OneNoteImporter extends FormatImporter {
 		const videos: HTMLIFrameElement[] = pageElement.findAll('iframe') as HTMLIFrameElement[];
 
 		for (const object of objects) {
+			// Objects may contain child nodes which would be lost when the object is replaced by markdown.
+			// To preserve these, move any child items to be siblings of the object
+			while (object.firstChild) {
+				object.parentNode?.insertBefore(object.firstChild, object.nextSibling);
+			}
+
 			let split: string[] = object.getAttribute('data-attachment')!.split('.');
 			const extension: string = split[split.length - 1];
 


### PR DESCRIPTION
Fixes bug where an object node may contain other content as child nodes, which gets lost when the node is converted to markdown. Moves child nodes to be sibling nodes to preserve them.