### PR TITLE
OneNote: Add MathML to LaTeX Conversion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 			"dependencies": {
 				"@joplin/turndown-plugin-gfm": "1.0.62",
 				"@zip.js/zip.js": "2.7.60",
+				"mathml-to-latex": "^1.5.0",
 				"plain-tag": "0.1.3",
 				"protobufjs": "7.2.5",
 				"static-params": "0.4.0",
@@ -1843,6 +1844,15 @@
 			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
 			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
 			"license": "Apache-2.0"
+		},
+		"node_modules/mathml-to-latex": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mathml-to-latex/-/mathml-to-latex-1.5.0.tgz",
+			"integrity": "sha512-rrWn0eEvcEcdMM4xfHcSGIy+i01DX9byOdXTLWg+w1iJ6O6ohP5UXY1dVzNUZLhzfl3EGcRekWLhY7JT5Omaew==",
+			"license": "MIT",
+			"dependencies": {
+				"@xmldom/xmldom": "^0.8.10"
+			}
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 	"dependencies": {
 		"@joplin/turndown-plugin-gfm": "1.0.62",
 		"@zip.js/zip.js": "2.7.60",
+		"mathml-to-latex": "^1.5.0",
 		"plain-tag": "0.1.3",
 		"protobufjs": "7.2.5",
 		"static-params": "0.4.0",


### PR DESCRIPTION
Introduce support for converting MathML equations into LaTeX, improving math rendering compatibility with Obsidian.
