### PR TITLE
Improve Bear imports: added front matter with date and tags, preserving timestamps for assets

### DIFF
--- a/src/format-importer.ts
+++ b/src/format-importer.ts
@@ -134,6 +134,7 @@ export abstract class FormatImporter {
 		if (folderPath === '') {
 			folderPath = '/';
 		}
+		folderPath = normalizePath(folderPath);
 
 		let folder = vault.getAbstractFileByPath(folderPath);
 
@@ -190,7 +191,8 @@ export abstract class FormatImporter {
 			i++;
 		}
 
-		return outputPath;
+		// Normalize the final outputPath before returning
+		return normalizePath(outputPath);
 	}
 
 	abstract import(ctx: ImportContext): Promise<any>;

--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -29,10 +29,16 @@ export class Bear2bkImporter extends FormatImporter {
 		console.log("[Bear Importer Tag Debug] Trying enclosedTagRegex");
 		while ((matchEnclosed = enclosedTagRegex.exec(content)) !== null) {
 			console.log("[Bear Importer Tag Debug] enclosedTagRegex match found: raw=", matchEnclosed[0], "group1=", matchEnclosed[1]);
-			const tag = matchEnclosed[1].trim();
-			if (tag) {
-				tags.add(tag);
-				console.log("[Bear Importer Tag Debug] Added enclosed tag:", tag);
+			const rawEnclosedTag = matchEnclosed[1].trim();
+			if (rawEnclosedTag) {
+				const parts = rawEnclosedTag.split('/');
+				for (const part of parts) {
+					const cleanPart = part.trim();
+					if (cleanPart) {
+						tags.add(cleanPart);
+						console.log("[Bear Importer Tag Debug] Added enclosed tag part:", cleanPart);
+					}
+				}
 			}
 		}
 
@@ -44,15 +50,21 @@ export class Bear2bkImporter extends FormatImporter {
 		console.log("[Bear Importer Tag Debug] Trying simpleTagRegex");
 		while ((matchSimple = simpleTagRegex.exec(content)) !== null) {
 			console.log("[Bear Importer Tag Debug] simpleTagRegex match found: raw=", matchSimple[0], "group1=", matchSimple[1]);
-			const simpleTag = matchSimple[1].trim(); 
-			if (simpleTag) {
-				tags.add(simpleTag);
-				console.log("[Bear Importer Tag Debug] Added simple tag:", simpleTag);
+			const rawSimpleTag = matchSimple[1].trim(); 
+			if (rawSimpleTag) {
+				const parts = rawSimpleTag.split('/');
+				for (const part of parts) {
+					const cleanPart = part.trim();
+					if (cleanPart) {
+						tags.add(cleanPart);
+						console.log("[Bear Importer Tag Debug] Added simple tag part:", cleanPart);
+					}
+				}
 			}
 		}
 
 		const finalTags = Array.from(tags);
-		console.log("[Bear Importer Tag Debug] Final extracted tags:", finalTags);
+		console.log("[Bear Importer Tag Debug] Final extracted tags (flattened):", finalTags);
 		return finalTags;
 	}
 

--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -77,7 +77,8 @@ export class Bear2bkImporter extends FormatImporter {
 								}
 							}
 
-							const filePath = normalizePath(mdFilename);
+							// Use the folder name as the note name, but create it directly in the target folder
+							const filePath = normalizePath(mdFilename + '.md');
 							const metadata = metadataLookup[parent];
 							let targetFolder = outputFolder;
 							if (metadata?.archived) {
@@ -87,7 +88,7 @@ export class Bear2bkImporter extends FormatImporter {
 								targetFolder = trashFolder;
 							}
 
-							// Create the file first
+							// Create the file directly in the target folder
 							const file = await this.saveAsMarkdownFile(targetFolder, filePath, mdContent);
 							
 							// Then add frontmatter and set timestamps


### PR DESCRIPTION
This pull request enhances the Bear (.bear2bk) importer, adding new features to improve the import experience and data fidelity.


1.  **Accurate Note Timestamp Preservation:**
    *   Original creation and modification dates for notes are now extracted from Bear's `info.json`.
    *   These timestamps are added to the frontmatter of imported notes as `created:` and `modified:` fields (format: `YYYY-MM-DDTHH:mm:ss`).
    *   The file system timestamps for the note files are also updated to match these original dates.
    *   Front matter now will look like this:
        ```
            ---
            created: 2023-02-21T13:36:29
            modified: 2024-02-29T14:25:51
            tags:
            - tag1
            - tag2
            ---
        ```

2.  **Comprehensive Tag Extraction and Processing:**
    *   Tags are now extracted directly from the Markdown body of each Bear note.
    *   **Supported Bear Tag Formats:**
        *   `#enclosed/tag#` (allows spaces and slashes; content within `#...#` must be single-line).
        *   `#simpletag` or `#tag/with/hierarchy` (allows slashes and hyphens not at start/end; no spaces within the tag itself).
    *   **URL Safety:** Tag extraction logic includes safeguards (lookaheads/lookbehinds) to prevent misinterpreting URL fragments (e.g., `page.html#section`) as tags.
    *   **Tag Flattening:** Nested tags (e.g., `#personal/project#` or `#work/projectA`) are automatically flattened into a list of individual tags (e.g., `personal`, `project` and `work`, `projectA`) in the frontmatter.
    *   **Frontmatter Integration:** Unique, flattened tags are added as a standard YAML list under the `tags:` key in each note's frontmatter.

3.  **Attachment Timestamp Preservation:**
    *   The importer now attempts to preserve the original creation (`ctime`) and modification (`mtime`) timestamps for attachments.
    *   Timestamps are extracted from the zip entry for each asset and passed as `DataWriteOptions` when creating the binary file in Obsidian. (Note: The age of these timestamps may ultimately be limited by the metadata stored in the Bear `.bear2bk` zip archive itself).

4.  **Handling of Archived and Trashed Notes:**
    *   Notes marked as "archived" or "trashed" in Bear are now correctly placed into `archive/` and `trash/` subfolders respectively, within the main import output directory.

