### PR TITLE
fix onenote importer bugs

### DIFF
--- a/src/format-importer.ts
+++ b/src/format-importer.ts
@@ -193,6 +193,20 @@ export abstract class FormatImporter {
 		return outputPath;
 	}
 
+	async pause(durationSeconds: number, reason: string, ctx: ImportContext|undefined): Promise<void> {
+		const promise = new Promise(resolve => setTimeout(resolve, durationSeconds * 1_000));
+
+		if (ctx) {
+			const previousStatusMessage = ctx.statusMessage;
+			ctx.status(`⏸️ Pausing import for ${durationSeconds} seconds (${reason})`);
+			await promise;
+			ctx.status(previousStatusMessage);
+		}
+		else {
+			await promise;
+		}
+	}
+
 	abstract import(ctx: ImportContext): Promise<any>;
 
 	// Utility functions for vault

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -959,7 +959,8 @@ export class OneNoteImporter extends FormatImporter {
 
 				// We're rate-limited - let's retry after the suggested amount of time
 				if (err?.code === '20166') {
-					let retryTime = (+!response.headers.get('Retry-After') * 1000) || 15000;
+					const retryAfter = response.headers.get('Retry-After');
+					let retryTime = retryAfter ? (+retryAfter * 1_000) : 15_000;
 					console.log(`Rate limit exceeded, waiting for: ${retryTime} ms`);
 
 					if (retryCount < MAX_RETRY_ATTEMPTS) {

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -960,7 +960,14 @@ export class OneNoteImporter extends FormatImporter {
 				// We're rate-limited - let's retry after the suggested amount of time
 				if (err?.code === '20166') {
 					const retryAfter = response.headers.get('Retry-After');
-					let retryTime = retryAfter ? (+retryAfter * 1_000) : 15_000;
+					// If we're rate-limited, the soonest we'll be able to make
+					// the request again is the next minute, so wait either as
+					// long as the API tells us to (with the Retry-After header)
+					// or wait 1 minute. Note: the OneNote API does not
+					// currently ever provide the Retry-After header. See
+					// https://learn.microsoft.com/en-us/graph/throttling-limits#onenote-service-limits
+					// for more info.
+					let retryTime = retryAfter ? (+retryAfter * 1_000) : 60_000;
 					console.log(`Rate limit exceeded, waiting for: ${retryTime} ms`);
 
 					if (retryCount < MAX_RETRY_ATTEMPTS) {

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -964,7 +964,7 @@ export class OneNoteImporter extends FormatImporter {
 				}
 
 				// We're rate-limited - let's retry after the suggested amount of time
-				if (err?.code === '20166') {
+				if (err?.code === '20166' || response.status === 429) {
 					const retryAfter = response.headers.get('Retry-After');
 					// If we're rate-limited, the soonest we'll be able to make
 					// the request again is the next minute, so wait either as

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -969,8 +969,13 @@ export class OneNoteImporter extends FormatImporter {
 				}
 				console.log('An error has occurred while fetching an resource:', err ? err : respJson);
 
-				// If our access token has expired, then refresh it and we can try again.
-				if (err?.code === '40001') {
+				// If our access token has expired, becomes invalid, or is
+				// otherwise no longer authorized, then refresh it and try
+				// again.
+				const isNotAuthorized = err?.code === '40001'
+					|| err?.code === 'InvalidAuthenticationToken'
+					|| response.status === 401;
+				if (isNotAuthorized) {
 					await this.updateAccessToken();
 					return this.fetchResource(url, returnType as any, retryCount + 1);
 				}

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -953,6 +953,9 @@ export class OneNoteImporter extends FormatImporter {
 
 		try {
 			// any errors that happen in the try block will be retried.
+			if (retryCount > 0) {
+				console.log(`Retry attempt #${retryCount} for ${url}`);
+			}
  			let response = await fetch(
  				url, 
  				{

--- a/src/main.ts
+++ b/src/main.ts
@@ -356,6 +356,7 @@ export class ImporterModal extends Modal {
 	plugin: ImporterPlugin;
 	importer: FormatImporter;
 	selectedId: string;
+	abortController: AbortController;
 
 	current: ImportContext | null = null;
 
@@ -364,6 +365,7 @@ export class ImporterModal extends Modal {
 		this.plugin = plugin;
 		this.titleEl.setText('Import data into Obsidian');
 		this.modalEl.addClass('mod-importer');
+		this.abortController = new AbortController();
 
 		let keys = Object.keys(plugin.importers);
 		if (keys.length > 0) {
@@ -458,6 +460,8 @@ export class ImporterModal extends Modal {
 	onClose() {
 		const { contentEl, current } = this;
 		contentEl.empty();
+		this.abortController.abort('import was canceled by user');
+
 		if (current) {
 			current.cancel();
 		}

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,6 +52,7 @@ export class ImportContext {
 	skipped: string[] = [];
 	failed: string[] = [];
 	maxFileNameLength: number = 100;
+	statusMessage: string = '';
 
 	cancelled: boolean = false;
 
@@ -112,6 +113,7 @@ export class ImportContext {
 	 * @param message
 	 */
 	status(message: string) {
+		this.statusMessage = message;
 		this.statusEl.setText(message.trim() + '...');
 	}
 


### PR DESCRIPTION
Fixes issues in https://github.com/obsidianmd/obsidian-importer/issues/359

- Improve typing by creating a `json-wrapped` that captures the case where the return value is in the `.value` property of the response
- allow `fetchRequest` callers to specify return type
- handle http status = 429 errors the same as response.code === 20166 errors
- backoff errors (429/20166) do NOT increase the retry count, we might theoretically retry these forever
- never return undefined responses from `fetchRequest`. it succeeds or throws an error when the retry limit is hit.
- make it so that when the importer dialog is closed, we abort all network requests and stop retrying. This is particularly important now that we might infinitely retry on 429 errors.