### PR TITLE
Onenote code import

### DIFF
--- a/src/formats/onenote/code.ts
+++ b/src/formats/onenote/code.ts
@@ -9,7 +9,7 @@ function isCode(node: Node|null): node is HTMLElement {
 /**
  * Return true iff node is a paragraph containing only code/line breaks
  */
-export function isCodeBlockWrappingParagraph(node: Node|null): node is HTMLParagraphElement {
+export function isParagraphWrappingOnlyCode(node: Node|null): node is HTMLParagraphElement {
 	return (
 		node != null
 		&& node instanceof HTMLParagraphElement


### PR DESCRIPTION
Addresses https://github.com/obsidianmd/obsidian-importer/issues/396

Fix several bugs with code in imported OneNote notes:

## Bug 1: don't merge code fences

Currently, all code on the page is merged into the first code fence found on the page. That's clearly a bug.

| OneNote Content | Import - Before | Import - After |
|-|-|-|
| <img width="491" alt="image" src="https://github.com/user-attachments/assets/eb5b66bb-5bf4-448e-a9aa-82b4e9278120" /> | <img width="613" alt="image" src="https://github.com/user-attachments/assets/11f55cb8-ef96-411d-b126-ca0f288fbdc7" /> | <img width="613" alt="image" src="https://github.com/user-attachments/assets/467d40ee-2413-4d4c-a173-11741a2c97bf" /> |

## Bug 2 and 3: text nodes and newlines

The importer uses `querySelectorAll` which only finds elements and not text nodes, so e.g. if two code blocks have a text node between them, we erroneously merge the two disjoint code blocks and then dump the text node after the code fence.

Also, we're injecting too many newlines in the imported markdown.

| OneNote Content | Import - Before | Import - After |
|-|-|-|
| <img width="609" alt="image" src="https://github.com/user-attachments/assets/d97e3970-8713-42c5-85db-9f8f6b160273" /> | <img width="632" alt="image" src="https://github.com/user-attachments/assets/ae6bc3de-2d19-4915-9c36-88c523594ea5" /> | <img width="628" alt="image" src="https://github.com/user-attachments/assets/e24b6ae9-0f99-4883-ae6d-208654d771de" /> |

## Bug 4: support inline code spans

if an element is code, is a span, and only contains text, use a `<code>` inline span to wrap it instead of a multi-line code fence.

| OneNote Content | Import - Before | Import - After |
|-|-|-|
| <img width="630" alt="image" src="https://github.com/user-attachments/assets/4f41d7c3-31bb-4f81-bb1d-74efa93640eb" /> | <img width="618" alt="image" src="https://github.com/user-attachments/assets/0ad2d360-9e51-47b2-8d57-c28be6416f0c" /> | <img width="574" alt="image" src="https://github.com/user-attachments/assets/f951b1d8-31ff-4371-919e-42c149dbd017" /> |
