### PR TITLE
feat: converter for Notion API → Obsidian MD (Databases → Bases)

### DIFF
--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -1,0 +1,69 @@
+[language-server.tailwindcss]
+command = "tailwindcss-language-server"
+config = { }
+args = ["--stdio"]
+timeout = 3
+
+[language-server.typescript-language-server]
+command = "typescript-language-server"
+args = ["--stdio"]
+timeout = 3
+config = { format = { "semicolons" = "insert", "convertTabsToSpaces" = false } }
+
+[language-server.json] 
+command = "vscode-json-language-server" 
+args = ["--stdio"]
+timeout = 3
+config = { format = { "convertTabsToSpaces" = false } }
+
+[[language]]
+name = "html"
+indent = { tab-width = 4, unit = "\t" }
+
+[[language]]
+name = "tsx"
+scope = "source.tsx"
+injection-regex = "(tsx)" 
+file-types = ["tsx"]
+indent = { tab-width = 4, unit = "\t" }
+auto-format = true
+roots = ["tailwind.config.js","tailwind.config.cjs", "tsconfig.json"]
+language-servers = ["typescript-language-server", "eslint", "tailwindcss"]
+
+[[language]]
+name = "typescript"
+scope = "source.ts"
+injection-regex = "(ts)" 
+file-types = ["ts"]
+indent = { tab-width = 4, unit = "\t" }
+auto-format = true
+roots = ["tailwind.config.js","tailwind.config.cjs", "tsconfig.json"]
+language-servers = ["typescript-language-server", "eslint", "tailwindcss"]
+
+[[language]]
+name = "javascript"
+scope = "source.js"
+injection-regex = "(js)" 
+file-types = ["js", "cjs", "mjs"]
+indent = { tab-width = 4, unit = "\t" }
+auto-format = true
+roots = ["tailwind.config.js","tailwind.config.cjs", "jsconfig.json"]
+language-servers = ["typescript-language-server", "eslint", "tailwindcss"]
+
+[[language]]
+name = "css"
+scope = "scope.css"
+injection-regex = "(css)"
+file-types = ["css"]
+indent = { tab-width = 4, unit = "\t" }
+auto-format = true
+language-servers = ["vscode-css-language-server", "tailwindcss"]
+
+[[language]]
+name = "json"
+scope = "source.json"
+injection-regex = "json"
+file-types = ["json"]
+indent = { tab-width = 4, unit = "\t" }
+auto-format = true
+language-servers = ["json"]

--- a/NOTION_API_TESTING.md
+++ b/NOTION_API_TESTING.md
@@ -1,0 +1,980 @@
+# Notion API Importer - Testing Guide
+
+## Table of Contents
+
+1. [Manual Testing Setup](#manual-testing-setup)
+2. [Creating Test Data](#creating-test-data)
+3. [Running the Converter](#running-the-converter)
+4. [Automated E2E Testing](#automated-e2e-testing)
+
+---
+
+## 1. Manual Testing Setup
+
+### Prerequisites
+
+- Obsidian app installed
+- Obsidian Importer plugin built and loaded
+- A Notion account
+
+### Step 1: Create a Notion Integration
+
+1. Go to https://www.notion.so/my-integrations
+2. Click **"+ New integration"**
+3. Give it a name: `Obsidian Importer Test`
+4. Select the workspace you want to test with
+5. Leave capabilities as default (Read content, Update content, Insert content)
+6. Click **"Submit"**
+7. Copy the **Integration Token** (starts with `secret_`)
+   - ⚠️ **Save this token securely** - you'll need it for the importer
+
+### Step 2: Share Databases with the Integration
+
+**Important:** Notion integrations can only access pages and databases that are explicitly shared with them.
+
+For each database you want to import:
+
+1. Open the database in Notion
+2. Click the `•••` menu in the top-right corner
+3. Scroll to **"Connections"** or **"Add connections"**
+4. Find and select your integration (`Obsidian Importer Test`)
+5. The database is now accessible to the integration
+
+### Step 3: Configure the Importer in Obsidian
+
+1. Open Obsidian
+2. Open Command Palette (`Cmd/Ctrl + P`)
+3. Search for **"Obsidian Importer: Open Importer"**
+4. Select **"Notion (API)"** from the format dropdown
+5. **Enter your Integration Token** in the token field
+6. **Select an output folder** in your vault
+7. Click **"Import"**
+
+The importer will:
+
+- Search your workspace for all accessible databases
+- Convert each database to a `.base` file
+- Convert all pages in each database to `.md` files with proper frontmatter
+- Download and embed all attachments
+
+---
+
+## 2. Creating Test Data
+
+To thoroughly test the converter, create a comprehensive test database in Notion with the following elements:
+
+### Database Setup: "Importer Test Database"
+
+#### Property Types to Include:
+
+Create properties of each type to test conversion:
+
+1. **Title** - `Name` (every database has this by default)
+2. **Text** - `Description`
+3. **Number** - `Price`, `Quantity`
+4. **Select** - `Status` with options: `To Do`, `In Progress`, `Done`
+5. **Multi-select** - `Tags` with options: `Important`, `Urgent`, `Follow-up`
+6. **Date** - `Due Date`, `Created Date`
+7. **Checkbox** - `Is Complete`
+8. **URL** - `Website`
+9. **Email** - `Contact Email`
+10. **Phone** - `Phone Number`
+11. **Files** - `Attachments`
+12. **Formula** - `Total` with expression: `prop("Price") * prop("Quantity")`
+13. **Relation** - Link to another database
+14. **Rollup** - Aggregate from related database
+15. **People** - `Assigned To`
+16. **Created time** - (auto-generated)
+17. **Last edited time** - (auto-generated)
+
+#### Test Pages to Create:
+
+**Page 1: "Rich Text Kitchen Sink"**
+
+- Test all text formatting:
+  - **Bold text**
+  - _Italic text_
+  - ~~Strikethrough~~
+  - `Inline code`
+  - [Links](https://example.com)
+  - Nested formatting: **_bold and italic_**
+- All heading levels (H1, H2, H3)
+- Multiple paragraph blocks
+- Equation: $E = mc^2$
+
+**Page 2: "Lists and Tasks"**
+
+- Bulleted lists with 3 levels of nesting
+- Numbered lists with sub-items
+- To-do lists:
+  - [ ] Unchecked task
+  - [x] Checked task
+  - [ ] Task with nested content
+    - More details here
+- Toggle blocks with hidden content
+
+**Page 3: "Code and Quotes"**
+
+- Code blocks in multiple languages:
+  ```python
+  def hello():
+      print("Hello, World!")
+  ```
+  ```javascript
+  const greet = () => console.log("Hello!");
+  ```
+- Block quotes with multiple paragraphs
+- Callouts with emojis
+
+**Page 4: "Tables and Dividers"**
+
+- Simple table with headers:
+  | Name | Age | City |
+  |------|-----|------|
+  | John | 30 | NYC |
+  | Jane | 25 | LA |
+- Table without headers
+- Tables with empty cells
+- Horizontal dividers (---) between sections
+
+**Page 5: "Media and Attachments"**
+
+- External images with captions
+- Uploaded images
+- PDF attachment
+- Video file
+- Multiple file attachments
+- Bookmarks to external websites
+
+**Page 6: "Complex Formulas"**
+Create a page in the database with complex formula values:
+
+- Simple arithmetic: `prop("Price") * prop("Quantity")`
+- Conditionals: `if(prop("Price") > 100, "Expensive", "Cheap")`
+- Nested conditions: `if(prop("Status") == "Done", "✓", if(prop("Status") == "In Progress", "⚠", "○"))`
+- String operations: `concat(prop("Name"), " - ", prop("Status"))`
+- Date operations: `formatDate(prop("Due Date"), "YYYY-MM-DD")`
+- Math functions: `round(prop("Price") * 1.08)`
+
+**Page 7: "Edge Cases"**
+
+- Empty content blocks
+- Very long text (3000+ words)
+- Special characters in title: `Test / Page \ With * Special ? Characters`
+- Emoji in content: 🚀 🎉 ✨
+- Multiple images in sequence
+- Nested lists 5 levels deep
+- Tables inside toggle blocks
+
+**Page 8: "Child Pages and Databases"**
+
+- Reference to child page
+- Reference to another database
+- Multiple internal links
+
+### Additional Test Databases
+
+**Database 2: "Formula Edge Cases"**
+Test all formula types from Notion's documentation:
+
+- `add()`, `subtract()`, `multiply()`, `divide()`
+- `pow()`, `sqrt()`, `abs()`, `round()`, `ceil()`, `floor()`
+- `min()`, `max()`, `sum()`
+- `length()`, `concat()`, `upper()`, `lower()`
+- `contains()`, `replace()`, `split()`
+- `now()`, `today()`, `dateAdd()`, `dateSubtract()`, `dateBetween()`
+- `if()`, `and()`, `or()`, `not()`
+- `at()`, `first()`, `last()`
+
+**Database 3: "Nested Structure Test"**
+
+- Pages with deeply nested content (10+ levels)
+- Toggle blocks containing everything
+- Lists with mixed bulleted/numbered/todo items
+
+---
+
+## 3. Running the Converter
+
+### Method 1: Through Obsidian UI (Recommended for Manual Testing)
+
+1. Build the plugin:
+
+   ```bash
+   cd /path/to/obsidian-importer
+   npm run build
+   ```
+
+2. Load the plugin in Obsidian:
+
+   - Copy `main.js`, `manifest.json`, `styles.css` to your vault's `.obsidian/plugins/obsidian-importer/`
+   - Reload Obsidian
+   - Enable the plugin in Settings → Community Plugins
+
+3. Run the importer:
+
+   - `Cmd/Ctrl + P` → "Obsidian Importer: Open Importer"
+   - Select "Notion (API)"
+   - Enter token and select output folder
+   - Click "Import"
+
+4. Monitor progress:
+   - Watch the status bar for progress
+   - Check the output folder for created files
+   - Review the console (Cmd/Ctrl + Shift + I) for errors/warnings
+
+### Method 2: Programmatic Testing (for Development)
+
+Create a test script: `test-notion-api.ts`
+
+```typescript
+import { NotionApiClient } from "./src/formats/notion-api/api-client";
+import { convertDatabaseToBase } from "./src/formats/notion-api/base-converter";
+import { BlockConverter } from "./src/formats/notion-api/block-converter";
+import * as fs from "fs";
+
+async function testImporter() {
+  const token = process.env.NOTION_TOKEN;
+  if (!token) {
+    throw new Error("NOTION_TOKEN environment variable required");
+  }
+
+  const client = new NotionApiClient({ auth: token });
+
+  // Search for databases
+  const searchResults = await client.searchAll();
+  console.log(`Found ${searchResults.length} items`);
+
+  // Filter to databases
+  const databases = searchResults.filter(
+    (r) =>
+      "object" in r && (r.object === "database" || r.object === "data_source"),
+  );
+  console.log(`Found ${databases.length} databases`);
+
+  // Convert first database
+  if (databases.length > 0) {
+    const db = databases[0] as any;
+    const result = convertDatabaseToBase(db);
+
+    console.log("Database:", result.databaseTitle);
+    console.log("Properties:", Object.keys(result.schema.properties || {}));
+    console.log("Formulas:", Object.keys(result.schema.formulas || {}));
+    console.log("Warnings:", result.warnings);
+
+    // Save to file
+    fs.writeFileSync("test-output.json", JSON.stringify(result, null, 2));
+  }
+}
+
+testImporter().catch(console.error);
+```
+
+Run with:
+
+```bash
+NOTION_TOKEN=secret_your_token_here npx tsx test-notion-api.ts
+```
+
+---
+
+## 4. Automated E2E Testing
+
+### Setup for CI/CD
+
+#### Step 1: Create a Notion Test Workspace
+
+1. Create a separate Notion workspace for testing
+2. Create an integration with `NOTION_TEST_TOKEN`
+3. Store the token as a GitHub Secret or CI environment variable
+
+#### Step 2: Populate Test Data Programmatically
+
+Create `tests/e2e/setup-notion-test-data.ts`:
+
+```typescript
+import { Client } from "@notionhq/client";
+
+async function setupTestData(token: string) {
+  const notion = new Client({ auth: token });
+
+  // Create parent page for all test content
+  const parentPage = await notion.pages.create({
+    parent: { type: "workspace", workspace: true },
+    properties: {
+      title: {
+        title: [{ text: { content: "E2E Test Suite" } }],
+      },
+    },
+  });
+
+  // Create test database
+  const database = await notion.databases.create({
+    parent: { type: "page_id", page_id: parentPage.id },
+    title: [{ text: { content: "Test Database" } }],
+    properties: {
+      Name: { title: {} },
+      Status: {
+        select: {
+          options: [
+            { name: "To Do", color: "red" },
+            { name: "In Progress", color: "yellow" },
+            { name: "Done", color: "green" },
+          ],
+        },
+      },
+      Price: { number: { format: "dollar" } },
+      Quantity: { number: {} },
+      Total: {
+        formula: {
+          expression: 'prop("Price") * prop("Quantity")',
+        },
+      },
+      Description: { rich_text: {} },
+      "Due Date": { date: {} },
+      "Is Complete": { checkbox: {} },
+      Tags: {
+        multi_select: {
+          options: [
+            { name: "Important", color: "red" },
+            { name: "Urgent", color: "orange" },
+          ],
+        },
+      },
+    },
+  });
+
+  // Create test pages with various content
+  const testPages = [
+    {
+      title: "Rich Text Test",
+      properties: {
+        Name: { title: [{ text: { content: "Rich Text Test" } }] },
+        Price: { number: 99.99 },
+        Quantity: { number: 3 },
+      },
+      content: [
+        {
+          object: "block",
+          type: "heading_1",
+          heading_1: {
+            rich_text: [{ text: { content: "Main Heading" } }],
+          },
+        },
+        {
+          object: "block",
+          type: "paragraph",
+          paragraph: {
+            rich_text: [
+              { text: { content: "Bold text", annotations: { bold: true } } },
+              { text: { content: " and " } },
+              {
+                text: { content: "italic text", annotations: { italic: true } },
+              },
+            ],
+          },
+        },
+        {
+          object: "block",
+          type: "code",
+          code: {
+            language: "javascript",
+            rich_text: [{ text: { content: "const x = 42;" } }],
+          },
+        },
+      ],
+    },
+    {
+      title: "Table Test",
+      properties: {
+        Name: { title: [{ text: { content: "Table Test" } }] },
+        Status: { select: { name: "Done" } },
+      },
+      content: [
+        {
+          object: "block",
+          type: "table",
+          table: {
+            table_width: 3,
+            has_column_header: true,
+            has_row_header: false,
+            children: [
+              {
+                type: "table_row",
+                table_row: {
+                  cells: [
+                    [{ text: { content: "Name" } }],
+                    [{ text: { content: "Age" } }],
+                    [{ text: { content: "City" } }],
+                  ],
+                },
+              },
+              {
+                type: "table_row",
+                table_row: {
+                  cells: [
+                    [{ text: { content: "John" } }],
+                    [{ text: { content: "30" } }],
+                    [{ text: { content: "NYC" } }],
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      title: "Media Test",
+      properties: {
+        Name: { title: [{ text: { content: "Media Test" } }] },
+      },
+      content: [
+        {
+          object: "block",
+          type: "image",
+          image: {
+            type: "external",
+            external: {
+              url: "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=400",
+            },
+            caption: [{ text: { content: "Test Image" } }],
+          },
+        },
+        {
+          object: "block",
+          type: "bookmark",
+          bookmark: {
+            url: "https://obsidian.md",
+            caption: [{ text: { content: "Obsidian Website" } }],
+          },
+        },
+      ],
+    },
+  ];
+
+  // Create all test pages
+  for (const pageData of testPages) {
+    const page = await notion.pages.create({
+      parent: { database_id: database.id },
+      properties: pageData.properties as any,
+    });
+
+    // Add content blocks
+    for (const block of pageData.content) {
+      await notion.blocks.children.append({
+        block_id: page.id,
+        children: [block as any],
+      });
+    }
+  }
+
+  return {
+    parentPageId: parentPage.id,
+    databaseId: database.id,
+    pageCount: testPages.length,
+  };
+}
+
+if (require.main === module) {
+  const token = process.env.NOTION_TOKEN;
+  if (!token) {
+    console.error("NOTION_TOKEN environment variable required");
+    process.exit(1);
+  }
+
+  setupTestData(token)
+    .then((result) => {
+      console.log("Test data created successfully:");
+      console.log(JSON.stringify(result, null, 2));
+    })
+    .catch((error) => {
+      console.error("Failed to create test data:", error);
+      process.exit(1);
+    });
+}
+
+export { setupTestData };
+```
+
+#### Step 3: Create E2E Test Runner
+
+Create `tests/e2e/run-e2e-tests.ts`:
+
+```typescript
+import { NotionApiClient } from "../../src/formats/notion-api/api-client";
+import { convertDatabaseToBase } from "../../src/formats/notion-api/base-converter";
+import { BlockConverter } from "../../src/formats/notion-api/block-converter";
+import { setupTestData } from "./setup-notion-test-data";
+import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
+
+interface TestResult {
+  passed: boolean;
+  name: string;
+  error?: string;
+}
+
+class E2ETestRunner {
+  private client: NotionApiClient;
+  private results: TestResult[] = [];
+  private outputDir: string;
+
+  constructor(token: string, outputDir: string) {
+    this.client = new NotionApiClient({ auth: token });
+    this.outputDir = outputDir;
+
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true });
+    }
+  }
+
+  async test(name: string, fn: () => Promise<void>): Promise<void> {
+    try {
+      await fn();
+      this.results.push({ passed: true, name });
+      console.log(`✓ ${name}`);
+    } catch (error) {
+      this.results.push({
+        passed: false,
+        name,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      console.error(`✗ ${name}`);
+      console.error(
+        `  Error: ${error instanceof Error ? error.message : error}`,
+      );
+    }
+  }
+
+  async runAll(): Promise<void> {
+    console.log("Setting up test data...");
+    const testData = await setupTestData(process.env.NOTION_TOKEN!);
+    console.log(`Created test database: ${testData.databaseId}\n`);
+
+    // Test 1: Database Discovery
+    await this.test("Discovers databases in workspace", async () => {
+      const results = await this.client.searchAll();
+      const databases = results.filter(
+        (r) =>
+          "object" in r &&
+          (r.object === "database" || r.object === "data_source"),
+      );
+      assert.ok(databases.length > 0, "Should find at least one database");
+    });
+
+    // Test 2: Database Conversion
+    await this.test("Converts database to Base schema", async () => {
+      const database = await this.client.getDatabase(testData.databaseId);
+      const result = convertDatabaseToBase(database as any);
+
+      assert.strictEqual(result.databaseId, testData.databaseId);
+      assert.ok(result.schema.properties, "Should have properties");
+      assert.ok(result.schema.formulas, "Should have formulas");
+      assert.ok(result.schema.formulas!["total"], "Should have total formula");
+
+      // Save for inspection
+      fs.writeFileSync(
+        path.join(this.outputDir, "database-schema.json"),
+        JSON.stringify(result, null, 2),
+      );
+    });
+
+    // Test 3: Formula Conversion
+    await this.test("Converts formulas correctly", async () => {
+      const database = await this.client.getDatabase(testData.databaseId);
+      const result = convertDatabaseToBase(database as any);
+
+      const totalFormula = result.schema.formulas!["total"];
+      assert.ok(totalFormula, "Total formula should exist");
+      assert.strictEqual(
+        totalFormula.expression,
+        "(Price * Quantity)",
+        "Formula should be converted correctly",
+      );
+    });
+
+    // Test 4: Page Conversion
+    await this.test("Converts pages to markdown", async () => {
+      const pages = await this.client.getAllDatabasePages(testData.databaseId);
+      assert.ok(pages.length >= 3, "Should have at least 3 test pages");
+
+      // Test rich text page
+      const richTextPage = pages.find((p) => {
+        const props = p.properties;
+        for (const prop of Object.values(props)) {
+          if (
+            typeof prop === "object" &&
+            prop !== null &&
+            "type" in prop &&
+            prop.type === "title" &&
+            "title" in prop
+          ) {
+            const title = (prop.title as any[])
+              .map((t) => t.plain_text)
+              .join("");
+            return title === "Rich Text Test";
+          }
+        }
+        return false;
+      });
+
+      assert.ok(richTextPage, "Should find Rich Text Test page");
+    });
+
+    // Test 5: Block Conversion
+    await this.test("Converts blocks to markdown", async () => {
+      const pages = await this.client.getAllDatabasePages(testData.databaseId);
+      const testPage = pages[0];
+
+      const mockVault = {
+        createBinary: async () => {},
+        create: async () => {},
+        exists: async () => false,
+      } as any;
+
+      const converter = new BlockConverter(
+        this.client,
+        mockVault,
+        this.outputDir,
+      );
+      const markdown = await converter.convertBlocksToMarkdown(testPage.id);
+
+      assert.ok(markdown, "Should generate markdown content");
+
+      // Save for inspection
+      fs.writeFileSync(path.join(this.outputDir, "page-markdown.md"), markdown);
+    });
+
+    // Test 6: Table Conversion
+    await this.test("Converts tables correctly", async () => {
+      const pages = await this.client.getAllDatabasePages(testData.databaseId);
+      const tablePage = pages.find((p) => {
+        const props = p.properties;
+        for (const prop of Object.values(props)) {
+          if (
+            typeof prop === "object" &&
+            prop !== null &&
+            "type" in prop &&
+            prop.type === "title" &&
+            "title" in prop
+          ) {
+            const title = (prop.title as any[])
+              .map((t) => t.plain_text)
+              .join("");
+            return title === "Table Test";
+          }
+        }
+        return false;
+      });
+
+      if (tablePage) {
+        const mockVault = { createBinary: async () => {} } as any;
+        const converter = new BlockConverter(
+          this.client,
+          mockVault,
+          this.outputDir,
+        );
+        const markdown = await converter.convertBlocksToMarkdown(tablePage.id);
+
+        assert.ok(markdown.includes("|"), "Should contain table syntax");
+        assert.ok(markdown.includes("---"), "Should contain table separator");
+      }
+    });
+
+    // Test 7: Image Handling
+    await this.test("Handles images correctly", async () => {
+      const pages = await this.client.getAllDatabasePages(testData.databaseId);
+      const mediaPage = pages.find((p) => {
+        const props = p.properties;
+        for (const prop of Object.values(props)) {
+          if (
+            typeof prop === "object" &&
+            prop !== null &&
+            "type" in prop &&
+            prop.type === "title" &&
+            "title" in prop
+          ) {
+            const title = (prop.title as any[])
+              .map((t) => t.plain_text)
+              .join("");
+            return title === "Media Test";
+          }
+        }
+        return false;
+      });
+
+      if (mediaPage) {
+        const mockVault = { createBinary: async () => {} } as any;
+        const converter = new BlockConverter(
+          this.client,
+          mockVault,
+          this.outputDir,
+        );
+        const markdown = await converter.convertBlocksToMarkdown(mediaPage.id);
+
+        assert.ok(markdown.includes("!["), "Should contain image embed");
+      }
+    });
+
+    // Print summary
+    console.log("\n" + "=".repeat(50));
+    console.log("Test Results Summary");
+    console.log("=".repeat(50));
+
+    const passed = this.results.filter((r) => r.passed).length;
+    const failed = this.results.filter((r) => !r.passed).length;
+
+    console.log(`Total: ${this.results.length}`);
+    console.log(`Passed: ${passed}`);
+    console.log(`Failed: ${failed}`);
+
+    if (failed > 0) {
+      console.log("\nFailed Tests:");
+      this.results
+        .filter((r) => !r.passed)
+        .forEach((r) => {
+          console.log(`  - ${r.name}: ${r.error}`);
+        });
+      process.exit(1);
+    }
+
+    // Save results
+    fs.writeFileSync(
+      path.join(this.outputDir, "test-results.json"),
+      JSON.stringify(this.results, null, 2),
+    );
+  }
+}
+
+if (require.main === module) {
+  const token = process.env.NOTION_TOKEN;
+  if (!token) {
+    console.error("NOTION_TOKEN environment variable required");
+    process.exit(1);
+  }
+
+  const outputDir = path.join(__dirname, "../../test-output");
+  const runner = new E2ETestRunner(token, outputDir);
+
+  runner
+    .runAll()
+    .then(() => {
+      console.log("\n✓ All tests passed!");
+    })
+    .catch((error) => {
+      console.error("\nTest runner failed:", error);
+      process.exit(1);
+    });
+}
+```
+
+#### Step 4: GitHub Actions Workflow
+
+Create `.github/workflows/e2e-notion-api.yml`:
+
+```yaml
+name: E2E Notion API Tests
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  schedule:
+    - cron: "0 0 * * 0" # Weekly on Sundays
+
+jobs:
+  e2e-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Build project
+        run: npm run build
+
+      - name: Run E2E tests
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TEST_TOKEN }}
+        run: npx tsx tests/e2e/run-e2e-tests.ts
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: e2e-test-results
+          path: test-output/
+
+      - name: Comment PR with results
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require('fs');
+            const results = JSON.parse(fs.readFileSync('test-output/test-results.json', 'utf8'));
+
+            const passed = results.filter(r => r.passed).length;
+            const failed = results.filter(r => !r.passed).length;
+
+            const body = `## E2E Test Results
+
+            - ✅ Passed: ${passed}
+            - ❌ Failed: ${failed}
+
+            ${failed > 0 ? '### Failed Tests\n' + results.filter(r => !r.passed).map(r => `- ${r.name}: ${r.error}`).join('\n') : ''}
+            `;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
+```
+
+#### Step 5: Local Testing Script
+
+Create `package.json` scripts:
+
+```json
+{
+  "scripts": {
+    "test": "vitest",
+    "test:e2e": "tsx tests/e2e/run-e2e-tests.ts",
+    "test:e2e:setup": "tsx tests/e2e/setup-notion-test-data.ts",
+    "test:all": "npm test && npm run test:e2e"
+  }
+}
+```
+
+Run locally:
+
+```bash
+export NOTION_TOKEN=secret_your_token_here
+npm run test:e2e:setup  # Creates test data
+npm run test:e2e        # Runs E2E tests
+```
+
+---
+
+## Verification Checklist
+
+After running the importer, verify:
+
+### Base Files (`.base`)
+
+- [ ] File created in output folder
+- [ ] Contains YAML schema in code block
+- [ ] Has correct property types
+- [ ] Formulas are converted properly
+- [ ] Options for select/multi-select preserved
+
+### Markdown Files (`.md`)
+
+- [ ] Frontmatter includes `notion-database` tag
+- [ ] Page title is correct (H1)
+- [ ] Rich text formatting preserved
+- [ ] All text styles work (bold, italic, strikethrough, code)
+- [ ] Links are clickable
+- [ ] Headings at correct levels
+
+### Lists
+
+- [ ] Bulleted lists formatted correctly
+- [ ] Numbered lists have proper numbering
+- [ ] To-do items show `[ ]` or `[x]`
+- [ ] Nested lists indented properly
+
+### Tables
+
+- [ ] Rendered with pipe syntax `| ... |`
+- [ ] Headers have separator line `| --- |`
+- [ ] All cells present
+- [ ] Empty cells handled
+
+### Media
+
+- [ ] Images downloaded to attachment folder
+- [ ] Images embedded with `![caption](path)`
+- [ ] Attachments downloaded
+- [ ] Captions preserved
+- [ ] External URLs work as fallback
+
+### Code and Math
+
+- [ ] Code blocks have language specified
+- [ ] Inline code uses backticks
+- [ ] Block equations use `$$...$$`
+- [ ] Inline equations use `$...$`
+
+### Edge Cases
+
+- [ ] Empty blocks don't create extra whitespace
+- [ ] Special characters in filenames handled
+- [ ] Very long content doesn't break
+- [ ] Nested structures preserved
+- [ ] No data loss
+
+---
+
+## Troubleshooting
+
+### "No databases found"
+
+- Ensure databases are shared with the integration
+- Check integration has correct permissions
+- Verify token is correct
+
+### "Failed to download attachment"
+
+- Check internet connection
+- Notion URLs may have expired (they expire after 1 hour)
+- Re-run the import to get fresh URLs
+
+### Formula conversion warnings
+
+- Check console for specific formula errors
+- Verify formula uses supported Notion functions
+- Some complex formulas may need manual adjustment
+
+### Build errors
+
+- Run `npm install --legacy-peer-deps`
+- Clear node_modules and reinstall
+- Check Node.js version (18+ recommended)
+
+---
+
+## Performance Notes
+
+Import speed depends on:
+
+- Number of databases: ~1-2 seconds per database
+- Number of pages: ~0.5 seconds per page
+- Number of blocks: ~10ms per block
+- Attachments: ~1-5 seconds per file (depends on size)
+
+For large workspaces (100+ pages), expect 5-10 minutes for complete import.
+
+---
+
+## Next Steps
+
+After successful testing:
+
+1. Document any issues found
+2. Create test cases for edge cases
+3. Add regression tests for fixed bugs
+4. Update this guide with new findings
+5. Share feedback with the development team

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,18 @@
 			"license": "MIT",
 			"dependencies": {
 				"@joplin/turndown-plugin-gfm": "1.0.62",
+				"@notionhq/client": "^5.1.0",
 				"@zip.js/zip.js": "2.7.60",
+				"mdast-util-from-markdown": "^2.0.2",
+				"mdast-util-to-markdown": "^2.1.2",
 				"plain-tag": "0.1.3",
 				"protobufjs": "7.2.5",
+				"remark-parse": "^11.0.0",
+				"remark-stringify": "^11.0.0",
 				"static-params": "0.4.0",
-				"xml-flow": "1.0.4"
+				"unified": "^11.0.5",
+				"xml-flow": "1.0.4",
+				"yaml": "^2.8.1"
 			},
 			"devDependencies": {
 				"@microsoft/microsoft-graph-types": "2.38.0",
@@ -619,6 +626,15 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@notionhq/client": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@notionhq/client/-/client-5.1.0.tgz",
+			"integrity": "sha512-YYVjXYk1XwKQ4XIh+iGjaaXOGHxaDgB3UaGnDMyrZ3X9UiYQsZpzPIvTuhvp97os8a5W5kTQFsyq77+I+COOVQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@protobufjs/aspromise": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -682,6 +698,15 @@
 				"@types/tern": "*"
 			}
 		},
+		"node_modules/@types/debug": {
+			"version": "4.1.12",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+			"integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/ms": "*"
+			}
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -693,6 +718,21 @@
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true
+		},
+		"node_modules/@types/mdast": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+			"integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "*"
+			}
+		},
+		"node_modules/@types/ms": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+			"license": "MIT"
 		},
 		"node_modules/@types/node": {
 			"version": "16.6.2",
@@ -713,6 +753,12 @@
 			"dependencies": {
 				"@types/estree": "*"
 			}
+		},
+		"node_modules/@types/unist": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+			"license": "MIT"
 		},
 		"node_modules/@types/xml-flow": {
 			"version": "1.0.1",
@@ -1000,6 +1046,16 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/bail": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+			"integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1065,6 +1121,16 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
+		"node_modules/character-entities": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+			"integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1108,7 +1174,6 @@
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
 			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -1121,11 +1186,46 @@
 				}
 			}
 		},
+		"node_modules/decode-named-character-reference": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
+			"integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
+			"license": "MIT",
+			"dependencies": {
+				"character-entities": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
+		},
+		"node_modules/dequal": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/devlop": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+			"integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+			"license": "MIT",
+			"dependencies": {
+				"dequal": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
 		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
@@ -1344,6 +1444,12 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"license": "MIT"
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -1637,6 +1743,18 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/is-plain-obj": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+			"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1721,6 +1839,16 @@
 			"resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
 			"integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
 		},
+		"node_modules/longest-streak": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+			"integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -1733,6 +1861,78 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/mdast-util-from-markdown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+			"integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"@types/unist": "^3.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-to-string": "^4.0.0",
+				"micromark": "^4.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-decode-string": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"unist-util-stringify-position": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-phrasing": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+			"integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"unist-util-is": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-to-markdown": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+			"integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"@types/unist": "^3.0.0",
+				"longest-streak": "^3.0.0",
+				"mdast-util-phrasing": "^4.0.0",
+				"mdast-util-to-string": "^4.0.0",
+				"micromark-util-classify-character": "^2.0.0",
+				"micromark-util-decode-string": "^2.0.0",
+				"unist-util-visit": "^5.0.0",
+				"zwitch": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-to-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+			"integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -1741,6 +1941,448 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/micromark": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+			"integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@types/debug": "^4.0.0",
+				"debug": "^4.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-core-commonmark": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-combine-extensions": "^2.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-encode": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"micromark-util-subtokenize": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-core-commonmark": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+			"integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-factory-destination": "^2.0.0",
+				"micromark-factory-label": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-factory-title": "^2.0.0",
+				"micromark-factory-whitespace": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-classify-character": "^2.0.0",
+				"micromark-util-html-tag-name": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-subtokenize": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-destination": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+			"integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-label": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+			"integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-space": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+			"integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-title": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+			"integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-whitespace": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+			"integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-character": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+			"integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-chunked": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+			"integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-classify-character": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+			"integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-combine-extensions": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+			"integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-decode-numeric-character-reference": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+			"integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-decode-string": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+			"integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decode-named-character-reference": "^1.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-encode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+			"integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-html-tag-name": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+			"integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-normalize-identifier": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+			"integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-resolve-all": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+			"integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-sanitize-uri": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+			"integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-encode": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-subtokenize": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+			"integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-symbol": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+			"integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-types": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+			"integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/micromatch": {
 			"version": "4.0.8",
@@ -1779,8 +2421,7 @@
 		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
@@ -1991,6 +2632,37 @@
 				}
 			]
 		},
+		"node_modules/remark-parse": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+			"integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-stringify": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+			"integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-to-markdown": "^2.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/resolve-from": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2164,6 +2836,16 @@
 				"node": ">=8.0"
 			}
 		},
+		"node_modules/trough": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+			"integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/ts-api-utils": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
@@ -2219,6 +2901,80 @@
 				"node": ">=4.2.0"
 			}
 		},
+		"node_modules/unified": {
+			"version": "11.0.5",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+			"integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"bail": "^2.0.0",
+				"devlop": "^1.0.0",
+				"extend": "^3.0.0",
+				"is-plain-obj": "^4.0.0",
+				"trough": "^2.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-is": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+			"integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-stringify-position": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+			"integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-visit": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+			"integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0",
+				"unist-util-visit-parents": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-visit-parents": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+			"integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -2226,6 +2982,34 @@
 			"dev": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/vfile": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+			"integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/vfile-message": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+			"integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-stringify-position": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/w3c-keyname": {
@@ -2270,6 +3054,18 @@
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		},
+		"node_modules/yaml": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+			"integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			}
+		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -2280,6 +3076,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zwitch": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+			"integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		}
 	},
@@ -2582,6 +3388,11 @@
 				"fastq": "^1.6.0"
 			}
 		},
+		"@notionhq/client": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@notionhq/client/-/client-5.1.0.tgz",
+			"integrity": "sha512-YYVjXYk1XwKQ4XIh+iGjaaXOGHxaDgB3UaGnDMyrZ3X9UiYQsZpzPIvTuhvp97os8a5W5kTQFsyq77+I+COOVQ=="
+		},
 		"@protobufjs/aspromise": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -2645,6 +3456,14 @@
 				"@types/tern": "*"
 			}
 		},
+		"@types/debug": {
+			"version": "4.1.12",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+			"integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+			"requires": {
+				"@types/ms": "*"
+			}
+		},
 		"@types/estree": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -2656,6 +3475,19 @@
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true
+		},
+		"@types/mdast": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+			"integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+			"requires": {
+				"@types/unist": "*"
+			}
+		},
+		"@types/ms": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
 		},
 		"@types/node": {
 			"version": "16.6.2",
@@ -2676,6 +3508,11 @@
 			"requires": {
 				"@types/estree": "*"
 			}
+		},
+		"@types/unist": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
 		},
 		"@types/xml-flow": {
 			"version": "1.0.1",
@@ -2844,6 +3681,11 @@
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
 			"dev": true
 		},
+		"bail": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+			"integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+		},
 		"balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2891,6 +3733,11 @@
 				"supports-color": "^7.1.0"
 			}
 		},
+		"character-entities": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+			"integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="
+		},
 		"color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2927,9 +3774,16 @@
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
 			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
 			"requires": {
 				"ms": "2.1.2"
+			}
+		},
+		"decode-named-character-reference": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
+			"integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
+			"requires": {
+				"character-entities": "^2.0.0"
 			}
 		},
 		"deep-is": {
@@ -2937,6 +3791,19 @@
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
+		},
+		"dequal": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
+		},
+		"devlop": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+			"integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+			"requires": {
+				"dequal": "^2.0.0"
+			}
 		},
 		"dir-glob": {
 			"version": "3.0.1",
@@ -3096,6 +3963,11 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
+		},
+		"extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
@@ -3322,6 +4194,11 @@
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
 			"dev": true
 		},
+		"is-plain-obj": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+			"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3394,6 +4271,11 @@
 			"resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
 			"integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
 		},
+		"longest-streak": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+			"integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="
+		},
 		"lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -3403,11 +4285,274 @@
 				"yallist": "^4.0.0"
 			}
 		},
+		"mdast-util-from-markdown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+			"integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+			"requires": {
+				"@types/mdast": "^4.0.0",
+				"@types/unist": "^3.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-to-string": "^4.0.0",
+				"micromark": "^4.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-decode-string": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"unist-util-stringify-position": "^4.0.0"
+			}
+		},
+		"mdast-util-phrasing": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+			"integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+			"requires": {
+				"@types/mdast": "^4.0.0",
+				"unist-util-is": "^6.0.0"
+			}
+		},
+		"mdast-util-to-markdown": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+			"integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+			"requires": {
+				"@types/mdast": "^4.0.0",
+				"@types/unist": "^3.0.0",
+				"longest-streak": "^3.0.0",
+				"mdast-util-phrasing": "^4.0.0",
+				"mdast-util-to-string": "^4.0.0",
+				"micromark-util-classify-character": "^2.0.0",
+				"micromark-util-decode-string": "^2.0.0",
+				"unist-util-visit": "^5.0.0",
+				"zwitch": "^2.0.0"
+			}
+		},
+		"mdast-util-to-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+			"integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+			"requires": {
+				"@types/mdast": "^4.0.0"
+			}
+		},
 		"merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
 			"dev": true
+		},
+		"micromark": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+			"integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+			"requires": {
+				"@types/debug": "^4.0.0",
+				"debug": "^4.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-core-commonmark": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-combine-extensions": "^2.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-encode": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"micromark-util-subtokenize": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"micromark-core-commonmark": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+			"integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+			"requires": {
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-factory-destination": "^2.0.0",
+				"micromark-factory-label": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-factory-title": "^2.0.0",
+				"micromark-factory-whitespace": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-classify-character": "^2.0.0",
+				"micromark-util-html-tag-name": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-subtokenize": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"micromark-factory-destination": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+			"integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+			"requires": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"micromark-factory-label": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+			"integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+			"requires": {
+				"devlop": "^1.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"micromark-factory-space": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+			"integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+			"requires": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"micromark-factory-title": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+			"integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+			"requires": {
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"micromark-factory-whitespace": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+			"integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+			"requires": {
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"micromark-util-character": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+			"integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+			"requires": {
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"micromark-util-chunked": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+			"integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+			"requires": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"micromark-util-classify-character": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+			"integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+			"requires": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"micromark-util-combine-extensions": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+			"integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+			"requires": {
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"micromark-util-decode-numeric-character-reference": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+			"integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+			"requires": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"micromark-util-decode-string": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+			"integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+			"requires": {
+				"decode-named-character-reference": "^1.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"micromark-util-encode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+			"integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="
+		},
+		"micromark-util-html-tag-name": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+			"integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="
+		},
+		"micromark-util-normalize-identifier": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+			"integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+			"requires": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"micromark-util-resolve-all": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+			"integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+			"requires": {
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"micromark-util-sanitize-uri": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+			"integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+			"requires": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-encode": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"micromark-util-subtokenize": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+			"integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+			"requires": {
+				"devlop": "^1.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"micromark-util-symbol": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+			"integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="
+		},
+		"micromark-util-types": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+			"integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="
 		},
 		"micromatch": {
 			"version": "4.0.8",
@@ -3437,8 +4582,7 @@
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"natural-compare": {
 			"version": "1.4.0",
@@ -3584,6 +4728,27 @@
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
 			"dev": true
 		},
+		"remark-parse": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+			"integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+			"requires": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"unified": "^11.0.0"
+			}
+		},
+		"remark-stringify": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+			"integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+			"requires": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-to-markdown": "^2.0.0",
+				"unified": "^11.0.0"
+			}
+		},
 		"resolve-from": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3700,6 +4865,11 @@
 				"is-number": "^7.0.0"
 			}
 		},
+		"trough": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+			"integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="
+		},
 		"ts-api-utils": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
@@ -3734,6 +4904,55 @@
 			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
 			"dev": true
 		},
+		"unified": {
+			"version": "11.0.5",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+			"integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+			"requires": {
+				"@types/unist": "^3.0.0",
+				"bail": "^2.0.0",
+				"devlop": "^1.0.0",
+				"extend": "^3.0.0",
+				"is-plain-obj": "^4.0.0",
+				"trough": "^2.0.0",
+				"vfile": "^6.0.0"
+			}
+		},
+		"unist-util-is": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+			"integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+			"requires": {
+				"@types/unist": "^3.0.0"
+			}
+		},
+		"unist-util-stringify-position": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+			"integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+			"requires": {
+				"@types/unist": "^3.0.0"
+			}
+		},
+		"unist-util-visit": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+			"integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+			"requires": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0",
+				"unist-util-visit-parents": "^6.0.0"
+			}
+		},
+		"unist-util-visit-parents": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+			"integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+			"requires": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0"
+			}
+		},
 		"uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3741,6 +4960,24 @@
 			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
+			}
+		},
+		"vfile": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+			"integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+			"requires": {
+				"@types/unist": "^3.0.0",
+				"vfile-message": "^4.0.0"
+			}
+		},
+		"vfile-message": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+			"integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+			"requires": {
+				"@types/unist": "^3.0.0",
+				"unist-util-stringify-position": "^4.0.0"
 			}
 		},
 		"w3c-keyname": {
@@ -3779,11 +5016,21 @@
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		},
+		"yaml": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+			"integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw=="
+		},
 		"yocto-queue": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
 			"dev": true
+		},
+		"zwitch": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+			"integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
 		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,8 @@
 				"eslint": "8.46.0",
 				"obsidian": "latest",
 				"tslib": "2.4.0",
-				"typescript": "4.7.4"
+				"typescript": "4.7.4",
+				"vitest": "^3.2.4"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -44,25 +45,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/@codemirror/state": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.0.tgz",
-			"integrity": "sha512-hm8XshYj5Fo30Bb922QX9hXB/bxOAVH+qaqHBzw5TKa72vOeslyGwd4X8M0c1dJ9JqxlaMceOQ8RsL9tC7gU0A==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@codemirror/view": {
-			"version": "6.24.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.24.0.tgz",
-			"integrity": "sha512-zK6m5pNkdhdJl8idPP1gA4N8JKTiSsOz8U/Iw+C1ChMwyLG7+MLiNXnH/wFuAk6KeGEe33/adOiAh5jMqee03w==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@codemirror/state": "^6.4.0",
-				"style-mod": "^4.1.0",
-				"w3c-keyname": "^2.2.4"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -585,6 +567,13 @@
 			"integrity": "sha512-Ts7cZ0Y9rIRgNkPtpXYB3BVjjSP2eeWzrPnQvJgNTC+FpopSjoaYjLQvPcEj1d6JcTMegnYoZK98/WJhm02Uaw==",
 			"license": "MIT"
 		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@microsoft/microsoft-graph-types": {
 			"version": "2.38.0",
 			"resolved": "https://registry.npmjs.org/@microsoft/microsoft-graph-types/-/microsoft-graph-types-2.38.0.tgz",
@@ -689,6 +678,324 @@
 			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
 			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
 		},
+		"node_modules/@rollup/rollup-android-arm-eabi": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.4.tgz",
+			"integrity": "sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-android-arm64": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.4.tgz",
+			"integrity": "sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-arm64": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.4.tgz",
+			"integrity": "sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-x64": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.4.tgz",
+			"integrity": "sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-arm64": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.4.tgz",
+			"integrity": "sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-x64": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.4.tgz",
+			"integrity": "sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.4.tgz",
+			"integrity": "sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.4.tgz",
+			"integrity": "sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-gnu": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.4.tgz",
+			"integrity": "sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-musl": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.4.tgz",
+			"integrity": "sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-gnu": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.4.tgz",
+			"integrity": "sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.4.tgz",
+			"integrity": "sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.4.tgz",
+			"integrity": "sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-musl": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.4.tgz",
+			"integrity": "sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-s390x-gnu": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.4.tgz",
+			"integrity": "sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-gnu": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.4.tgz",
+			"integrity": "sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-musl": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.4.tgz",
+			"integrity": "sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-openharmony-arm64": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.4.tgz",
+			"integrity": "sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-arm64-msvc": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.4.tgz",
+			"integrity": "sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-ia32-msvc": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.4.tgz",
+			"integrity": "sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-gnu": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.4.tgz",
+			"integrity": "sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-msvc": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.4.tgz",
+			"integrity": "sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@types/chai": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+			"integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*"
+			}
+		},
 		"node_modules/@types/codemirror": {
 			"version": "5.60.8",
 			"resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
@@ -707,11 +1014,19 @@
 				"@types/ms": "*"
 			}
 		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/estree": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-			"dev": true
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
@@ -959,6 +1274,121 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
+		"node_modules/@vitest/expect": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+			"integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "3.2.4",
+				"@vitest/utils": "3.2.4",
+				"chai": "^5.2.0",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+			"integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "3.2.4",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.17"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+			"integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+			"integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "3.2.4",
+				"pathe": "^2.0.3",
+				"strip-literal": "^3.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+			"integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "3.2.4",
+				"magic-string": "^0.30.17",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+			"integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyspy": "^4.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+			"integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "3.2.4",
+				"loupe": "^3.1.4",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
 		"node_modules/@zip.js/zip.js": {
 			"version": "2.7.60",
 			"resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.60.tgz",
@@ -1046,6 +1476,16 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/bail": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -1096,6 +1536,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/cac": {
+			"version": "6.7.14",
+			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1103,6 +1553,23 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/chai": {
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+			"integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"assertion-error": "^2.0.1",
+				"check-error": "^2.1.1",
+				"deep-eql": "^5.0.1",
+				"loupe": "^3.1.0",
+				"pathval": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/chalk": {
@@ -1129,6 +1596,16 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/check-error": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+			"integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16"
 			}
 		},
 		"node_modules/color-convert": {
@@ -1171,11 +1648,12 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
 			"dependencies": {
-				"ms": "2.1.2"
+				"ms": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=6.0"
@@ -1197,6 +1675,16 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/deep-eql": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/deep-is": {
@@ -1250,6 +1738,13 @@
 			"engines": {
 				"node": ">=6.0.0"
 			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/esbuild": {
 			"version": "0.25.4",
@@ -1436,6 +1931,16 @@
 				"node": ">=4.0"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1443,6 +1948,16 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+			"integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/extend": {
@@ -1504,6 +2019,24 @@
 			"dev": true,
 			"dependencies": {
 				"reusify": "^1.0.4"
+			}
+		},
+		"node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/file-entry-cache": {
@@ -1571,6 +2104,21 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
 		},
 		"node_modules/glob": {
 			"version": "7.2.3",
@@ -1761,6 +2309,13 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
 		},
+		"node_modules/js-tokens": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+			"integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -1849,6 +2404,13 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/loupe": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+			"integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -1859,6 +2421,16 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.19",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+			"integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
 		"node_modules/mdast-util-from-markdown": {
@@ -2419,9 +2991,29 @@
 			}
 		},
 		"node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
+		},
+		"node_modules/nanoid": {
+			"version": "3.3.11",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
 		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
@@ -2554,6 +3146,30 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/pathval": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+			"integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.16"
+			}
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -2570,6 +3186,35 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/plain-tag/-/plain-tag-0.1.3.tgz",
 			"integrity": "sha512-yyVAOFKTAElc7KdLt2+UKGExNYwYb/Y/WE9i+1ezCQsJE8gbKSjewfpRqK2nQgZ4d4hhAAGgDCOcIZVilqE5UA=="
+		},
+		"node_modules/postcss": {
+			"version": "8.5.6",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.11",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
 		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
@@ -2697,6 +3342,48 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/rollup": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.4.tgz",
+			"integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "1.0.8"
+			},
+			"bin": {
+				"rollup": "dist/bin/rollup"
+			},
+			"engines": {
+				"node": ">=18.0.0",
+				"npm": ">=8.0.0"
+			},
+			"optionalDependencies": {
+				"@rollup/rollup-android-arm-eabi": "4.52.4",
+				"@rollup/rollup-android-arm64": "4.52.4",
+				"@rollup/rollup-darwin-arm64": "4.52.4",
+				"@rollup/rollup-darwin-x64": "4.52.4",
+				"@rollup/rollup-freebsd-arm64": "4.52.4",
+				"@rollup/rollup-freebsd-x64": "4.52.4",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.52.4",
+				"@rollup/rollup-linux-arm-musleabihf": "4.52.4",
+				"@rollup/rollup-linux-arm64-gnu": "4.52.4",
+				"@rollup/rollup-linux-arm64-musl": "4.52.4",
+				"@rollup/rollup-linux-loong64-gnu": "4.52.4",
+				"@rollup/rollup-linux-ppc64-gnu": "4.52.4",
+				"@rollup/rollup-linux-riscv64-gnu": "4.52.4",
+				"@rollup/rollup-linux-riscv64-musl": "4.52.4",
+				"@rollup/rollup-linux-s390x-gnu": "4.52.4",
+				"@rollup/rollup-linux-x64-gnu": "4.52.4",
+				"@rollup/rollup-linux-x64-musl": "4.52.4",
+				"@rollup/rollup-openharmony-arm64": "4.52.4",
+				"@rollup/rollup-win32-arm64-msvc": "4.52.4",
+				"@rollup/rollup-win32-ia32-msvc": "4.52.4",
+				"@rollup/rollup-win32-x64-gnu": "4.52.4",
+				"@rollup/rollup-win32-x64-msvc": "4.52.4",
+				"fsevents": "~2.3.2"
+			}
+		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -2761,6 +3448,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -2770,10 +3464,34 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/static-params": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/static-params/-/static-params-0.4.0.tgz",
 			"integrity": "sha512-PV5nE992wwLEaXOUtXKrJeyVPBiizGpC8xyqqRrACxc8duz3Ym/pyraEkd/hYOmQFuZPTF9CRaL+Ac+84yxzyg=="
+		},
+		"node_modules/std-env": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+			"integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",
@@ -2799,12 +3517,18 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/style-mod": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.0.tgz",
-			"integrity": "sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA==",
+		"node_modules/strip-literal": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+			"integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
 			"dev": true,
-			"peer": true
+			"license": "MIT",
+			"dependencies": {
+				"js-tokens": "^9.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
@@ -2823,6 +3547,80 @@
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true
+		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+			"integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.15",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyglobby/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/tinypool": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+			"integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+			"integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tinyspy": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+			"integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -3012,12 +3810,202 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/w3c-keyname": {
-			"version": "2.2.8",
-			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
-			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+		"node_modules/vite": {
+			"version": "7.1.9",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.1.9.tgz",
+			"integrity": "sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==",
 			"dev": true,
-			"peer": true
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "^0.25.0",
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3",
+				"postcss": "^8.5.6",
+				"rollup": "^4.43.0",
+				"tinyglobby": "^0.2.15"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"lightningcss": "^1.21.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vite-node": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+			"integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cac": "^6.7.14",
+				"debug": "^4.4.1",
+				"es-module-lexer": "^1.7.0",
+				"pathe": "^2.0.3",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+			},
+			"bin": {
+				"vite-node": "vite-node.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/vite/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/vitest": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+			"integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/chai": "^5.2.2",
+				"@vitest/expect": "3.2.4",
+				"@vitest/mocker": "3.2.4",
+				"@vitest/pretty-format": "^3.2.4",
+				"@vitest/runner": "3.2.4",
+				"@vitest/snapshot": "3.2.4",
+				"@vitest/spy": "3.2.4",
+				"@vitest/utils": "3.2.4",
+				"chai": "^5.2.0",
+				"debug": "^4.4.1",
+				"expect-type": "^1.2.1",
+				"magic-string": "^0.30.17",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.2",
+				"std-env": "^3.9.0",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^0.3.2",
+				"tinyglobby": "^0.2.14",
+				"tinypool": "^1.1.1",
+				"tinyrainbow": "^2.0.0",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+				"vite-node": "3.2.4",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@types/debug": "^4.1.12",
+				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+				"@vitest/browser": "3.2.4",
+				"@vitest/ui": "3.2.4",
+				"happy-dom": "*",
+				"jsdom": "*"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@types/debug": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vitest/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
@@ -3032,6 +4020,23 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/wrappy": {
@@ -3095,25 +4100,6 @@
 			"resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
 			"integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
 			"dev": true
-		},
-		"@codemirror/state": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.0.tgz",
-			"integrity": "sha512-hm8XshYj5Fo30Bb922QX9hXB/bxOAVH+qaqHBzw5TKa72vOeslyGwd4X8M0c1dJ9JqxlaMceOQ8RsL9tC7gU0A==",
-			"dev": true,
-			"peer": true
-		},
-		"@codemirror/view": {
-			"version": "6.24.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.24.0.tgz",
-			"integrity": "sha512-zK6m5pNkdhdJl8idPP1gA4N8JKTiSsOz8U/Iw+C1ChMwyLG7+MLiNXnH/wFuAk6KeGEe33/adOiAh5jMqee03w==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@codemirror/state": "^6.4.0",
-				"style-mod": "^4.1.0",
-				"w3c-keyname": "^2.2.4"
-			}
 		},
 		"@esbuild/aix-ppc64": {
 			"version": "0.25.4",
@@ -3356,6 +4342,12 @@
 			"resolved": "https://registry.npmjs.org/@joplin/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.62.tgz",
 			"integrity": "sha512-Ts7cZ0Y9rIRgNkPtpXYB3BVjjSP2eeWzrPnQvJgNTC+FpopSjoaYjLQvPcEj1d6JcTMegnYoZK98/WJhm02Uaw=="
 		},
+		"@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true
+		},
 		"@microsoft/microsoft-graph-types": {
 			"version": "2.38.0",
 			"resolved": "https://registry.npmjs.org/@microsoft/microsoft-graph-types/-/microsoft-graph-types-2.38.0.tgz",
@@ -3447,6 +4439,169 @@
 			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
 			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
 		},
+		"@rollup/rollup-android-arm-eabi": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.4.tgz",
+			"integrity": "sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==",
+			"dev": true,
+			"optional": true
+		},
+		"@rollup/rollup-android-arm64": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.4.tgz",
+			"integrity": "sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==",
+			"dev": true,
+			"optional": true
+		},
+		"@rollup/rollup-darwin-arm64": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.4.tgz",
+			"integrity": "sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==",
+			"dev": true,
+			"optional": true
+		},
+		"@rollup/rollup-darwin-x64": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.4.tgz",
+			"integrity": "sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==",
+			"dev": true,
+			"optional": true
+		},
+		"@rollup/rollup-freebsd-arm64": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.4.tgz",
+			"integrity": "sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@rollup/rollup-freebsd-x64": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.4.tgz",
+			"integrity": "sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==",
+			"dev": true,
+			"optional": true
+		},
+		"@rollup/rollup-linux-arm-gnueabihf": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.4.tgz",
+			"integrity": "sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@rollup/rollup-linux-arm-musleabihf": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.4.tgz",
+			"integrity": "sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==",
+			"dev": true,
+			"optional": true
+		},
+		"@rollup/rollup-linux-arm64-gnu": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.4.tgz",
+			"integrity": "sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==",
+			"dev": true,
+			"optional": true
+		},
+		"@rollup/rollup-linux-arm64-musl": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.4.tgz",
+			"integrity": "sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==",
+			"dev": true,
+			"optional": true
+		},
+		"@rollup/rollup-linux-loong64-gnu": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.4.tgz",
+			"integrity": "sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@rollup/rollup-linux-ppc64-gnu": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.4.tgz",
+			"integrity": "sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==",
+			"dev": true,
+			"optional": true
+		},
+		"@rollup/rollup-linux-riscv64-gnu": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.4.tgz",
+			"integrity": "sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==",
+			"dev": true,
+			"optional": true
+		},
+		"@rollup/rollup-linux-riscv64-musl": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.4.tgz",
+			"integrity": "sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==",
+			"dev": true,
+			"optional": true
+		},
+		"@rollup/rollup-linux-s390x-gnu": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.4.tgz",
+			"integrity": "sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==",
+			"dev": true,
+			"optional": true
+		},
+		"@rollup/rollup-linux-x64-gnu": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.4.tgz",
+			"integrity": "sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==",
+			"dev": true,
+			"optional": true
+		},
+		"@rollup/rollup-linux-x64-musl": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.4.tgz",
+			"integrity": "sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==",
+			"dev": true,
+			"optional": true
+		},
+		"@rollup/rollup-openharmony-arm64": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.4.tgz",
+			"integrity": "sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==",
+			"dev": true,
+			"optional": true
+		},
+		"@rollup/rollup-win32-arm64-msvc": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.4.tgz",
+			"integrity": "sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@rollup/rollup-win32-ia32-msvc": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.4.tgz",
+			"integrity": "sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==",
+			"dev": true,
+			"optional": true
+		},
+		"@rollup/rollup-win32-x64-gnu": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.4.tgz",
+			"integrity": "sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@rollup/rollup-win32-x64-msvc": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.4.tgz",
+			"integrity": "sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==",
+			"dev": true,
+			"optional": true
+		},
+		"@types/chai": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+			"integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+			"dev": true,
+			"requires": {
+				"@types/deep-eql": "*"
+			}
+		},
 		"@types/codemirror": {
 			"version": "5.60.8",
 			"resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
@@ -3464,10 +4619,16 @@
 				"@types/ms": "*"
 			}
 		},
+		"@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true
+		},
 		"@types/estree": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
 			"dev": true
 		},
 		"@types/json-schema": {
@@ -3624,6 +4785,81 @@
 				"eslint-visitor-keys": "^3.4.1"
 			}
 		},
+		"@vitest/expect": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+			"integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+			"dev": true,
+			"requires": {
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "3.2.4",
+				"@vitest/utils": "3.2.4",
+				"chai": "^5.2.0",
+				"tinyrainbow": "^2.0.0"
+			}
+		},
+		"@vitest/mocker": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+			"integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+			"dev": true,
+			"requires": {
+				"@vitest/spy": "3.2.4",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.17"
+			}
+		},
+		"@vitest/pretty-format": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+			"integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+			"dev": true,
+			"requires": {
+				"tinyrainbow": "^2.0.0"
+			}
+		},
+		"@vitest/runner": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+			"integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+			"dev": true,
+			"requires": {
+				"@vitest/utils": "3.2.4",
+				"pathe": "^2.0.3",
+				"strip-literal": "^3.0.0"
+			}
+		},
+		"@vitest/snapshot": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+			"integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+			"dev": true,
+			"requires": {
+				"@vitest/pretty-format": "3.2.4",
+				"magic-string": "^0.30.17",
+				"pathe": "^2.0.3"
+			}
+		},
+		"@vitest/spy": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+			"integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+			"dev": true,
+			"requires": {
+				"tinyspy": "^4.0.3"
+			}
+		},
+		"@vitest/utils": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+			"integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+			"dev": true,
+			"requires": {
+				"@vitest/pretty-format": "3.2.4",
+				"loupe": "^3.1.4",
+				"tinyrainbow": "^2.0.0"
+			}
+		},
 		"@zip.js/zip.js": {
 			"version": "2.7.60",
 			"resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.60.tgz",
@@ -3639,8 +4875,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"ajv": {
 			"version": "6.12.6",
@@ -3681,6 +4916,12 @@
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
 			"dev": true
 		},
+		"assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true
+		},
 		"bail": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -3717,11 +4958,30 @@
 			"integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
 			"dev": true
 		},
+		"cac": {
+			"version": "6.7.14",
+			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+			"dev": true
+		},
 		"callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 			"dev": true
+		},
+		"chai": {
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+			"integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+			"dev": true,
+			"requires": {
+				"assertion-error": "^2.0.1",
+				"check-error": "^2.1.1",
+				"deep-eql": "^5.0.1",
+				"loupe": "^3.1.0",
+				"pathval": "^2.0.0"
+			}
 		},
 		"chalk": {
 			"version": "4.1.2",
@@ -3737,6 +4997,12 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
 			"integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="
+		},
+		"check-error": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+			"integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+			"dev": true
 		},
 		"color-convert": {
 			"version": "2.0.1",
@@ -3771,11 +5037,11 @@
 			}
 		},
 		"debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
 			"requires": {
-				"ms": "2.1.2"
+				"ms": "^2.1.3"
 			}
 		},
 		"decode-named-character-reference": {
@@ -3785,6 +5051,12 @@
 			"requires": {
 				"character-entities": "^2.0.0"
 			}
+		},
+		"deep-eql": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+			"dev": true
 		},
 		"deep-is": {
 			"version": "0.1.4",
@@ -3822,6 +5094,12 @@
 			"requires": {
 				"esutils": "^2.0.2"
 			}
+		},
+		"es-module-lexer": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+			"dev": true
 		},
 		"esbuild": {
 			"version": "0.25.4",
@@ -3958,10 +5236,25 @@
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 			"dev": true
 		},
+		"estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"requires": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true
+		},
+		"expect-type": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+			"integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
 			"dev": true
 		},
 		"extend": {
@@ -4020,6 +5313,12 @@
 				"reusify": "^1.0.4"
 			}
 		},
+		"fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true
+		},
 		"file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -4070,6 +5369,13 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true
+		},
+		"fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"optional": true
 		},
 		"glob": {
 			"version": "7.2.3",
@@ -4205,6 +5511,12 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
 		},
+		"js-tokens": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+			"integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+			"dev": true
+		},
 		"js-yaml": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -4276,6 +5588,12 @@
 			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
 			"integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="
 		},
+		"loupe": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+			"integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+			"dev": true
+		},
 		"lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -4283,6 +5601,15 @@
 			"dev": true,
 			"requires": {
 				"yallist": "^4.0.0"
+			}
+		},
+		"magic-string": {
+			"version": "0.30.19",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+			"integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
 		"mdast-util-from-markdown": {
@@ -4580,9 +5907,15 @@
 			"dev": true
 		},
 		"ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+		},
+		"nanoid": {
+			"version": "3.3.11",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"dev": true
 		},
 		"natural-compare": {
 			"version": "1.4.0",
@@ -4680,6 +6013,24 @@
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
 			"dev": true
 		},
+		"pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true
+		},
+		"pathval": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+			"integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+			"dev": true
+		},
+		"picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true
+		},
 		"picomatch": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -4690,6 +6041,17 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/plain-tag/-/plain-tag-0.1.3.tgz",
 			"integrity": "sha512-yyVAOFKTAElc7KdLt2+UKGExNYwYb/Y/WE9i+1ezCQsJE8gbKSjewfpRqK2nQgZ4d4hhAAGgDCOcIZVilqE5UA=="
+		},
+		"postcss": {
+			"version": "8.5.6",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+			"dev": true,
+			"requires": {
+				"nanoid": "^3.3.11",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			}
 		},
 		"prelude-ls": {
 			"version": "1.2.1",
@@ -4770,6 +6132,38 @@
 				"glob": "^7.1.3"
 			}
 		},
+		"rollup": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.4.tgz",
+			"integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
+			"dev": true,
+			"requires": {
+				"@rollup/rollup-android-arm-eabi": "4.52.4",
+				"@rollup/rollup-android-arm64": "4.52.4",
+				"@rollup/rollup-darwin-arm64": "4.52.4",
+				"@rollup/rollup-darwin-x64": "4.52.4",
+				"@rollup/rollup-freebsd-arm64": "4.52.4",
+				"@rollup/rollup-freebsd-x64": "4.52.4",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.52.4",
+				"@rollup/rollup-linux-arm-musleabihf": "4.52.4",
+				"@rollup/rollup-linux-arm64-gnu": "4.52.4",
+				"@rollup/rollup-linux-arm64-musl": "4.52.4",
+				"@rollup/rollup-linux-loong64-gnu": "4.52.4",
+				"@rollup/rollup-linux-ppc64-gnu": "4.52.4",
+				"@rollup/rollup-linux-riscv64-gnu": "4.52.4",
+				"@rollup/rollup-linux-riscv64-musl": "4.52.4",
+				"@rollup/rollup-linux-s390x-gnu": "4.52.4",
+				"@rollup/rollup-linux-x64-gnu": "4.52.4",
+				"@rollup/rollup-linux-x64-musl": "4.52.4",
+				"@rollup/rollup-openharmony-arm64": "4.52.4",
+				"@rollup/rollup-win32-arm64-msvc": "4.52.4",
+				"@rollup/rollup-win32-ia32-msvc": "4.52.4",
+				"@rollup/rollup-win32-x64-gnu": "4.52.4",
+				"@rollup/rollup-win32-x64-msvc": "4.52.4",
+				"@types/estree": "1.0.8",
+				"fsevents": "~2.3.2"
+			}
+		},
 		"run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4808,16 +6202,40 @@
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
 			"dev": true
 		},
+		"siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true
+		},
 		"slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 			"dev": true
 		},
+		"source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true
+		},
+		"stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true
+		},
 		"static-params": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/static-params/-/static-params-0.4.0.tgz",
 			"integrity": "sha512-PV5nE992wwLEaXOUtXKrJeyVPBiizGpC8xyqqRrACxc8duz3Ym/pyraEkd/hYOmQFuZPTF9CRaL+Ac+84yxzyg=="
+		},
+		"std-env": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+			"integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+			"dev": true
 		},
 		"strip-ansi": {
 			"version": "6.0.1",
@@ -4834,12 +6252,14 @@
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 			"dev": true
 		},
-		"style-mod": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.0.tgz",
-			"integrity": "sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA==",
+		"strip-literal": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+			"integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
 			"dev": true,
-			"peer": true
+			"requires": {
+				"js-tokens": "^9.0.1"
+			}
 		},
 		"supports-color": {
 			"version": "7.2.0",
@@ -4854,6 +6274,54 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+			"dev": true
+		},
+		"tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true
+		},
+		"tinyexec": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+			"integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+			"dev": true
+		},
+		"tinyglobby": {
+			"version": "0.2.15",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"dev": true,
+			"requires": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3"
+			},
+			"dependencies": {
+				"picomatch": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+					"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+					"dev": true
+				}
+			}
+		},
+		"tinypool": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+			"integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+			"dev": true
+		},
+		"tinyrainbow": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+			"integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+			"dev": true
+		},
+		"tinyspy": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+			"integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
 			"dev": true
 		},
 		"to-regex-range": {
@@ -4874,8 +6342,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
 			"integrity": "sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"tslib": {
 			"version": "2.4.0",
@@ -4980,12 +6447,80 @@
 				"unist-util-stringify-position": "^4.0.0"
 			}
 		},
-		"w3c-keyname": {
-			"version": "2.2.8",
-			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
-			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+		"vite": {
+			"version": "7.1.9",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.1.9.tgz",
+			"integrity": "sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==",
 			"dev": true,
-			"peer": true
+			"requires": {
+				"esbuild": "^0.25.0",
+				"fdir": "^6.5.0",
+				"fsevents": "~2.3.3",
+				"picomatch": "^4.0.3",
+				"postcss": "^8.5.6",
+				"rollup": "^4.43.0",
+				"tinyglobby": "^0.2.15"
+			},
+			"dependencies": {
+				"picomatch": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+					"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+					"dev": true
+				}
+			}
+		},
+		"vite-node": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+			"integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+			"dev": true,
+			"requires": {
+				"cac": "^6.7.14",
+				"debug": "^4.4.1",
+				"es-module-lexer": "^1.7.0",
+				"pathe": "^2.0.3",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+			}
+		},
+		"vitest": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+			"integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+			"dev": true,
+			"requires": {
+				"@types/chai": "^5.2.2",
+				"@vitest/expect": "3.2.4",
+				"@vitest/mocker": "3.2.4",
+				"@vitest/pretty-format": "^3.2.4",
+				"@vitest/runner": "3.2.4",
+				"@vitest/snapshot": "3.2.4",
+				"@vitest/spy": "3.2.4",
+				"@vitest/utils": "3.2.4",
+				"chai": "^5.2.0",
+				"debug": "^4.4.1",
+				"expect-type": "^1.2.1",
+				"magic-string": "^0.30.17",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.2",
+				"std-env": "^3.9.0",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^0.3.2",
+				"tinyglobby": "^0.2.14",
+				"tinypool": "^1.1.1",
+				"tinyrainbow": "^2.0.0",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+				"vite-node": "3.2.4",
+				"why-is-node-running": "^2.3.0"
+			},
+			"dependencies": {
+				"picomatch": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+					"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+					"dev": true
+				}
+			}
 		},
 		"which": {
 			"version": "2.0.2",
@@ -4994,6 +6529,16 @@
 			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
+			}
+		},
+		"why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"requires": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
 			}
 		},
 		"wrappy": {

--- a/package.json
+++ b/package.json
@@ -27,10 +27,17 @@
 	},
 	"dependencies": {
 		"@joplin/turndown-plugin-gfm": "1.0.62",
+		"@notionhq/client": "^5.1.0",
 		"@zip.js/zip.js": "2.7.60",
+		"mdast-util-from-markdown": "^2.0.2",
+		"mdast-util-to-markdown": "^2.1.2",
 		"plain-tag": "0.1.3",
 		"protobufjs": "7.2.5",
+		"remark-parse": "^11.0.0",
+		"remark-stringify": "^11.0.0",
 		"static-params": "0.4.0",
-		"xml-flow": "1.0.4"
+		"unified": "^11.0.5",
+		"xml-flow": "1.0.4",
+		"yaml": "^2.8.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+		"test": "vitest",
+		"test:ui": "vitest --ui",
+		"test:coverage": "vitest --coverage",
 		"version": "node version-bump.mjs && git add manifest.json package.json versions.json",
 		"lint": "eslint src --ext .ts --fix"
 	},
@@ -23,7 +26,8 @@
 		"eslint": "8.46.0",
 		"obsidian": "latest",
 		"tslib": "2.4.0",
-		"typescript": "4.7.4"
+		"typescript": "4.7.4",
+		"vitest": "^3.2.4"
 	},
 	"dependencies": {
 		"@joplin/turndown-plugin-gfm": "1.0.62",

--- a/src/formats/notion-api.ts
+++ b/src/formats/notion-api.ts
@@ -1,0 +1,189 @@
+import { Notice, Setting } from 'obsidian';
+import { FormatImporter } from '../format-importer';
+import { ImportContext } from '../main';
+import { NotionApiClient } from './notion-api/api-client';
+import { isDatabaseObject, type NotionDatabaseWithProperties } from './notion-api/notion-types';
+import { convertDatabaseToBase, writeBaseFile, createDatabaseTag } from './notion-api/base-converter';
+import type { PageObjectResponse, RichTextItemResponse } from '@notionhq/client/build/src/api-endpoints';
+
+export class NotionApiImporter extends FormatImporter {
+	integrationToken: string = '';
+	client: NotionApiClient | null = null;
+
+	init() {
+		this.addOutputLocationSetting('Notion');
+
+		new Setting(this.modal.contentEl)
+			.setName('Notion Integration Token')
+			.setDesc('Enter your Notion integration token. You can create one at https://www.notion.so/my-integrations')
+			.addText(text => text
+				.setPlaceholder('secret_...')
+				.setValue(this.integrationToken)
+				.onChange(value => {
+					this.integrationToken = value;
+					if (value) {
+						this.client = new NotionApiClient({ auth: value });
+					}
+				}));
+	}
+
+	async import(ctx: ImportContext): Promise<void> {
+		if (!this.integrationToken) {
+			new Notice('Please enter a Notion integration token.');
+			return;
+		}
+
+		if (!this.client) {
+			this.client = new NotionApiClient({ auth: this.integrationToken });
+		}
+
+		const folder = await this.getOutputFolder();
+		if (!folder) {
+			new Notice('Please select an output location.');
+			return;
+		}
+
+		try {
+			ctx.status('Searching for databases in workspace...');
+
+			const searchResults = await this.client.searchAll();
+			const databases: NotionDatabaseWithProperties[] = [];
+
+			for (const result of searchResults) {
+				if (isDatabaseObject(result)) {
+					databases.push(result);
+				}
+			}
+
+			if (databases.length === 0) {
+				new Notice('No databases found in workspace. Make sure your integration has access to the databases.');
+				return;
+			}
+
+			ctx.status(`Found ${databases.length} databases. Starting conversion...`);
+
+			for (let i = 0; i < databases.length; i++) {
+				if (ctx.isCancelled()) return;
+
+				const database = databases[i];
+				ctx.reportProgress(i, databases.length);
+				ctx.status(`Converting database ${i + 1}/${databases.length}`);
+
+				try {
+					await this.convertDatabase(ctx, database, folder.path);
+				} catch (error) {
+					ctx.reportFailed(database.id, error);
+				}
+			}
+
+			ctx.status('Import complete!');
+			new Notice(`Successfully imported ${databases.length} databases.`);
+
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+			new Notice(`Import failed: ${errorMessage}`);
+			console.error('Notion API import error:', error);
+		}
+	}
+
+	async convertDatabase(
+		ctx: ImportContext,
+		database: NotionDatabaseWithProperties,
+		outputPath: string
+	): Promise<void> {
+		if (!this.client) {
+			throw new Error('Client not initialized');
+		}
+
+		const buildResult = convertDatabaseToBase(database);
+
+		if (buildResult.warnings.length > 0) {
+			console.warn(`Warnings for database ${buildResult.databaseTitle}:`, buildResult.warnings);
+		}
+
+		const sanitizedTitle = this.sanitizeFilePath(buildResult.databaseTitle);
+		await this.createFolders(outputPath);
+
+		await writeBaseFile(this.vault, buildResult.schema, outputPath, sanitizedTitle, buildResult.databaseTitle);
+
+		ctx.status(`Fetching pages from database: ${buildResult.databaseTitle}`);
+		const pages = await this.client.getAllDatabasePages(database.id);
+
+		for (const page of pages) {
+			if (ctx.isCancelled()) return;
+
+			try {
+				await this.convertPage(ctx, page, database.id, outputPath);
+			} catch (error) {
+				ctx.reportFailed(page.id, error);
+			}
+		}
+
+		ctx.reportNoteSuccess(`${buildResult.databaseTitle}.base`);
+	}
+
+	async convertPage(
+		ctx: ImportContext,
+		page: PageObjectResponse,
+		databaseId: string,
+		outputPath: string
+	): Promise<void> {
+		const pageTitle = this.extractPageTitle(page);
+		const sanitizedTitle = this.sanitizeFilePath(pageTitle || 'Untitled');
+
+		const frontmatter = createDatabaseTag(databaseId);
+
+		const frontmatterLines = Object.entries(frontmatter)
+			.map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
+			.join('\n');
+
+		const content = `---\n${frontmatterLines}\n---\n\n# ${pageTitle}\n`;
+
+		const filePath = `${outputPath}/${sanitizedTitle}.md`;
+
+		try {
+			await this.vault.create(filePath, content);
+			ctx.reportNoteSuccess(page.id);
+		} catch (error) {
+			if (error instanceof Error && error.message.includes('already exists')) {
+				const uniquePath = await this.getAvailablePathForAttachment(
+					`${sanitizedTitle}.md`,
+					[]
+				);
+				await this.vault.create(uniquePath, content);
+				ctx.reportNoteSuccess(page.id);
+			} else {
+				throw error;
+			}
+		}
+	}
+
+	extractPageTitle(page: PageObjectResponse): string {
+		const properties = page.properties;
+
+		for (const prop of Object.values(properties)) {
+			if (typeof prop === 'object' && prop !== null && 'type' in prop && prop.type === 'title') {
+				if ('title' in prop) {
+					const titleValue = prop.title;
+					if (Array.isArray(titleValue)) {
+						const titleParts = (titleValue as RichTextItemResponse[])
+							.filter(part => part.type === 'text' && 'text' in part && part.text?.content)
+							.map(part => {
+								if (part.type === 'text' && 'text' in part) {
+									return part.text.content;
+								}
+								return '';
+							});
+
+						const result = titleParts.join('');
+						if (result) {
+							return result;
+						}
+					}
+				}
+			}
+		}
+
+		return 'Untitled';
+	}
+}

--- a/src/formats/notion-api/api-client.ts
+++ b/src/formats/notion-api/api-client.ts
@@ -1,0 +1,199 @@
+import { Client } from '@notionhq/client';
+import type {
+	GetPageResponse,
+	GetDatabaseResponse,
+	ListBlockChildrenResponse,
+	SearchResponse,
+	PageObjectResponse,
+	BlockObjectResponse,
+	DatabaseObjectResponse,
+} from '@notionhq/client/build/src/api-endpoints';
+
+export interface NotionApiConfig {
+	auth: string;
+	notionVersion?: string;
+}
+
+export type NotionSearchResult = SearchResponse['results'][number] | DatabaseObjectResponse;
+
+interface QueryDatabaseParameters {
+	database_id: string;
+	start_cursor?: string;
+	page_size?: number;
+}
+
+interface QueryDatabaseResult {
+	results: PageObjectResponse[];
+	has_more: boolean;
+	next_cursor: string | null;
+}
+
+type ExtendedClient = Client & {
+	databases: Client['databases'] & {
+		query: (params: QueryDatabaseParameters) => Promise<QueryDatabaseResult>;
+	};
+}
+
+class RateLimiter {
+	private queue: Array<() => void> = [];
+	private processing = false;
+	private lastRequestTime = 0;
+	private readonly minInterval: number;
+
+	constructor(requestsPerSecond: number) {
+		this.minInterval = 1000 / requestsPerSecond;
+	}
+
+	async throttle<T>(fn: () => Promise<T>): Promise<T> {
+		return new Promise((resolve, reject) => {
+			this.queue.push(async () => {
+				try {
+					const result = await fn();
+					resolve(result);
+				} catch (error) {
+					reject(error);
+				}
+			});
+
+			if (!this.processing) {
+				this.processQueue();
+			}
+		});
+	}
+
+	private async processQueue(): Promise<void> {
+		if (this.queue.length === 0) {
+			this.processing = false;
+			return;
+		}
+
+		this.processing = true;
+		const now = Date.now();
+		const timeSinceLastRequest = now - this.lastRequestTime;
+
+		if (timeSinceLastRequest < this.minInterval) {
+			await this.sleep(this.minInterval - timeSinceLastRequest);
+		}
+
+		const task = this.queue.shift();
+		if (task) {
+			this.lastRequestTime = Date.now();
+			await task();
+		}
+
+		this.processQueue();
+	}
+
+	private sleep(ms: number): Promise<void> {
+		return new Promise(resolve => setTimeout(resolve, ms));
+	}
+}
+
+async function collectAll<T>(
+	fetchPage: (cursor?: string) => Promise<{ results: T[]; hasMore: boolean; nextCursor?: string }>
+): Promise<T[]> {
+	const allResults: T[] = [];
+	let cursor: string | undefined;
+	let hasMore = true;
+
+	while (hasMore) {
+		const response = await fetchPage(cursor);
+		allResults.push(...response.results);
+		hasMore = response.hasMore;
+		cursor = response.nextCursor;
+	}
+
+	return allResults;
+}
+
+export class NotionApiClient {
+	private client: ExtendedClient;
+	private rateLimiter: RateLimiter;
+
+	constructor(config: NotionApiConfig) {
+		this.client = new Client({
+			auth: config.auth,
+			notionVersion: config.notionVersion || '2022-06-28',
+		}) as ExtendedClient;
+		this.rateLimiter = new RateLimiter(3);
+	}
+
+	async getPage(pageId: string): Promise<GetPageResponse> {
+		return this.rateLimiter.throttle(() =>
+			this.client.pages.retrieve({ page_id: pageId })
+		);
+	}
+
+	async getDatabase(databaseId: string): Promise<GetDatabaseResponse> {
+		return this.rateLimiter.throttle(() =>
+			this.client.databases.retrieve({ database_id: databaseId })
+		);
+	}
+
+	async getAllDatabasePages(databaseId: string): Promise<PageObjectResponse[]> {
+		const results: PageObjectResponse[] = [];
+		let cursor: string | undefined;
+		let hasMore = true;
+
+		while (hasMore) {
+			const response = await this.rateLimiter.throttle(() =>
+				this.client.databases.query({
+					database_id: databaseId,
+					start_cursor: cursor,
+					page_size: 100,
+				})
+			);
+
+			results.push(...response.results);
+			hasMore = response.has_more;
+			cursor = response.next_cursor || undefined;
+		}
+
+		return results;
+	}
+
+	async getBlockChildren(blockId: string, startCursor?: string): Promise<ListBlockChildrenResponse> {
+		return this.rateLimiter.throttle(() =>
+			this.client.blocks.children.list({
+				block_id: blockId,
+				start_cursor: startCursor,
+				page_size: 100,
+			})
+		);
+	}
+
+	async getAllBlockChildren(blockId: string): Promise<ListBlockChildrenResponse['results']> {
+		return collectAll(async (cursor) => {
+			const response = await this.getBlockChildren(blockId, cursor);
+			return {
+				results: response.results,
+				hasMore: response.has_more,
+				nextCursor: response.next_cursor || undefined,
+			};
+		});
+	}
+
+	async search(query?: string, options?: {
+		startCursor?: string;
+		pageSize?: number;
+	}): Promise<SearchResponse> {
+		return this.rateLimiter.throttle(() =>
+			this.client.search({
+				query,
+				start_cursor: options?.startCursor,
+				page_size: options?.pageSize || 100,
+			})
+		);
+	}
+
+	async searchAll(query?: string): Promise<NotionSearchResult[]> {
+		return collectAll(async (cursor) => {
+			const response = await this.search(query, { startCursor: cursor });
+			return {
+				results: response.results,
+				hasMore: response.has_more,
+				nextCursor: response.next_cursor || undefined,
+			};
+		});
+	}
+}

--- a/src/formats/notion-api/base-converter.ts
+++ b/src/formats/notion-api/base-converter.ts
@@ -1,0 +1,190 @@
+import { stringify } from 'yaml';
+import type { Vault } from 'obsidian';
+import type { RichTextItemResponse } from '@notionhq/client/build/src/api-endpoints';
+import type {
+	NotionDatabaseWithProperties,
+	NotionDatabasePropertyType,
+	BaseProperty,
+	BaseFormula,
+	BaseSchema,
+	BasePropertyType,
+} from './notion-types';
+import {
+	isSelectProperty,
+	isMultiSelectProperty,
+	isStatusProperty,
+	isFormulaProperty,
+	PROPERTY_TYPE_MAPPINGS,
+} from './notion-types';
+import { convertNotionFormula } from './formula-converter';
+
+interface ColumnMappingResult {
+	properties: Record<string, BaseProperty>;
+	formulas: Record<string, BaseFormula>;
+	warnings: string[];
+}
+
+export interface BaseConversionResult {
+	schema: BaseSchema;
+	warnings: string[];
+	databaseId: string;
+	databaseTitle: string;
+}
+
+function mapDatabaseColumns(database: NotionDatabaseWithProperties): ColumnMappingResult {
+	const properties: Record<string, BaseProperty> = {};
+	const formulas: Record<string, BaseFormula> = {};
+	const warnings: string[] = [];
+
+	const dbProperties = database.properties;
+
+	for (const [key, prop] of Object.entries(dbProperties)) {
+		const propertyId = prop.id;
+		const propertyName = prop.name || key;
+
+		if (isFormulaProperty(prop)) {
+			const formulaExpression = prop.formula.expression;
+
+			if (formulaExpression && typeof formulaExpression === 'string') {
+				const convertedFormula = convertNotionFormula(formulaExpression);
+
+				if (convertedFormula.success && convertedFormula.formula) {
+					formulas[propertyId] = {
+						name: propertyId,
+						displayName: propertyName,
+						expression: convertedFormula.formula,
+					};
+
+					if (convertedFormula.warnings && convertedFormula.warnings.length > 0) {
+						warnings.push(...convertedFormula.warnings.map(w => `${propertyName}: ${w}`));
+					}
+				} else {
+					warnings.push(`Failed to convert formula for ${propertyName}: ${convertedFormula.error}`);
+					formulas[propertyId] = {
+						name: propertyId,
+						displayName: propertyName,
+						expression: `"${formulaExpression}"`,
+					};
+				}
+			}
+		} else {
+			const baseType = PROPERTY_TYPE_MAPPINGS[prop.type];
+
+			if (baseType) {
+				const baseProperty: BaseProperty = {
+					type: baseType,
+					name: propertyId,
+					displayName: propertyName,
+				};
+
+				if (isSelectProperty(prop)) {
+					baseProperty.options = prop.select.options.map(opt => opt.name);
+				} else if (isMultiSelectProperty(prop)) {
+					baseProperty.options = prop.multi_select.options.map(opt => opt.name);
+				} else if (isStatusProperty(prop)) {
+					baseProperty.options = prop.status.options.map(opt => opt.name);
+				}
+
+				properties[propertyId] = baseProperty;
+			} else {
+				warnings.push(`Unsupported property type: ${prop.type} for ${propertyName}`);
+			}
+		}
+	}
+
+	return { properties, formulas, warnings };
+}
+
+function extractDatabaseTitle(database: NotionDatabaseWithProperties): string {
+	const titleProperty = database.title;
+	if (Array.isArray(titleProperty)) {
+		const titleParts = (titleProperty as RichTextItemResponse[])
+			.filter(part => part.type === 'text' && 'text' in part && part.text?.content)
+			.map(part => {
+				if (part.type === 'text' && 'text' in part) {
+					return part.text.content;
+				}
+				return '';
+			})
+			.filter((content: string) => content.length > 0);
+
+		return titleParts.join('') || 'Untitled Database';
+	}
+
+	return 'Untitled Database';
+}
+
+export function convertDatabaseToBase(database: NotionDatabaseWithProperties): BaseConversionResult {
+	const columnMapping = mapDatabaseColumns(database);
+	const databaseId = database.id;
+	const databaseTitle = extractDatabaseTitle(database);
+
+	const schema: BaseSchema = {
+		version: '1.0',
+		filters: {
+			property: 'notion-database',
+			operator: '=',
+			value: databaseId,
+		},
+	};
+
+	if (Object.keys(columnMapping.properties).length > 0) {
+		schema.properties = columnMapping.properties;
+	}
+
+	if (Object.keys(columnMapping.formulas).length > 0) {
+		schema.formulas = columnMapping.formulas;
+	}
+
+	schema.views = [{
+		name: 'Table',
+		type: 'table',
+	}];
+
+	return {
+		schema,
+		warnings: columnMapping.warnings,
+		databaseId,
+		databaseTitle,
+	};
+}
+
+export function serializeBaseSchema(schema: BaseSchema): string {
+	return stringify(schema, {
+		lineWidth: 0,
+		defaultStringType: 'QUOTE_DOUBLE',
+		defaultKeyType: 'PLAIN',
+	});
+}
+
+export function createBaseFileContent(schema: BaseSchema, title?: string): string {
+	const yaml = serializeBaseSchema(schema);
+	const codeBlock = '```base\n' + yaml + '```';
+
+	if (title) {
+		return `# ${title}\n\n${codeBlock}\n`;
+	}
+
+	return `${codeBlock}\n`;
+}
+
+export async function writeBaseFile(
+	vault: Vault,
+	schema: BaseSchema,
+	folderPath: string,
+	filename: string,
+	title?: string
+): Promise<string> {
+	const content = createBaseFileContent(schema, title);
+	const fullPath = `${folderPath}/${filename}.base`;
+
+	await vault.create(fullPath, content);
+
+	return fullPath;
+}
+
+export function createDatabaseTag(databaseId: string): Record<string, string> {
+	return {
+		'notion-database': databaseId,
+	};
+}

--- a/src/formats/notion-api/block-converter.ts
+++ b/src/formats/notion-api/block-converter.ts
@@ -1,0 +1,561 @@
+import type {
+	BlockObjectResponse,
+	RichTextItemResponse,
+	ListBlockChildrenResponse,
+} from '@notionhq/client/build/src/api-endpoints';
+import type { NotionApiClient } from './api-client';
+import type { Vault } from 'obsidian';
+
+interface ConversionContext {
+	vault: Vault;
+	client: NotionApiClient;
+	attachmentFolder: string;
+	indentLevel: number;
+	listCounters: Map<number, number>;
+}
+
+export class BlockConverter {
+	private client: NotionApiClient;
+	private vault: Vault;
+	private attachmentFolder: string;
+
+	constructor(client: NotionApiClient, vault: Vault, attachmentFolder: string) {
+		this.client = client;
+		this.vault = vault;
+		this.attachmentFolder = attachmentFolder;
+	}
+
+	async convertBlocksToMarkdown(blockId: string): Promise<string> {
+		const context: ConversionContext = {
+			vault: this.vault,
+			client: this.client,
+			attachmentFolder: this.attachmentFolder,
+			indentLevel: 0,
+			listCounters: new Map(),
+		};
+
+		const blocks = await this.client.getAllBlockChildren(blockId);
+		return this.convertBlockList(blocks, context);
+	}
+
+	private async convertBlockList(
+		blocks: ListBlockChildrenResponse['results'],
+		context: ConversionContext
+	): Promise<string> {
+		const lines: string[] = [];
+		let previousBlockType: string | null = null;
+
+		for (const block of blocks) {
+			if (!('type' in block)) continue;
+
+			const currentBlockType = block.type;
+			const needsSpacing = this.needsSpacingBetweenBlocks(previousBlockType, currentBlockType);
+
+			if (needsSpacing && lines.length > 0) {
+				lines.push('');
+			}
+
+			const markdown = await this.convertBlock(block, context);
+			if (markdown) {
+				lines.push(markdown);
+			}
+
+			previousBlockType = currentBlockType;
+		}
+
+		return lines.join('\n');
+	}
+
+	private needsSpacingBetweenBlocks(prev: string | null, current: string): boolean {
+		if (!prev) return false;
+
+		const blockTypes = {
+			list: ['bulleted_list_item', 'numbered_list_item', 'to_do'],
+			code: ['code'],
+			quote: ['quote'],
+			callout: ['callout'],
+			heading: ['heading_1', 'heading_2', 'heading_3'],
+			table: ['table'],
+		};
+
+		const prevIsList = blockTypes.list.includes(prev);
+		const currentIsList = blockTypes.list.includes(current);
+
+		if (prevIsList && !currentIsList) return true;
+		if (!prevIsList && currentIsList) return true;
+
+		const prevIsSpecial = [...blockTypes.code, ...blockTypes.quote, ...blockTypes.callout, ...blockTypes.heading].includes(prev);
+		const currentIsSpecial = [...blockTypes.code, ...blockTypes.quote, ...blockTypes.callout, ...blockTypes.heading].includes(current);
+
+		if (prevIsSpecial || currentIsSpecial) return true;
+
+		return false;
+	}
+
+	private async convertBlock(
+		block: BlockObjectResponse,
+		context: ConversionContext
+	): Promise<string> {
+		const indent = '  '.repeat(context.indentLevel);
+
+		switch (block.type) {
+			case 'paragraph':
+				return this.convertParagraph(block, context, indent);
+			case 'heading_1':
+				return this.convertHeading(block, 1);
+			case 'heading_2':
+				return this.convertHeading(block, 2);
+			case 'heading_3':
+				return this.convertHeading(block, 3);
+			case 'bulleted_list_item':
+				return this.convertBulletedListItem(block, context, indent);
+			case 'numbered_list_item':
+				return this.convertNumberedListItem(block, context, indent);
+			case 'to_do':
+				return this.convertToDo(block, context, indent);
+			case 'toggle':
+				return this.convertToggle(block, context, indent);
+			case 'code':
+				return this.convertCode(block);
+			case 'quote':
+				return this.convertQuote(block, context);
+			case 'callout':
+				return this.convertCallout(block, context);
+			case 'divider':
+				return '---';
+			case 'image':
+				return this.convertImage(block, context);
+			case 'file':
+				return this.convertFile(block, context);
+			case 'bookmark':
+				return this.convertBookmark(block);
+			case 'link_preview':
+				return this.convertLinkPreview(block);
+			case 'table':
+				return this.convertTable(block, context);
+			case 'table_row':
+				return '';
+			case 'child_page':
+				return this.convertChildPage(block);
+			case 'child_database':
+				return this.convertChildDatabase(block);
+			case 'equation':
+				return this.convertEquation(block);
+			default:
+				return `${indent}<!-- Unsupported block type: ${block.type} -->`;
+		}
+	}
+
+	private convertRichText(richText: RichTextItemResponse[]): string {
+		return richText.map(item => this.convertRichTextItem(item)).join('');
+	}
+
+	private convertRichTextItem(item: RichTextItemResponse): string {
+		let text = item.plain_text;
+
+		if (!text) return '';
+
+		if (item.type === 'equation' && 'equation' in item) {
+			return `$${item.equation.expression}$`;
+		}
+
+		if (item.type === 'mention') {
+			if ('mention' in item) {
+				const mention = item.mention;
+				if (mention.type === 'page' && 'page' in mention) {
+					return `[[${item.plain_text}]]`;
+				}
+				if (mention.type === 'date' && 'date' in mention) {
+					return item.plain_text;
+				}
+				if (mention.type === 'user' && 'user' in mention) {
+					return `@${item.plain_text}`;
+				}
+			}
+			return item.plain_text;
+		}
+
+		const annotations = item.annotations;
+
+		if (annotations.code) {
+			text = `\`${text}\``;
+		}
+
+		if (annotations.bold) {
+			text = `**${text}**`;
+		}
+
+		if (annotations.italic) {
+			text = `*${text}*`;
+		}
+
+		if (annotations.strikethrough) {
+			text = `~~${text}~~`;
+		}
+
+		if (item.href || (item.type === 'text' && 'text' in item && item.text.link)) {
+			const url = item.href || (item.type === 'text' && 'text' in item && item.text.link ? item.text.link.url : '');
+			if (url) {
+				text = `[${text}](${url})`;
+			}
+		}
+
+		return text;
+	}
+
+	private async convertParagraph(
+		block: BlockObjectResponse,
+		context: ConversionContext,
+		indent: string
+	): Promise<string> {
+		if (block.type !== 'paragraph') return '';
+
+		const text = this.convertRichText(block.paragraph.rich_text);
+
+		if (!text.trim() && !block.has_children) {
+			return '';
+		}
+
+		let result = text ? `${indent}${text}` : '';
+
+		if (block.has_children) {
+			const childContext = { ...context, indentLevel: context.indentLevel + 1 };
+			const children = await this.client.getAllBlockChildren(block.id);
+			const childMarkdown = await this.convertBlockList(children, childContext);
+			if (childMarkdown) {
+				result = result ? `${result}\n${childMarkdown}` : childMarkdown;
+			}
+		}
+
+		return result;
+	}
+
+	private convertHeading(block: BlockObjectResponse, level: 1 | 2 | 3): string {
+		let text = '';
+
+		if (level === 1 && block.type === 'heading_1') {
+			text = this.convertRichText(block.heading_1.rich_text);
+		} else if (level === 2 && block.type === 'heading_2') {
+			text = this.convertRichText(block.heading_2.rich_text);
+		} else if (level === 3 && block.type === 'heading_3') {
+			text = this.convertRichText(block.heading_3.rich_text);
+		} else {
+			return '';
+		}
+
+		const prefix = '#'.repeat(level);
+		return `${prefix} ${text}`;
+	}
+
+	private async convertBulletedListItem(
+		block: BlockObjectResponse,
+		context: ConversionContext,
+		indent: string
+	): Promise<string> {
+		if (block.type !== 'bulleted_list_item') return '';
+
+		const text = this.convertRichText(block.bulleted_list_item.rich_text);
+		let result = `${indent}- ${text}`;
+
+		if (block.has_children) {
+			const childContext = { ...context, indentLevel: context.indentLevel + 1 };
+			const children = await this.client.getAllBlockChildren(block.id);
+			const childMarkdown = await this.convertBlockList(children, childContext);
+			if (childMarkdown) {
+				result += `\n${childMarkdown}`;
+			}
+		}
+
+		return result;
+	}
+
+	private async convertNumberedListItem(
+		block: BlockObjectResponse,
+		context: ConversionContext,
+		indent: string
+	): Promise<string> {
+		if (block.type !== 'numbered_list_item') return '';
+
+		const level = context.indentLevel;
+		const counter = context.listCounters.get(level) || 0;
+		context.listCounters.set(level, counter + 1);
+
+		const text = this.convertRichText(block.numbered_list_item.rich_text);
+		let result = `${indent}${counter + 1}. ${text}`;
+
+		if (block.has_children) {
+			const childContext = { ...context, indentLevel: context.indentLevel + 1 };
+			const children = await this.client.getAllBlockChildren(block.id);
+			const childMarkdown = await this.convertBlockList(children, childContext);
+			if (childMarkdown) {
+				result += `\n${childMarkdown}`;
+			}
+		}
+
+		return result;
+	}
+
+	private async convertToDo(
+		block: BlockObjectResponse,
+		context: ConversionContext,
+		indent: string
+	): Promise<string> {
+		if (block.type !== 'to_do') return '';
+
+		const checked = block.to_do.checked;
+		const checkbox = checked ? '[x]' : '[ ]';
+		const text = this.convertRichText(block.to_do.rich_text);
+		let result = `${indent}- ${checkbox} ${text}`;
+
+		if (block.has_children) {
+			const childContext = { ...context, indentLevel: context.indentLevel + 1 };
+			const children = await this.client.getAllBlockChildren(block.id);
+			const childMarkdown = await this.convertBlockList(children, childContext);
+			if (childMarkdown) {
+				result += `\n${childMarkdown}`;
+			}
+		}
+
+		return result;
+	}
+
+	private async convertToggle(
+		block: BlockObjectResponse,
+		context: ConversionContext,
+		indent: string
+	): Promise<string> {
+		if (block.type !== 'toggle') return '';
+
+		const text = this.convertRichText(block.toggle.rich_text);
+		let result = `${indent}- ${text}`;
+
+		if (block.has_children) {
+			const childContext = { ...context, indentLevel: context.indentLevel + 1 };
+			const children = await this.client.getAllBlockChildren(block.id);
+			const childMarkdown = await this.convertBlockList(children, childContext);
+			if (childMarkdown) {
+				result += `\n${childMarkdown}`;
+			}
+		}
+
+		return result;
+	}
+
+	private convertCode(block: BlockObjectResponse): string {
+		if (block.type !== 'code') return '';
+
+		const language = block.code.language || '';
+		const code = this.convertRichText(block.code.rich_text);
+		return `\`\`\`${language}\n${code}\n\`\`\``;
+	}
+
+	private async convertQuote(block: BlockObjectResponse, context: ConversionContext): Promise<string> {
+		if (block.type !== 'quote') return '';
+
+		const text = this.convertRichText(block.quote.rich_text);
+		let result = `> ${text}`;
+
+		if (block.has_children) {
+			const children = await this.client.getAllBlockChildren(block.id);
+			const childMarkdown = await this.convertBlockList(children, context);
+			if (childMarkdown) {
+				const quotedChildren = childMarkdown.split('\n').map(line => `> ${line}`).join('\n');
+				result += `\n${quotedChildren}`;
+			}
+		}
+
+		return result;
+	}
+
+	private async convertCallout(block: BlockObjectResponse, context: ConversionContext): Promise<string> {
+		if (block.type !== 'callout') return '';
+
+		const icon = 'icon' in block.callout && block.callout.icon ?
+			(block.callout.icon.type === 'emoji' ? block.callout.icon.emoji : '') : '';
+		const text = this.convertRichText(block.callout.rich_text);
+
+		let result = `> [!note]${icon ? ` ${icon}` : ''}\n> ${text}`;
+
+		if (block.has_children) {
+			const children = await this.client.getAllBlockChildren(block.id);
+			const childMarkdown = await this.convertBlockList(children, context);
+			if (childMarkdown) {
+				const quotedChildren = childMarkdown.split('\n').map(line => `> ${line}`).join('\n');
+				result += `\n${quotedChildren}`;
+			}
+		}
+
+		return result;
+	}
+
+	private async convertImage(block: BlockObjectResponse, context: ConversionContext): Promise<string> {
+		if (block.type !== 'image') return '';
+
+		const image = block.image;
+		let url = '';
+		let caption = '';
+
+		if (image.type === 'external') {
+			url = image.external.url;
+		} else if (image.type === 'file') {
+			url = image.file.url;
+		}
+
+		if ('caption' in image && image.caption) {
+			caption = this.convertRichText(image.caption);
+		}
+
+		if (!url) return '';
+
+		const filename = this.extractFilenameFromUrl(url);
+		const localPath = await this.downloadAttachment(url, filename, context.attachmentFolder);
+
+		if (localPath) {
+			return caption ? `![${caption}](${localPath})` : `![](${localPath})`;
+		}
+
+		return caption ? `![${caption}](${url})` : `![](${url})`;
+	}
+
+	private async convertFile(block: BlockObjectResponse, context: ConversionContext): Promise<string> {
+		if (block.type !== 'file') return '';
+
+		const file = block.file;
+		let url = '';
+		let caption = '';
+
+		if (file.type === 'external') {
+			url = file.external.url;
+		} else if (file.type === 'file') {
+			url = file.file.url;
+		}
+
+		if ('caption' in file && file.caption) {
+			caption = this.convertRichText(file.caption);
+		}
+
+		if (!url) return '';
+
+		const filename = caption || this.extractFilenameFromUrl(url);
+		const localPath = await this.downloadAttachment(url, filename, context.attachmentFolder);
+
+		if (localPath) {
+			return `[${filename}](${localPath})`;
+		}
+
+		return `[${filename}](${url})`;
+	}
+
+	private convertBookmark(block: BlockObjectResponse): string {
+		if (block.type !== 'bookmark') return '';
+
+		const url = block.bookmark.url;
+		const caption = block.bookmark.caption && block.bookmark.caption.length > 0
+			? this.convertRichText(block.bookmark.caption)
+			: url;
+
+		return `[${caption}](${url})`;
+	}
+
+	private convertLinkPreview(block: BlockObjectResponse): string {
+		if (block.type !== 'link_preview') return '';
+
+		return `[Link](${block.link_preview.url})`;
+	}
+
+	private async convertTable(block: BlockObjectResponse, context: ConversionContext): Promise<string> {
+		if (block.type !== 'table') return '';
+
+		const hasColumnHeader = block.table.has_column_header;
+		const hasRowHeader = block.table.has_row_header;
+
+		const children = await this.client.getAllBlockChildren(block.id);
+		const rows: string[][] = [];
+
+		for (const child of children) {
+			if ('type' in child && child.type === 'table_row') {
+				const cells = child.table_row.cells.map(cell => this.convertRichText(cell));
+				rows.push(cells);
+			}
+		}
+
+		if (rows.length === 0) return '';
+
+		const columnCount = Math.max(...rows.map(row => row.length));
+		const lines: string[] = [];
+
+		for (let i = 0; i < rows.length; i++) {
+			const row = rows[i];
+			while (row.length < columnCount) {
+				row.push('');
+			}
+
+			const rowMarkdown = `| ${row.join(' | ')} |`;
+			lines.push(rowMarkdown);
+
+			if (i === 0 && hasColumnHeader) {
+				const separator = `| ${Array(columnCount).fill('---').join(' | ')} |`;
+				lines.push(separator);
+			}
+		}
+
+		return lines.join('\n');
+	}
+
+	private convertChildPage(block: BlockObjectResponse): string {
+		if (block.type !== 'child_page') return '';
+
+		const title = block.child_page.title;
+		return `[[${title}]]`;
+	}
+
+	private convertChildDatabase(block: BlockObjectResponse): string {
+		if (block.type !== 'child_database') return '';
+
+		const title = block.child_database.title;
+		return `[[${title}]]`;
+	}
+
+	private convertEquation(block: BlockObjectResponse): string {
+		if (block.type !== 'equation') return '';
+
+		const expression = block.equation.expression;
+		return `$$\n${expression}\n$$`;
+	}
+
+	private extractFilenameFromUrl(url: string): string {
+		try {
+			const urlObj = new URL(url);
+			const pathname = urlObj.pathname;
+			const segments = pathname.split('/');
+			const filename = segments[segments.length - 1];
+			return decodeURIComponent(filename) || 'attachment';
+		} catch {
+			return 'attachment';
+		}
+	}
+
+	private async downloadAttachment(
+		url: string,
+		filename: string,
+		attachmentFolder: string
+	): Promise<string | null> {
+		try {
+			const response = await fetch(url);
+			if (!response.ok) return null;
+
+			const arrayBuffer = await response.arrayBuffer();
+			const buffer = Buffer.from(arrayBuffer);
+
+			const sanitizedFilename = filename.replace(/[^a-zA-Z0-9._-]/g, '_');
+			const fullPath = `${attachmentFolder}/${sanitizedFilename}`;
+
+			await this.vault.createBinary(fullPath, buffer);
+
+			return sanitizedFilename;
+		} catch (error) {
+			console.error(`Failed to download attachment: ${url}`, error);
+			return null;
+		}
+	}
+}

--- a/src/formats/notion-api/formula-converter.ts
+++ b/src/formats/notion-api/formula-converter.ts
@@ -49,6 +49,7 @@ export interface FormulaConversionResult {
 }
 
 const FUNCTION_MAPPINGS: Record<string, { obsidianName: string; requiresTransformation: boolean }> = {
+	prop: { obsidianName: 'PROPERTY_REF', requiresTransformation: true },
 	length: { obsidianName: 'length', requiresTransformation: false },
 	substring: { obsidianName: 'substring', requiresTransformation: false },
 	contains: { obsidianName: 'contains', requiresTransformation: false },
@@ -462,7 +463,7 @@ function translateLiteral(node: LiteralNode): string {
 }
 
 function translateProperty(node: PropertyRefNode): string {
-	return `prop("${node.name}")`;
+	return node.name;
 }
 
 function translateFunction(node: FunctionCallNode, warnings: string[]): string {
@@ -484,6 +485,11 @@ function translateFunction(node: FunctionCallNode, warnings: string[]): string {
 
 function transformFunction(notionName: string, obsidianName: string, args: string[]): string {
 	switch (notionName) {
+		case 'prop':
+			if (args.length === 0) {
+				return 'MISSING_PROPERTY_NAME';
+			}
+			return args[0].replace(/^"(.*)"$/, '$1').replace(/^'(.*)'$/, '$1');
 		case 'add':
 			return args.length === 2 ? `(${args[0]} + ${args[1]})` : `sum(${args.join(', ')})`;
 		case 'subtract':

--- a/src/formats/notion-api/formula-converter.ts
+++ b/src/formats/notion-api/formula-converter.ts
@@ -1,0 +1,562 @@
+type FormulaASTNode =
+	| LiteralNode
+	| PropertyRefNode
+	| FunctionCallNode
+	| BinaryOpNode
+	| UnaryOpNode;
+
+interface LiteralNode {
+	type: 'literal';
+	valueType: 'string' | 'number' | 'boolean';
+	value: string | number | boolean;
+}
+
+interface PropertyRefNode {
+	type: 'property';
+	name: string;
+}
+
+interface FunctionCallNode {
+	type: 'function';
+	name: string;
+	args: FormulaASTNode[];
+}
+
+interface BinaryOpNode {
+	type: 'binary';
+	operator: '+' | '-' | '*' | '/' | '==' | '!=' | '>' | '<' | '>=' | '<=' | 'and' | 'or';
+	left: FormulaASTNode;
+	right: FormulaASTNode;
+}
+
+interface UnaryOpNode {
+	type: 'unary';
+	operator: 'not' | '-';
+	operand: FormulaASTNode;
+}
+
+interface FormulaParseResult {
+	success: boolean;
+	ast?: FormulaASTNode;
+	error?: string;
+}
+
+export interface FormulaConversionResult {
+	success: boolean;
+	formula?: string;
+	error?: string;
+	warnings?: string[];
+}
+
+const FUNCTION_MAPPINGS: Record<string, { obsidianName: string; requiresTransformation: boolean }> = {
+	length: { obsidianName: 'length', requiresTransformation: false },
+	substring: { obsidianName: 'substring', requiresTransformation: false },
+	contains: { obsidianName: 'contains', requiresTransformation: false },
+	lower: { obsidianName: 'lower', requiresTransformation: false },
+	upper: { obsidianName: 'upper', requiresTransformation: false },
+	replace: { obsidianName: 'replace', requiresTransformation: false },
+	replaceAll: { obsidianName: 'regexreplace', requiresTransformation: true },
+	concat: { obsidianName: 'concat', requiresTransformation: false },
+	join: { obsidianName: 'join', requiresTransformation: false },
+	add: { obsidianName: '+', requiresTransformation: true },
+	subtract: { obsidianName: '-', requiresTransformation: true },
+	multiply: { obsidianName: '*', requiresTransformation: true },
+	divide: { obsidianName: '/', requiresTransformation: true },
+	pow: { obsidianName: 'pow', requiresTransformation: false },
+	sqrt: { obsidianName: 'sqrt', requiresTransformation: false },
+	min: { obsidianName: 'min', requiresTransformation: false },
+	max: { obsidianName: 'max', requiresTransformation: false },
+	sum: { obsidianName: 'sum', requiresTransformation: false },
+	round: { obsidianName: 'round', requiresTransformation: false },
+	ceil: { obsidianName: 'ceil', requiresTransformation: false },
+	floor: { obsidianName: 'floor', requiresTransformation: false },
+	abs: { obsidianName: 'abs', requiresTransformation: false },
+	if: { obsidianName: 'if', requiresTransformation: false },
+	and: { obsidianName: 'and', requiresTransformation: false },
+	or: { obsidianName: 'or', requiresTransformation: false },
+	not: { obsidianName: 'not', requiresTransformation: false },
+	equal: { obsidianName: '==', requiresTransformation: true },
+	unequal: { obsidianName: '!=', requiresTransformation: true },
+	larger: { obsidianName: '>', requiresTransformation: true },
+	largerEq: { obsidianName: '>=', requiresTransformation: true },
+	smaller: { obsidianName: '<', requiresTransformation: true },
+	smallerEq: { obsidianName: '<=', requiresTransformation: true },
+	now: { obsidianName: 'now', requiresTransformation: false },
+	today: { obsidianName: 'dateonly', requiresTransformation: true },
+	dateAdd: { obsidianName: 'dateadd', requiresTransformation: false },
+	dateSubtract: { obsidianName: 'datesubtract', requiresTransformation: false },
+	dateBetween: { obsidianName: 'datediff', requiresTransformation: false },
+	formatDate: { obsidianName: 'dateformat', requiresTransformation: false },
+	year: { obsidianName: 'year', requiresTransformation: false },
+	month: { obsidianName: 'month', requiresTransformation: false },
+	date: { obsidianName: 'day', requiresTransformation: false },
+	day: { obsidianName: 'weekday', requiresTransformation: false },
+	hour: { obsidianName: 'hour', requiresTransformation: false },
+	minute: { obsidianName: 'minute', requiresTransformation: false },
+	at: { obsidianName: 'at', requiresTransformation: false },
+	first: { obsidianName: 'first', requiresTransformation: false },
+	last: { obsidianName: 'last', requiresTransformation: false },
+	sort: { obsidianName: 'sort', requiresTransformation: false },
+	reverse: { obsidianName: 'reverse', requiresTransformation: false },
+	map: { obsidianName: 'map', requiresTransformation: false },
+	filter: { obsidianName: 'filter', requiresTransformation: false },
+	split: { obsidianName: 'split', requiresTransformation: false },
+	every: { obsidianName: 'all', requiresTransformation: false },
+	some: { obsidianName: 'any', requiresTransformation: false },
+};
+
+class FormulaParser {
+	private input: string;
+	private position: number;
+	private current: string;
+
+	constructor(input: string) {
+		this.input = input.trim();
+		this.position = 0;
+		this.current = this.input[0] || '';
+	}
+
+	parse(): FormulaParseResult {
+		try {
+			const ast = this.parseExpression();
+			return { success: true, ast };
+		} catch (error) {
+			return {
+				success: false,
+				error: error instanceof Error ? error.message : 'Unknown parse error',
+			};
+		}
+	}
+
+	private advance(): void {
+		this.position++;
+		this.current = this.input[this.position] || '';
+	}
+
+	private skipWhitespace(): void {
+		while (this.current && /\s/.test(this.current)) {
+			this.advance();
+		}
+	}
+
+	private peek(offset: number = 1): string {
+		return this.input[this.position + offset] || '';
+	}
+
+	private parseExpression(): FormulaASTNode {
+		return this.parseLogicalOr();
+	}
+
+	private parseLogicalOr(): FormulaASTNode {
+		let left = this.parseLogicalAnd();
+
+		while (this.matchKeyword('or')) {
+			const operator = 'or';
+			this.skipWhitespace();
+			const right = this.parseLogicalAnd();
+			left = { type: 'binary', operator, left, right };
+		}
+
+		return left;
+	}
+
+	private parseLogicalAnd(): FormulaASTNode {
+		let left = this.parseComparison();
+
+		while (this.matchKeyword('and')) {
+			const operator = 'and';
+			this.skipWhitespace();
+			const right = this.parseComparison();
+			left = { type: 'binary', operator, left, right };
+		}
+
+		return left;
+	}
+
+	private parseComparison(): FormulaASTNode {
+		let left = this.parseAdditive();
+
+		this.skipWhitespace();
+		if (this.current === '=' && this.peek() === '=') {
+			this.advance();
+			this.advance();
+			this.skipWhitespace();
+			const right = this.parseAdditive();
+			return { type: 'binary', operator: '==', left, right };
+		} else if (this.current === '!' && this.peek() === '=') {
+			this.advance();
+			this.advance();
+			this.skipWhitespace();
+			const right = this.parseAdditive();
+			return { type: 'binary', operator: '!=', left, right };
+		} else if (this.current === '>' && this.peek() === '=') {
+			this.advance();
+			this.advance();
+			this.skipWhitespace();
+			const right = this.parseAdditive();
+			return { type: 'binary', operator: '>=', left, right };
+		} else if (this.current === '<' && this.peek() === '=') {
+			this.advance();
+			this.advance();
+			this.skipWhitespace();
+			const right = this.parseAdditive();
+			return { type: 'binary', operator: '<=', left, right };
+		} else if (this.current === '>') {
+			this.advance();
+			this.skipWhitespace();
+			const right = this.parseAdditive();
+			return { type: 'binary', operator: '>', left, right };
+		} else if (this.current === '<') {
+			this.advance();
+			this.skipWhitespace();
+			const right = this.parseAdditive();
+			return { type: 'binary', operator: '<', left, right };
+		}
+
+		return left;
+	}
+
+	private parseAdditive(): FormulaASTNode {
+		let left = this.parseMultiplicative();
+
+		while (true) {
+			this.skipWhitespace();
+			if (this.current === '+') {
+				this.advance();
+				this.skipWhitespace();
+				const right = this.parseMultiplicative();
+				left = { type: 'binary', operator: '+', left, right };
+			} else if (this.current === '-') {
+				this.advance();
+				this.skipWhitespace();
+				const right = this.parseMultiplicative();
+				left = { type: 'binary', operator: '-', left, right };
+			} else {
+				break;
+			}
+		}
+
+		return left;
+	}
+
+	private parseMultiplicative(): FormulaASTNode {
+		let left = this.parseUnary();
+
+		while (true) {
+			this.skipWhitespace();
+			if (this.current === '*') {
+				this.advance();
+				this.skipWhitespace();
+				const right = this.parseUnary();
+				left = { type: 'binary', operator: '*', left, right };
+			} else if (this.current === '/') {
+				this.advance();
+				this.skipWhitespace();
+				const right = this.parseUnary();
+				left = { type: 'binary', operator: '/', left, right };
+			} else {
+				break;
+			}
+		}
+
+		return left;
+	}
+
+	private parseUnary(): FormulaASTNode {
+		this.skipWhitespace();
+
+		if (this.matchKeyword('not')) {
+			this.skipWhitespace();
+			const operand = this.parseUnary();
+			return { type: 'unary', operator: 'not', operand };
+		}
+
+		if (this.current === '-') {
+			this.advance();
+			this.skipWhitespace();
+			const operand = this.parseUnary();
+			return { type: 'unary', operator: '-', operand };
+		}
+
+		return this.parsePrimary();
+	}
+
+	private parsePrimary(): FormulaASTNode {
+		this.skipWhitespace();
+
+		if (this.current === '(') {
+			return this.parseParenthesizedExpression();
+		}
+
+		if (this.current === '"' || this.current === "'") {
+			return this.parseStringLiteral();
+		}
+
+		if (/\d/.test(this.current)) {
+			return this.parseNumberLiteral();
+		}
+
+		if (this.matchKeyword('true')) {
+			return { type: 'literal', valueType: 'boolean', value: true };
+		}
+
+		if (this.matchKeyword('false')) {
+			return { type: 'literal', valueType: 'boolean', value: false };
+		}
+
+		if (/[a-zA-Z_]/.test(this.current)) {
+			return this.parseIdentifierOrFunction();
+		}
+
+		throw new Error(`Unexpected character: ${this.current}`);
+	}
+
+	private parseParenthesizedExpression(): FormulaASTNode {
+		this.advance();
+		const expr = this.parseExpression();
+		this.skipWhitespace();
+		if (this.current !== ')') {
+			throw new Error('Expected closing parenthesis');
+		}
+		this.advance();
+		return expr;
+	}
+
+	private parseStringLiteral(): LiteralNode {
+		const quote = this.current;
+		this.advance();
+		let value = '';
+
+		while (this.current && this.current !== quote) {
+			if (this.current === '\\') {
+				this.advance();
+				value += this.current;
+			} else {
+				value += this.current;
+			}
+			this.advance();
+		}
+
+		if (this.current !== quote) {
+			throw new Error('Unterminated string literal');
+		}
+		this.advance();
+
+		return { type: 'literal', valueType: 'string', value };
+	}
+
+	private parseNumberLiteral(): LiteralNode {
+		let value = '';
+
+		while (this.current && /[\d.]/.test(this.current)) {
+			value += this.current;
+			this.advance();
+		}
+
+		return { type: 'literal', valueType: 'number', value: parseFloat(value) };
+	}
+
+	private parseIdentifierOrFunction(): PropertyRefNode | FunctionCallNode {
+		let name = '';
+
+		while (this.current && /[a-zA-Z0-9_]/.test(this.current)) {
+			name += this.current;
+			this.advance();
+		}
+
+		this.skipWhitespace();
+
+		if (this.current === '(') {
+			return this.parseFunctionCall(name);
+		}
+
+		return { type: 'property', name };
+	}
+
+	private parseFunctionCall(name: string): FunctionCallNode {
+		this.advance();
+		const args = this.parseArgumentList();
+		if (this.current !== ')') {
+			throw new Error('Expected closing parenthesis for function call');
+		}
+		this.advance();
+		return { type: 'function', name, args };
+	}
+
+	private parseArgumentList(): FormulaASTNode[] {
+		const args: FormulaASTNode[] = [];
+		this.skipWhitespace();
+
+		if (this.current === ')') {
+			return args;
+		}
+
+		while (true) {
+			args.push(this.parseExpression());
+			this.skipWhitespace();
+
+			if (this.current === ',') {
+				this.advance();
+				this.skipWhitespace();
+			} else {
+				break;
+			}
+		}
+
+		return args;
+	}
+
+	private matchKeyword(keyword: string): boolean {
+		const start = this.position;
+		const end = start + keyword.length;
+
+		if (this.input.substring(start, end).toLowerCase() === keyword.toLowerCase()) {
+			const nextChar = this.input[end];
+			if (!nextChar || !/[a-zA-Z0-9_]/.test(nextChar)) {
+				for (let i = 0; i < keyword.length; i++) {
+					this.advance();
+				}
+				return true;
+			}
+		}
+
+		return false;
+	}
+}
+
+function translateFormula(ast: FormulaASTNode): FormulaConversionResult {
+	const warnings: string[] = [];
+
+	try {
+		const formula = translateNode(ast, warnings);
+		return { success: true, formula, warnings };
+	} catch (error) {
+		return {
+			success: false,
+			error: error instanceof Error ? error.message : 'Unknown translation error',
+			warnings,
+		};
+	}
+}
+
+function translateNode(node: FormulaASTNode, warnings: string[]): string {
+	switch (node.type) {
+		case 'literal':
+			return translateLiteral(node);
+		case 'property':
+			return translateProperty(node);
+		case 'function':
+			return translateFunction(node, warnings);
+		case 'binary':
+			return translateBinary(node, warnings);
+		case 'unary':
+			return translateUnary(node, warnings);
+	}
+}
+
+function translateLiteral(node: LiteralNode): string {
+	if (node.valueType === 'string') {
+		return `"${node.value}"`;
+	}
+	return String(node.value);
+}
+
+function translateProperty(node: PropertyRefNode): string {
+	return `prop("${node.name}")`;
+}
+
+function translateFunction(node: FunctionCallNode, warnings: string[]): string {
+	const mapping = FUNCTION_MAPPINGS[node.name];
+
+	if (!mapping) {
+		warnings.push(`Unsupported function: ${node.name}`);
+		return `UNSUPPORTED_FUNCTION(${node.name})`;
+	}
+
+	const args = node.args.map(arg => translateNode(arg, warnings));
+
+	if (mapping.requiresTransformation) {
+		return transformFunction(node.name, mapping.obsidianName, args);
+	}
+
+	return `${mapping.obsidianName}(${args.join(', ')})`;
+}
+
+function transformFunction(notionName: string, obsidianName: string, args: string[]): string {
+	switch (notionName) {
+		case 'add':
+			return args.length === 2 ? `(${args[0]} + ${args[1]})` : `sum(${args.join(', ')})`;
+		case 'subtract':
+			return args.length === 2 ? `(${args[0]} - ${args[1]})` : args[0];
+		case 'multiply':
+			return args.length === 2 ? `(${args[0]} * ${args[1]})` : `product(${args.join(', ')})`;
+		case 'divide':
+			return args.length === 2 ? `(${args[0]} / ${args[1]})` : args[0];
+		case 'equal':
+			return `(${args[0]} == ${args[1]})`;
+		case 'unequal':
+			return `(${args[0]} != ${args[1]})`;
+		case 'larger':
+			return `(${args[0]} > ${args[1]})`;
+		case 'largerEq':
+			return `(${args[0]} >= ${args[1]})`;
+		case 'smaller':
+			return `(${args[0]} < ${args[1]})`;
+		case 'smallerEq':
+			return `(${args[0]} <= ${args[1]})`;
+		case 'today':
+			return 'dateonly(now())';
+		case 'replaceAll':
+			return `regexreplace(${args.join(', ')})`;
+		default:
+			return `${obsidianName}(${args.join(', ')})`;
+	}
+}
+
+function translateBinary(node: BinaryOpNode, warnings: string[]): string {
+	const left = translateNode(node.left, warnings);
+	const right = translateNode(node.right, warnings);
+
+	switch (node.operator) {
+		case '+':
+		case '-':
+		case '*':
+		case '/':
+		case '==':
+		case '!=':
+		case '>':
+		case '<':
+		case '>=':
+		case '<=':
+			return `(${left} ${node.operator} ${right})`;
+		case 'and':
+			return `and(${left}, ${right})`;
+		case 'or':
+			return `or(${left}, ${right})`;
+	}
+}
+
+function translateUnary(node: UnaryOpNode, warnings: string[]): string {
+	const operand = translateNode(node.operand, warnings);
+
+	switch (node.operator) {
+		case 'not':
+			return `not(${operand})`;
+		case '-':
+			return `(-${operand})`;
+	}
+}
+
+export function convertNotionFormula(formula: string): FormulaConversionResult {
+	const parser = new FormulaParser(formula);
+	const parseResult = parser.parse();
+
+	if (!parseResult.success || !parseResult.ast) {
+		return {
+			success: false,
+			error: parseResult.error,
+		};
+	}
+
+	return translateFormula(parseResult.ast);
+}

--- a/src/formats/notion-api/notion-types.ts
+++ b/src/formats/notion-api/notion-types.ts
@@ -1,0 +1,187 @@
+import type { DatabaseObjectResponse, PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
+
+export interface NotionDatabaseProperty {
+	id: string;
+	name: string;
+	type: string;
+	[key: string]: unknown;
+}
+
+export interface NotionSelectOption {
+	id?: string;
+	name: string;
+	color?: string;
+}
+
+export interface NotionSelectProperty extends NotionDatabaseProperty {
+	type: 'select';
+	select: {
+		options: NotionSelectOption[];
+	};
+}
+
+export interface NotionMultiSelectProperty extends NotionDatabaseProperty {
+	type: 'multi_select';
+	multi_select: {
+		options: NotionSelectOption[];
+	};
+}
+
+export interface NotionStatusProperty extends NotionDatabaseProperty {
+	type: 'status';
+	status: {
+		options: NotionSelectOption[];
+		groups?: unknown[];
+	};
+}
+
+export interface NotionFormulaProperty extends NotionDatabaseProperty {
+	type: 'formula';
+	formula: {
+		expression?: string;
+		[key: string]: unknown;
+	};
+}
+
+export type NotionDatabasePropertyType =
+	| NotionSelectProperty
+	| NotionMultiSelectProperty
+	| NotionStatusProperty
+	| NotionFormulaProperty
+	| NotionDatabaseProperty;
+
+export type NotionDatabaseWithProperties = DatabaseObjectResponse & {
+	properties: Record<string, NotionDatabasePropertyType>;
+};
+
+export function isDatabaseObject(obj: { object?: string }): obj is NotionDatabaseWithProperties {
+	return obj.object === 'database' || obj.object === 'data_source';
+}
+
+export function isSelectProperty(prop: NotionDatabasePropertyType): prop is NotionSelectProperty {
+	return prop.type === 'select' && 'select' in prop;
+}
+
+export function isMultiSelectProperty(prop: NotionDatabasePropertyType): prop is NotionMultiSelectProperty {
+	return prop.type === 'multi_select' && 'multi_select' in prop;
+}
+
+export function isStatusProperty(prop: NotionDatabasePropertyType): prop is NotionStatusProperty {
+	return prop.type === 'status' && 'status' in prop;
+}
+
+export function isFormulaProperty(prop: NotionDatabasePropertyType): prop is NotionFormulaProperty {
+	return prop.type === 'formula' && 'formula' in prop;
+}
+
+export type BasePropertyType =
+	| 'text'
+	| 'number'
+	| 'date'
+	| 'checkbox'
+	| 'select'
+	| 'multi-select'
+	| 'link'
+	| 'file';
+
+export interface BaseProperty {
+	type: BasePropertyType;
+	name: string;
+	displayName?: string;
+	options?: string[];
+	format?: string;
+}
+
+export interface BaseFormula {
+	name: string;
+	displayName?: string;
+	expression: string;
+}
+
+export type FilterOperator =
+	| '='
+	| '!='
+	| '>'
+	| '<'
+	| '>='
+	| '<='
+	| 'contains'
+	| 'not contains'
+	| 'starts with'
+	| 'ends with'
+	| 'is empty'
+	| 'is not empty';
+
+export interface FilterCondition {
+	property: string;
+	operator: FilterOperator;
+	value?: unknown;
+}
+
+export interface FilterGroup {
+	and?: (FilterCondition | FilterGroup)[];
+	or?: (FilterCondition | FilterGroup)[];
+	not?: FilterCondition | FilterGroup;
+}
+
+export type BaseFilter = string | FilterCondition | FilterGroup;
+
+export type BaseViewType = 'table' | 'list' | 'gallery' | 'board' | 'calendar';
+
+export interface BaseView {
+	name: string;
+	type: BaseViewType;
+	filters?: BaseFilter;
+	sorts?: BaseSort[];
+	groups?: BaseGroup[];
+	columns?: BaseColumn[];
+	properties?: Record<string, unknown>;
+}
+
+export interface BaseColumn {
+	property: string;
+	width?: number;
+	visible?: boolean;
+}
+
+export interface BaseSort {
+	property: string;
+	direction: 'ascending' | 'descending';
+}
+
+export interface BaseGroup {
+	property: string;
+	direction?: 'ascending' | 'descending';
+}
+
+export interface BaseSchema {
+	version?: string;
+	filters?: BaseFilter;
+	properties?: Record<string, BaseProperty>;
+	formulas?: Record<string, BaseFormula>;
+	views?: BaseView[];
+}
+
+export const PROPERTY_TYPE_MAPPINGS: Record<string, BasePropertyType> = {
+	'title': 'text',
+	'rich_text': 'text',
+	'number': 'number',
+	'select': 'select',
+	'multi_select': 'multi-select',
+	'status': 'select',
+	'date': 'date',
+	'people': 'text',
+	'files': 'file',
+	'checkbox': 'checkbox',
+	'url': 'link',
+	'email': 'link',
+	'phone_number': 'text',
+	'formula': 'text',
+	'relation': 'link',
+	'rollup': 'text',
+	'created_time': 'date',
+	'created_by': 'text',
+	'last_edited_time': 'date',
+	'last_edited_by': 'text',
+	'unique_id': 'text',
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { EvernoteEnexImporter } from './formats/evernote-enex';
 import { HtmlImporter } from './formats/html';
 import { KeepImporter } from './formats/keep-json';
 import { NotionImporter } from './formats/notion';
+import { NotionApiImporter } from './formats/notion-api';
 import { OneNoteImporter } from './formats/onenote';
 import { RoamJSONImporter } from './formats/roam-json';
 import { TextbundleImporter } from './formats/textbundle';
@@ -276,6 +277,13 @@ export default class ImporterPlugin extends Plugin {
 				importer: NotionImporter,
 				helpPermalink: 'import/notion',
 				formatDescription: 'Export your Notion workspace to HTML format.',
+			},
+			'notion-api': {
+				name: 'Notion (API)',
+				optionText: 'Notion (API)',
+				importer: NotionApiImporter,
+				helpPermalink: 'import/notion',
+				formatDescription: 'Import from Notion using the Notion API. Converts Databases to Bases.',
 			},
 			'roam-json': {
 				name: 'Roam Research',

--- a/tests/notion-api/README.md
+++ b/tests/notion-api/README.md
@@ -1,0 +1,27 @@
+# Notion API Importer Tests
+
+This directory contains test data and verification files for the Notion API importer.
+
+## Directory Structure
+
+- `mock-data/` - JSON files representing Notion API responses
+- `expected-outputs/` - Expected output files (.base and .md) that the importer should produce
+- `formula-tests.md` - Manual formula conversion test cases
+- `test-checklist.md` - Manual testing checklist
+
+## Running Tests
+
+Since this project doesn't use automated unit tests, testing is manual:
+
+1. Review the test cases in `formula-tests.md`
+2. Compare actual outputs with files in `expected-outputs/`
+3. Use the checklist in `test-checklist.md` to verify all functionality
+
+## Test Coverage
+
+- Formula conversion (Notion formulas → Obsidian Bases formulas)
+- Property type mappings (Notion property types → Base property types)
+- Base schema generation and YAML serialization
+- API client rate limiting and pagination
+- Page title extraction from RichTextItemResponse
+- Block-to-markdown conversion

--- a/tests/notion-api/expected-outputs/blocks-sample.md
+++ b/tests/notion-api/expected-outputs/blocks-sample.md
@@ -1,0 +1,21 @@
+This is a simple paragraph with **bold text** and *italic text*
+
+## Section Title
+
+- First item
+- Second item with `code`
+
+```typescript
+const greeting = "Hello, World!";
+console.log(greeting);
+```
+
+- [ ] Incomplete task
+- [x] Completed task
+
+> This is a quote with important information.
+
+> [!note] 💡
+> This is an important callout!
+
+---

--- a/tests/notion-api/expected-outputs/formula-database.base
+++ b/tests/notion-api/expected-outputs/formula-database.base
@@ -1,0 +1,42 @@
+# Product Inventory
+
+```base
+version: "1.0"
+filters:
+  property: "notion-database"
+  operator: "="
+  value: "formula-test-123"
+properties:
+  title:
+    type: "text"
+    name: "title"
+    displayName: "Product Name"
+  price_id:
+    type: "number"
+    name: "price_id"
+    displayName: "Price"
+  qty_id:
+    type: "number"
+    name: "qty_id"
+    displayName: "Quantity"
+formulas:
+  total_id:
+    name: "total_id"
+    displayName: "Total Value"
+    expression: "(Price * Quantity)"
+  label_id:
+    name: "label_id"
+    displayName: "Status Label"
+    expression: "if((Price > 100), \"Expensive\", \"Affordable\")"
+  display_id:
+    name: "display_id"
+    displayName: "Display Name"
+    expression: "concat(Product Name, \" ($\", Price, \")\")"
+  category_id:
+    name: "category_id"
+    displayName: "Price Category"
+    expression: "if((Price >= 100), \"Premium\", if((Price >= 50), \"Standard\", \"Budget\"))"
+views:
+  - name: "Table"
+    type: "table"
+```

--- a/tests/notion-api/expected-outputs/sample-page.md
+++ b/tests/notion-api/expected-outputs/sample-page.md
@@ -1,0 +1,5 @@
+---
+notion-database: "abc123-456def-789ghi"
+---
+
+# Sample Task

--- a/tests/notion-api/expected-outputs/simple-database.base
+++ b/tests/notion-api/expected-outputs/simple-database.base
@@ -1,0 +1,41 @@
+# Project Tasks
+
+```base
+version: "1.0"
+filters:
+  property: "notion-database"
+  operator: "="
+  value: "abc123-456def-789ghi"
+properties:
+  title:
+    type: "text"
+    name: "title"
+    displayName: "Name"
+  status_id:
+    type: "select"
+    name: "status_id"
+    displayName: "Status"
+    options:
+      - "To Do"
+      - "In Progress"
+      - "Done"
+  priority_id:
+    type: "select"
+    name: "priority_id"
+    displayName: "Priority"
+    options:
+      - "Low"
+      - "Medium"
+      - "High"
+  date_id:
+    type: "date"
+    name: "date_id"
+    displayName: "Due Date"
+  checkbox_id:
+    type: "checkbox"
+    name: "checkbox_id"
+    displayName: "Completed"
+views:
+  - name: "Table"
+    type: "table"
+```

--- a/tests/notion-api/formula-tests.md
+++ b/tests/notion-api/formula-tests.md
@@ -1,0 +1,202 @@
+# Formula Conversion Test Cases
+
+This file contains test cases for verifying Notion formula conversion to Obsidian Bases format.
+
+## Critical: prop() Function Handling
+
+### Test 1: Simple prop() reference
+**Notion Formula:**
+```
+prop("Name")
+```
+**Expected Obsidian Output:**
+```
+Name
+```
+
+### Test 2: prop() in conditional
+**Notion Formula:**
+```
+if(prop("Status") == "Done", true, false)
+```
+**Expected Obsidian Output:**
+```
+if(Status == "Done", true, false)
+```
+
+### Test 3: prop() in arithmetic
+**Notion Formula:**
+```
+prop("Price") * prop("Quantity")
+```
+**Expected Obsidian Output:**
+```
+(Price * Quantity)
+```
+
+### Test 4: Multiple prop() in concat
+**Notion Formula:**
+```
+concat(prop("FirstName"), " ", prop("LastName"))
+```
+**Expected Obsidian Output:**
+```
+concat(FirstName, " ", LastName)
+```
+
+### Test 5: prop() with spaces in property name
+**Notion Formula:**
+```
+prop("First Name")
+```
+**Expected Obsidian Output:**
+```
+First Name
+```
+
+## Function Mappings
+
+### Test 6: add() function
+**Notion Formula:**
+```
+add(prop("A"), prop("B"))
+```
+**Expected Obsidian Output:**
+```
+(A + B)
+```
+
+### Test 7: Multiple add() arguments
+**Notion Formula:**
+```
+add(1, 2, 3, 4)
+```
+**Expected Obsidian Output:**
+```
+sum(1, 2, 3, 4)
+```
+
+### Test 8: Date formatting
+**Notion Formula:**
+```
+formatDate(prop("Created"), "YYYY-MM-DD")
+```
+**Expected Obsidian Output:**
+```
+dateformat(Created, "YYYY-MM-DD")
+```
+
+### Test 9: today() function
+**Notion Formula:**
+```
+today()
+```
+**Expected Obsidian Output:**
+```
+dateonly(now())
+```
+
+### Test 10: String operations
+**Notion Formula:**
+```
+upper(prop("Name"))
+```
+**Expected Obsidian Output:**
+```
+upper(Name)
+```
+
+### Test 11: Comparison operators
+**Notion Formula:**
+```
+prop("Score") >= 90
+```
+**Expected Obsidian Output:**
+```
+(Score >= 90)
+```
+
+### Test 12: Boolean logic
+**Notion Formula:**
+```
+and(prop("IsActive"), prop("IsVerified"))
+```
+**Expected Obsidian Output:**
+```
+and(IsActive, IsVerified)
+```
+
+### Test 13: Complex nested formula
+**Notion Formula:**
+```
+if(prop("Price") > 100, concat("$", formatDate(prop("ExpensiveDate"), "MM/DD/YYYY")), concat("$", formatDate(prop("CheapDate"), "MM/DD/YYYY")))
+```
+**Expected Obsidian Output:**
+```
+if((Price > 100), concat("$", dateformat(ExpensiveDate, "MM/DD/YYYY")), concat("$", dateformat(CheapDate, "MM/DD/YYYY")))
+```
+
+## Edge Cases
+
+### Test 14: Direct property reference (no prop() wrapper)
+**Notion Formula:**
+```
+Name
+```
+**Expected Obsidian Output:**
+```
+Name
+```
+
+### Test 15: String literals with quotes
+**Notion Formula:**
+```
+concat(prop("Name"), " - ", "Active")
+```
+**Expected Obsidian Output:**
+```
+concat(Name, " - ", "Active")
+```
+
+### Test 16: Numeric literals
+**Notion Formula:**
+```
+prop("Price") * 1.08
+```
+**Expected Obsidian Output:**
+```
+(Price * 1.08)
+```
+
+### Test 17: Boolean literals
+**Notion Formula:**
+```
+if(prop("IsActive"), true, false)
+```
+**Expected Obsidian Output:**
+```
+if(IsActive, true, false)
+```
+
+## Testing Instructions
+
+To test these conversions:
+
+1. Open the TypeScript console or create a test file
+2. Import the `convertNotionFormula` function from `formula-converter.ts`
+3. For each test case:
+   ```typescript
+   import { convertNotionFormula } from '../src/formats/notion-api/formula-converter';
+
+   const result = convertNotionFormula('prop("Name")');
+   console.log(result);
+   // Expected: { success: true, formula: 'Name', warnings: [] }
+   ```
+4. Verify the output matches the expected result
+5. Check for any warnings in the result
+
+## Known Limitations
+
+- Notion Formulas 2.0 introduced complex types (lists, objects) that may not fully map to Obsidian Bases
+- Some Notion functions may not have Obsidian equivalents
+- Property references with special characters may need sanitization

--- a/tests/notion-api/mock-data/blocks-sample.json
+++ b/tests/notion-api/mock-data/blocks-sample.json
@@ -1,0 +1,305 @@
+{
+  "results": [
+    {
+      "object": "block",
+      "id": "block-1",
+      "type": "paragraph",
+      "paragraph": {
+        "rich_text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "This is a simple paragraph with "
+            },
+            "plain_text": "This is a simple paragraph with ",
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            }
+          },
+          {
+            "type": "text",
+            "text": {
+              "content": "bold text"
+            },
+            "plain_text": "bold text",
+            "annotations": {
+              "bold": true,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            }
+          },
+          {
+            "type": "text",
+            "text": {
+              "content": " and "
+            },
+            "plain_text": " and ",
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            }
+          },
+          {
+            "type": "text",
+            "text": {
+              "content": "italic text"
+            },
+            "plain_text": "italic text",
+            "annotations": {
+              "bold": false,
+              "italic": true,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            }
+          }
+        ]
+      },
+      "has_children": false
+    },
+    {
+      "object": "block",
+      "id": "block-2",
+      "type": "heading_2",
+      "heading_2": {
+        "rich_text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "Section Title"
+            },
+            "plain_text": "Section Title",
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            }
+          }
+        ]
+      },
+      "has_children": false
+    },
+    {
+      "object": "block",
+      "id": "block-3",
+      "type": "bulleted_list_item",
+      "bulleted_list_item": {
+        "rich_text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "First item"
+            },
+            "plain_text": "First item",
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            }
+          }
+        ]
+      },
+      "has_children": false
+    },
+    {
+      "object": "block",
+      "id": "block-4",
+      "type": "bulleted_list_item",
+      "bulleted_list_item": {
+        "rich_text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "Second item with "
+            },
+            "plain_text": "Second item with ",
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            }
+          },
+          {
+            "type": "text",
+            "text": {
+              "content": "code"
+            },
+            "plain_text": "code",
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": true,
+              "color": "default"
+            }
+          }
+        ]
+      },
+      "has_children": false
+    },
+    {
+      "object": "block",
+      "id": "block-5",
+      "type": "code",
+      "code": {
+        "language": "typescript",
+        "rich_text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "const greeting = \"Hello, World!\";\nconsole.log(greeting);"
+            },
+            "plain_text": "const greeting = \"Hello, World!\";\nconsole.log(greeting);",
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            }
+          }
+        ]
+      },
+      "has_children": false
+    },
+    {
+      "object": "block",
+      "id": "block-6",
+      "type": "to_do",
+      "to_do": {
+        "checked": false,
+        "rich_text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "Incomplete task"
+            },
+            "plain_text": "Incomplete task",
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            }
+          }
+        ]
+      },
+      "has_children": false
+    },
+    {
+      "object": "block",
+      "id": "block-7",
+      "type": "to_do",
+      "to_do": {
+        "checked": true,
+        "rich_text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "Completed task"
+            },
+            "plain_text": "Completed task",
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            }
+          }
+        ]
+      },
+      "has_children": false
+    },
+    {
+      "object": "block",
+      "id": "block-8",
+      "type": "quote",
+      "quote": {
+        "rich_text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "This is a quote with important information."
+            },
+            "plain_text": "This is a quote with important information.",
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            }
+          }
+        ]
+      },
+      "has_children": false
+    },
+    {
+      "object": "block",
+      "id": "block-9",
+      "type": "callout",
+      "callout": {
+        "icon": {
+          "type": "emoji",
+          "emoji": "💡"
+        },
+        "rich_text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "This is an important callout!"
+            },
+            "plain_text": "This is an important callout!",
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            }
+          }
+        ]
+      },
+      "has_children": false
+    },
+    {
+      "object": "block",
+      "id": "block-10",
+      "type": "divider",
+      "divider": {},
+      "has_children": false
+    }
+  ],
+  "has_more": false,
+  "next_cursor": null
+}

--- a/tests/notion-api/mock-data/database-simple.json
+++ b/tests/notion-api/mock-data/database-simple.json
@@ -1,0 +1,82 @@
+{
+  "object": "database",
+  "id": "abc123-456def-789ghi",
+  "created_time": "2024-01-01T00:00:00.000Z",
+  "last_edited_time": "2024-01-01T00:00:00.000Z",
+  "title": [
+    {
+      "type": "text",
+      "text": {
+        "content": "Project Tasks"
+      }
+    }
+  ],
+  "properties": {
+    "Name": {
+      "id": "title",
+      "name": "Name",
+      "type": "title",
+      "title": {}
+    },
+    "Status": {
+      "id": "status_id",
+      "name": "Status",
+      "type": "select",
+      "select": {
+        "options": [
+          {
+            "id": "opt1",
+            "name": "To Do",
+            "color": "red"
+          },
+          {
+            "id": "opt2",
+            "name": "In Progress",
+            "color": "yellow"
+          },
+          {
+            "id": "opt3",
+            "name": "Done",
+            "color": "green"
+          }
+        ]
+      }
+    },
+    "Priority": {
+      "id": "priority_id",
+      "name": "Priority",
+      "type": "select",
+      "select": {
+        "options": [
+          {
+            "id": "pri1",
+            "name": "Low",
+            "color": "gray"
+          },
+          {
+            "id": "pri2",
+            "name": "Medium",
+            "color": "blue"
+          },
+          {
+            "id": "pri3",
+            "name": "High",
+            "color": "orange"
+          }
+        ]
+      }
+    },
+    "Due Date": {
+      "id": "date_id",
+      "name": "Due Date",
+      "type": "date",
+      "date": {}
+    },
+    "Completed": {
+      "id": "checkbox_id",
+      "name": "Completed",
+      "type": "checkbox",
+      "checkbox": {}
+    }
+  }
+}

--- a/tests/notion-api/mock-data/database-with-formulas.json
+++ b/tests/notion-api/mock-data/database-with-formulas.json
@@ -1,0 +1,68 @@
+{
+  "object": "database",
+  "id": "formula-test-123",
+  "created_time": "2024-01-01T00:00:00.000Z",
+  "last_edited_time": "2024-01-01T00:00:00.000Z",
+  "title": [
+    {
+      "type": "text",
+      "text": {
+        "content": "Product Inventory"
+      }
+    }
+  ],
+  "properties": {
+    "Product Name": {
+      "id": "title",
+      "name": "Product Name",
+      "type": "title",
+      "title": {}
+    },
+    "Price": {
+      "id": "price_id",
+      "name": "Price",
+      "type": "number",
+      "number": {
+        "format": "dollar"
+      }
+    },
+    "Quantity": {
+      "id": "qty_id",
+      "name": "Quantity",
+      "type": "number",
+      "number": {}
+    },
+    "Total Value": {
+      "id": "total_id",
+      "name": "Total Value",
+      "type": "formula",
+      "formula": {
+        "expression": "prop(\"Price\") * prop(\"Quantity\")"
+      }
+    },
+    "Status Label": {
+      "id": "label_id",
+      "name": "Status Label",
+      "type": "formula",
+      "formula": {
+        "expression": "if(prop(\"Price\") > 100, \"Expensive\", \"Affordable\")"
+      }
+    },
+    "Display Name": {
+      "id": "display_id",
+      "name": "Display Name",
+      "type": "formula",
+      "formula": {
+        "expression": "concat(prop(\"Product Name\"), \" ($\", prop(\"Price\"), \")\")"
+      }
+    },
+    "Price Category": {
+      "id": "category_id",
+      "name": "Price Category",
+      "type": "formula",
+      "formula": {
+        "expression": "if(prop(\"Price\") >= 100, \"Premium\", if(prop(\"Price\") >= 50, \"Standard\", \"Budget\"))"
+      }
+    }
+  }
+}

--- a/tests/notion-api/mock-data/page-sample.json
+++ b/tests/notion-api/mock-data/page-sample.json
@@ -1,0 +1,48 @@
+{
+  "object": "page",
+  "id": "page-123-abc",
+  "created_time": "2024-01-01T00:00:00.000Z",
+  "last_edited_time": "2024-01-01T00:00:00.000Z",
+  "properties": {
+    "Name": {
+      "id": "title",
+      "type": "title",
+      "title": [
+        {
+          "type": "text",
+          "text": {
+            "content": "Sample Task"
+          }
+        }
+      ]
+    },
+    "Status": {
+      "id": "status_id",
+      "type": "select",
+      "select": {
+        "name": "In Progress",
+        "color": "yellow"
+      }
+    },
+    "Priority": {
+      "id": "priority_id",
+      "type": "select",
+      "select": {
+        "name": "High",
+        "color": "orange"
+      }
+    },
+    "Due Date": {
+      "id": "date_id",
+      "type": "date",
+      "date": {
+        "start": "2024-12-31"
+      }
+    },
+    "Completed": {
+      "id": "checkbox_id",
+      "type": "checkbox",
+      "checkbox": false
+    }
+  }
+}

--- a/tests/notion-api/test-base-converter.ts
+++ b/tests/notion-api/test-base-converter.ts
@@ -1,0 +1,80 @@
+import { convertDatabaseToBase, createBaseFileContent } from '../../src/formats/notion-api/base-converter';
+import type { NotionDatabaseWithProperties } from '../../src/formats/notion-api/notion-types';
+import * as fs from 'fs';
+import * as path from 'path';
+
+console.log('=== Base Converter Test Suite ===\n');
+
+let passed = 0;
+let failed = 0;
+
+const mockDataDir = path.join(__dirname, 'mock-data');
+const expectedOutputsDir = path.join(__dirname, 'expected-outputs');
+
+async function testDatabase(name: string, mockFile: string, expectedFile: string) {
+	try {
+		const mockPath = path.join(mockDataDir, mockFile);
+		const expectedPath = path.join(expectedOutputsDir, expectedFile);
+
+		const mockData = JSON.parse(fs.readFileSync(mockPath, 'utf-8')) as NotionDatabaseWithProperties;
+
+		const result = convertDatabaseToBase(mockData);
+		const actualContent = createBaseFileContent(result.schema, result.databaseTitle);
+
+		const expectedContent = fs.readFileSync(expectedPath, 'utf-8');
+
+		if (actualContent.trim() === expectedContent.trim()) {
+			console.log(`✅ ${name}`);
+			console.log(`   Database: ${result.databaseTitle}`);
+			console.log(`   Properties: ${Object.keys(result.schema.properties || {}).length}`);
+			console.log(`   Formulas: ${Object.keys(result.schema.formulas || {}).length}`);
+			if (result.warnings.length > 0) {
+				console.log(`   Warnings: ${result.warnings.length}`);
+			}
+			console.log('');
+			passed++;
+		} else {
+			console.log(`❌ ${name}`);
+			console.log(`   Output doesn't match expected`);
+			console.log('\n   === EXPECTED ===');
+			console.log(expectedContent);
+			console.log('\n   === ACTUAL ===');
+			console.log(actualContent);
+			console.log('');
+			failed++;
+		}
+	} catch (error) {
+		console.log(`❌ ${name}`);
+		console.log(`   Error: ${error instanceof Error ? error.message : String(error)}`);
+		console.log('');
+		failed++;
+	}
+}
+
+async function runTests() {
+	console.log('Testing simple database conversion...');
+	await testDatabase(
+		'Simple Database',
+		'database-simple.json',
+		'simple-database.base'
+	);
+
+	console.log('Testing database with formulas conversion...');
+	await testDatabase(
+		'Database with Formulas',
+		'database-with-formulas.json',
+		'formula-database.base'
+	);
+
+	console.log('\n=== Summary ===');
+	console.log(`Passed: ${passed}/2`);
+	console.log(`Failed: ${failed}/2`);
+
+	if (failed === 0) {
+		console.log('\n✅ All Base converter tests passed!');
+	} else {
+		console.log(`\n❌ ${failed} test(s) failed`);
+	}
+}
+
+runTests();

--- a/tests/notion-api/test-checklist.md
+++ b/tests/notion-api/test-checklist.md
@@ -1,0 +1,164 @@
+# Notion API Importer Test Checklist
+
+## Formula Conversion Tests
+
+### Critical prop() Function Tests
+- [ ] Test 1: Simple `prop("Name")` → `Name`
+- [ ] Test 2: `prop()` in conditional statement
+- [ ] Test 3: `prop()` in arithmetic operations
+- [ ] Test 4: Multiple `prop()` calls in one formula
+- [ ] Test 5: `prop()` with property names containing spaces
+
+### Function Mapping Tests
+- [ ] Test 6: `add()` with 2 arguments → `(A + B)`
+- [ ] Test 7: `add()` with 3+ arguments → `sum()`
+- [ ] Test 8: Date formatting functions
+- [ ] Test 9: `today()` → `dateonly(now())`
+- [ ] Test 10: String manipulation functions
+- [ ] Test 11: Comparison operators
+- [ ] Test 12: Boolean logic (and/or/not)
+- [ ] Test 13: Complex nested formulas
+
+### Edge Cases
+- [ ] Test 14: Direct property reference (no `prop()`)
+- [ ] Test 15: String literals with quotes
+- [ ] Test 16: Numeric literals
+- [ ] Test 17: Boolean literals
+
+## Property Type Mapping Tests
+
+### Basic Types
+- [ ] Title property → text
+- [ ] Rich text property → text
+- [ ] Number property → number
+- [ ] Checkbox property → checkbox
+- [ ] Date property → date
+- [ ] URL property → link
+- [ ] Email property → text
+- [ ] Phone number property → text
+
+### Select Types (with options extraction)
+- [ ] Select property → select with options array
+- [ ] Multi-select property → multi-select with options array
+- [ ] Status property → select with options array
+
+### Unsupported Types (should generate warnings)
+- [ ] Relation property → warning
+- [ ] Rollup property → warning
+- [ ] Files property → file (or warning?)
+- [ ] Formula property → goes to formulas section
+
+## Base Schema Generation Tests
+
+### YAML Structure
+- [ ] `version` field is set to "1.0"
+- [ ] `filters` object references database ID correctly
+- [ ] `properties` section exists when database has properties
+- [ ] `formulas` section exists when database has formulas
+- [ ] `views` array contains default table view
+- [ ] Properties have correct structure (type, name, displayName)
+- [ ] Formulas have correct structure (name, displayName, expression)
+
+### YAML Formatting
+- [ ] Text literals use double quotes
+- [ ] Formula expressions properly formatted
+- [ ] Arithmetic operators have spaces: `a * b` not `a*b`
+- [ ] Line width unlimited (no wrapping)
+- [ ] Property names preserved exactly (including spaces)
+
+## API Client Tests
+
+### Rate Limiting
+- [ ] Rate limiter enforces 3 requests/second
+- [ ] Multiple rapid requests are properly throttled
+- [ ] No requests lost during throttling
+
+### Pagination
+- [ ] `searchAll()` handles `has_more` correctly
+- [ ] `searchAll()` uses `next_cursor` for subsequent pages
+- [ ] All results aggregated across multiple pages
+- [ ] `getAllDatabasePages()` fetches all pages from database
+- [ ] Pagination handles empty result sets
+
+### Error Handling
+- [ ] Invalid API token returns user-friendly error
+- [ ] Network failures handled gracefully
+- [ ] API rate limit errors handled
+- [ ] Invalid database ID handled
+
+## Page Processing Tests
+
+### Title Extraction
+- [ ] Extract title from PageObjectResponse with single text part
+- [ ] Extract title with multiple RichTextItemResponse parts
+- [ ] Handle pages with no title → "Untitled"
+- [ ] Handle pages with empty string title → "Untitled"
+- [ ] Concatenate multiple title parts correctly
+
+### File Creation
+- [ ] Create markdown file with proper frontmatter
+- [ ] Database tag in frontmatter: `notion-database: "id"`
+- [ ] Title in markdown heading: `# Title`
+- [ ] Handle duplicate filenames (append number)
+- [ ] Sanitize file paths (remove invalid characters)
+
+## Integration Tests
+
+### End-to-End Workflow
+- [ ] Search for databases in workspace
+- [ ] Filter results to only databases
+- [ ] Convert each database to .base file
+- [ ] Fetch pages from each database
+- [ ] Convert each page to .md file
+- [ ] Report progress correctly
+- [ ] Handle cancellation gracefully
+
+### Mock Data Tests
+- [ ] Load `database-simple.json` → produces `simple-database.base`
+- [ ] Load `database-with-formulas.json` → produces `formula-database.base`
+- [ ] Load `page-sample.json` → produces `sample-page.md`
+- [ ] Compare actual vs expected outputs byte-by-byte
+
+## Known Issues and Limitations
+
+### Current Implementation Gaps
+- [ ] **CRITICAL**: Page content (blocks) not converted - only stub pages created
+- [ ] **IMPORTANT**: No rich text formatting conversion
+- [ ] **IMPORTANT**: No nested block handling
+- [ ] **IMPORTANT**: No attachment downloading
+- [ ] Formulas 2.0 complex types (lists, objects) may not fully map
+
+### Future Enhancements Needed
+- [ ] Implement block-to-markdown conversion
+- [ ] Implement rich text formatting (bold, italic, code, etc.)
+- [ ] Implement nested blocks (indentation)
+- [ ] Implement block types (paragraph, heading, list, code, etc.)
+- [ ] Implement attachment downloading
+- [ ] Implement synced blocks
+- [ ] Implement database views
+- [ ] Implement page property values conversion
+
+## Testing Instructions
+
+1. **Manual Formula Testing:**
+   - Copy test formulas from `formula-tests.md`
+   - Use TypeScript/Node console to test `convertNotionFormula()`
+   - Verify output matches expected result
+
+2. **Mock Data Testing:**
+   - Load mock JSON files
+   - Pass through converter functions
+   - Compare output with expected output files
+   - Use diff tool to check for discrepancies
+
+3. **Live API Testing:**
+   - Create test Notion workspace
+   - Add databases with various property types
+   - Add formulas to test conversion
+   - Run importer with actual API token
+   - Verify generated .base and .md files
+
+4. **Regression Testing:**
+   - Keep expected output files in version control
+   - After code changes, re-run tests
+   - Ensure outputs still match expected files

--- a/tests/notion-api/test-formulas.ts
+++ b/tests/notion-api/test-formulas.ts
@@ -1,0 +1,146 @@
+import { convertNotionFormula } from '../../src/formats/notion-api/formula-converter';
+
+interface TestCase {
+	name: string;
+	input: string;
+	expected: string;
+}
+
+const testCases: TestCase[] = [
+	{
+		name: 'Test 1: Simple prop() reference',
+		input: 'prop("Name")',
+		expected: 'Name',
+	},
+	{
+		name: 'Test 2: prop() in conditional',
+		input: 'if(prop("Status") == "Done", true, false)',
+		expected: 'if((Status == "Done"), true, false)',
+	},
+	{
+		name: 'Test 3: prop() in arithmetic',
+		input: 'prop("Price") * prop("Quantity")',
+		expected: '(Price * Quantity)',
+	},
+	{
+		name: 'Test 4: Multiple prop() in concat',
+		input: 'concat(prop("FirstName"), " ", prop("LastName"))',
+		expected: 'concat(FirstName, " ", LastName)',
+	},
+	{
+		name: 'Test 5: prop() with spaces',
+		input: 'prop("First Name")',
+		expected: 'First Name',
+	},
+	{
+		name: 'Test 6: add() function',
+		input: 'add(prop("A"), prop("B"))',
+		expected: '(A + B)',
+	},
+	{
+		name: 'Test 7: Multiple add() arguments',
+		input: 'add(1, 2, 3, 4)',
+		expected: 'sum(1, 2, 3, 4)',
+	},
+	{
+		name: 'Test 8: Date formatting',
+		input: 'formatDate(prop("Created"), "YYYY-MM-DD")',
+		expected: 'dateformat(Created, "YYYY-MM-DD")',
+	},
+	{
+		name: 'Test 9: today() function',
+		input: 'today()',
+		expected: 'dateonly(now())',
+	},
+	{
+		name: 'Test 10: String operations',
+		input: 'upper(prop("Name"))',
+		expected: 'upper(Name)',
+	},
+	{
+		name: 'Test 11: Comparison operators',
+		input: 'prop("Score") >= 90',
+		expected: '(Score >= 90)',
+	},
+	{
+		name: 'Test 12: Boolean logic',
+		input: 'and(prop("IsActive"), prop("IsVerified"))',
+		expected: 'and(IsActive, IsVerified)',
+	},
+	{
+		name: 'Test 13: Complex nested formula',
+		input: 'if(prop("Price") > 100, concat("$", formatDate(prop("ExpensiveDate"), "MM/DD/YYYY")), concat("$", formatDate(prop("CheapDate"), "MM/DD/YYYY")))',
+		expected: 'if((Price > 100), concat("$", dateformat(ExpensiveDate, "MM/DD/YYYY")), concat("$", dateformat(CheapDate, "MM/DD/YYYY")))',
+	},
+	{
+		name: 'Test 14: Direct property reference',
+		input: 'Name',
+		expected: 'Name',
+	},
+	{
+		name: 'Test 15: String literals with quotes',
+		input: 'concat(prop("Name"), " - ", "Active")',
+		expected: 'concat(Name, " - ", "Active")',
+	},
+	{
+		name: 'Test 16: Numeric literals',
+		input: 'prop("Price") * 1.08',
+		expected: '(Price * 1.08)',
+	},
+	{
+		name: 'Test 17: Boolean literals',
+		input: 'if(prop("IsActive"), true, false)',
+		expected: 'if(IsActive, true, false)',
+	},
+];
+
+console.log('=== Notion Formula Converter Test Suite ===\n');
+
+let passed = 0;
+let failed = 0;
+const failures: string[] = [];
+
+for (const test of testCases) {
+	const result = convertNotionFormula(test.input);
+
+	if (!result.success) {
+		console.log(`❌ ${test.name}`);
+		console.log(`   Input:    ${test.input}`);
+		console.log(`   Error:    ${result.error}`);
+		console.log('');
+		failed++;
+		failures.push(`${test.name}: ${result.error}`);
+		continue;
+	}
+
+	if (result.formula === test.expected) {
+		console.log(`✅ ${test.name}`);
+		passed++;
+	} else {
+		console.log(`❌ ${test.name}`);
+		console.log(`   Input:    ${test.input}`);
+		console.log(`   Expected: ${test.expected}`);
+		console.log(`   Got:      ${result.formula}`);
+		if (result.warnings && result.warnings.length > 0) {
+			console.log(`   Warnings: ${result.warnings.join(', ')}`);
+		}
+		console.log('');
+		failed++;
+		failures.push(`${test.name}: Expected "${test.expected}", got "${result.formula}"`);
+	}
+}
+
+console.log(`\n=== Summary ===`);
+console.log(`Passed: ${passed}/${testCases.length}`);
+console.log(`Failed: ${failed}/${testCases.length}`);
+
+if (failed > 0) {
+	console.log('\n=== Failures ===');
+	failures.forEach(f => console.log(`  - ${f}`));
+}
+
+if (failed === 0) {
+	console.log('\n✅ All tests passed!');
+} else {
+	console.log(`\n❌ ${failed} test(s) failed`);
+}

--- a/tests/notion-api/test-page-title.ts
+++ b/tests/notion-api/test-page-title.ts
@@ -1,0 +1,179 @@
+import type { PageObjectResponse, RichTextItemResponse } from '@notionhq/client/build/src/api-endpoints';
+import * as fs from 'fs';
+import * as path from 'path';
+
+function extractPageTitle(page: PageObjectResponse): string {
+	const properties = page.properties;
+
+	for (const prop of Object.values(properties)) {
+		if (typeof prop === 'object' && prop !== null && 'type' in prop && prop.type === 'title') {
+			if ('title' in prop) {
+				const titleValue = prop.title;
+				if (Array.isArray(titleValue)) {
+					const titleParts = (titleValue as RichTextItemResponse[])
+						.filter(part => part.type === 'text' && 'text' in part && part.text?.content)
+						.map(part => {
+							if (part.type === 'text' && 'text' in part) {
+								return part.text.content;
+							}
+							return '';
+						});
+
+					const result = titleParts.join('');
+					if (result) {
+						return result;
+					}
+				}
+			}
+		}
+	}
+
+	return 'Untitled';
+}
+
+console.log('=== Page Title Extraction Test Suite ===\n');
+
+const mockDataDir = path.join(__dirname, 'mock-data');
+const pagePath = path.join(mockDataDir, 'page-sample.json');
+
+let passed = 0;
+let failed = 0;
+
+try {
+	const pageData = JSON.parse(fs.readFileSync(pagePath, 'utf-8')) as PageObjectResponse;
+	const title = extractPageTitle(pageData);
+	const expected = 'Sample Task';
+
+	if (title === expected) {
+		console.log(`✅ Page title extraction`);
+		console.log(`   Title: "${title}"`);
+		passed++;
+	} else {
+		console.log(`❌ Page title extraction`);
+		console.log(`   Expected: "${expected}"`);
+		console.log(`   Got: "${title}"`);
+		failed++;
+	}
+} catch (error) {
+	console.log(`❌ Page title extraction`);
+	console.log(`   Error: ${error instanceof Error ? error.message : String(error)}`);
+	failed++;
+}
+
+const pageNoTitle: PageObjectResponse = {
+	object: 'page',
+	id: 'test-123',
+	created_time: '2024-01-01T00:00:00.000Z',
+	last_edited_time: '2024-01-01T00:00:00.000Z',
+	properties: {
+		'Name': {
+			id: 'title',
+			type: 'title',
+			title: []
+		}
+	}
+} as any;
+
+try {
+	const title = extractPageTitle(pageNoTitle);
+	const expected = 'Untitled';
+
+	if (title === expected) {
+		console.log(`✅ Page with no title (fallback to "Untitled")`);
+		console.log(`   Title: "${title}"`);
+		passed++;
+	} else {
+		console.log(`❌ Page with no title`);
+		console.log(`   Expected: "${expected}"`);
+		console.log(`   Got: "${title}"`);
+		failed++;
+	}
+} catch (error) {
+	console.log(`❌ Page with no title`);
+	console.log(`   Error: ${error instanceof Error ? error.message : String(error)}`);
+	failed++;
+}
+
+const pageMultipleParts: PageObjectResponse = {
+	object: 'page',
+	id: 'test-456',
+	created_time: '2024-01-01T00:00:00.000Z',
+	last_edited_time: '2024-01-01T00:00:00.000Z',
+	properties: {
+		'Name': {
+			id: 'title',
+			type: 'title',
+			title: [
+				{
+					type: 'text',
+					text: { content: 'First ' },
+					plain_text: 'First ',
+					annotations: {
+						bold: false,
+						italic: false,
+						strikethrough: false,
+						underline: false,
+						code: false,
+						color: 'default'
+					}
+				},
+				{
+					type: 'text',
+					text: { content: 'Second ' },
+					plain_text: 'Second ',
+					annotations: {
+						bold: false,
+						italic: false,
+						strikethrough: false,
+						underline: false,
+						code: false,
+						color: 'default'
+					}
+				},
+				{
+					type: 'text',
+					text: { content: 'Third' },
+					plain_text: 'Third',
+					annotations: {
+						bold: false,
+						italic: false,
+						strikethrough: false,
+						underline: false,
+						code: false,
+						color: 'default'
+					}
+				}
+			]
+		}
+	}
+} as any;
+
+try {
+	const title = extractPageTitle(pageMultipleParts);
+	const expected = 'First Second Third';
+
+	if (title === expected) {
+		console.log(`✅ Page with multiple title parts`);
+		console.log(`   Title: "${title}"`);
+		passed++;
+	} else {
+		console.log(`❌ Page with multiple title parts`);
+		console.log(`   Expected: "${expected}"`);
+		console.log(`   Got: "${title}"`);
+		failed++;
+	}
+} catch (error) {
+	console.log(`❌ Page with multiple title parts`);
+	console.log(`   Error: ${error instanceof Error ? error.message : String(error)}`);
+	failed++;
+}
+
+console.log('\n=== Summary ===');
+console.log(`Passed: ${passed}/3`);
+console.log(`Failed: ${failed}/3`);
+
+if (failed === 0) {
+	console.log('\n✅ All page title extraction tests passed!');
+} else {
+	console.log(`\n❌ ${failed} test(s) failed`);
+}

--- a/tests/notion-api/unit-tests/base-converter.spec.ts
+++ b/tests/notion-api/unit-tests/base-converter.spec.ts
@@ -1,0 +1,355 @@
+import { describe, it, expect } from 'vitest';
+import { convertDatabaseToBase, serializeBaseSchema, createBaseFileContent } from '../../../src/formats/notion-api/base-converter';
+import type { NotionDatabaseWithProperties } from '../../../src/formats/notion-api/notion-types';
+
+describe('Base Converter', () => {
+	describe('convertDatabaseToBase', () => {
+		it('should convert simple database with basic properties', () => {
+			const database: NotionDatabaseWithProperties = {
+				object: 'database',
+				id: 'test-db-123',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				title: [
+					{
+						type: 'text',
+						text: { content: 'Test Database' },
+						plain_text: 'Test Database',
+						annotations: {
+							bold: false,
+							italic: false,
+							strikethrough: false,
+							underline: false,
+							code: false,
+							color: 'default'
+						}
+					}
+				],
+				properties: {
+					'Name': {
+						id: 'title',
+						name: 'Name',
+						type: 'title',
+						title: {}
+					},
+					'Status': {
+						id: 'status',
+						name: 'Status',
+						type: 'select',
+						select: {
+							options: [
+								{ name: 'To Do', color: 'red' },
+								{ name: 'In Progress', color: 'yellow' },
+								{ name: 'Done', color: 'green' }
+							]
+						}
+					}
+				}
+			} as any;
+
+			const result = convertDatabaseToBase(database);
+
+			expect(result.databaseId).toBe('test-db-123');
+			expect(result.databaseTitle).toBe('Test Database');
+			expect(result.schema.version).toBe('1.0');
+			expect(result.schema.filters).toEqual({
+				property: 'notion-database',
+				operator: '=',
+				value: 'test-db-123'
+			});
+			expect(result.schema.properties).toBeDefined();
+			expect(Object.keys(result.schema.properties!)).toHaveLength(2);
+			expect(result.warnings).toEqual([]);
+		});
+
+		it('should convert database with formulas', () => {
+			const database: NotionDatabaseWithProperties = {
+				object: 'database',
+				id: 'formula-db-456',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				title: [
+					{
+						type: 'text',
+						text: { content: 'Formula Test' },
+						plain_text: 'Formula Test',
+						annotations: {
+							bold: false,
+							italic: false,
+							strikethrough: false,
+							underline: false,
+							code: false,
+							color: 'default'
+						}
+					}
+				],
+				properties: {
+					'Price': {
+						id: 'price',
+						name: 'Price',
+						type: 'number',
+						number: { format: 'dollar' }
+					},
+					'Quantity': {
+						id: 'qty',
+						name: 'Quantity',
+						type: 'number',
+						number: {}
+					},
+					'Total': {
+						id: 'total',
+						name: 'Total',
+						type: 'formula',
+						formula: {
+							expression: 'prop("Price") * prop("Quantity")'
+						}
+					}
+				}
+			} as any;
+
+			const result = convertDatabaseToBase(database);
+
+			expect(result.schema.properties).toBeDefined();
+			expect(Object.keys(result.schema.properties!)).toHaveLength(2);
+			expect(result.schema.formulas).toBeDefined();
+			expect(Object.keys(result.schema.formulas!)).toHaveLength(1);
+			expect(result.schema.formulas!['total'].expression).toBe('(Price * Quantity)');
+		});
+
+		it('should handle database with empty title', () => {
+			const database: NotionDatabaseWithProperties = {
+				object: 'database',
+				id: 'empty-title-db',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				title: [],
+				properties: {}
+			} as any;
+
+			const result = convertDatabaseToBase(database);
+
+			expect(result.databaseTitle).toBe('Untitled Database');
+		});
+
+		it('should generate warnings for truly unsupported property types', () => {
+			const database: NotionDatabaseWithProperties = {
+				object: 'database',
+				id: 'unsupported-db',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				title: [{ type: 'text', text: { content: 'Test' }, plain_text: 'Test', annotations: {} as any }],
+				properties: {
+					'FakeType': {
+						id: 'fake',
+						name: 'FakeType',
+						type: 'completely_unsupported_type' as any
+					}
+				}
+			} as any;
+
+			const result = convertDatabaseToBase(database);
+
+			expect(result.warnings.length).toBeGreaterThan(0);
+			expect(result.warnings[0]).toContain('Unsupported property type');
+		});
+	});
+
+	describe('property type mapping', () => {
+		const createDatabase = (propertyType: string, propertyData: any): NotionDatabaseWithProperties => ({
+			object: 'database',
+			id: 'test-id',
+			created_time: '2024-01-01T00:00:00.000Z',
+			last_edited_time: '2024-01-01T00:00:00.000Z',
+			title: [{ type: 'text', text: { content: 'Test' }, plain_text: 'Test', annotations: {} as any }],
+			properties: {
+				'TestProp': {
+					id: 'test-prop',
+					name: 'TestProp',
+					type: propertyType,
+					...propertyData
+				}
+			}
+		} as any);
+
+		it('should map title property to text', () => {
+			const db = createDatabase('title', { title: {} });
+			const result = convertDatabaseToBase(db);
+			expect(result.schema.properties!['test-prop'].type).toBe('text');
+		});
+
+		it('should map rich_text property to text', () => {
+			const db = createDatabase('rich_text', { rich_text: {} });
+			const result = convertDatabaseToBase(db);
+			expect(result.schema.properties!['test-prop'].type).toBe('text');
+		});
+
+		it('should map number property to number', () => {
+			const db = createDatabase('number', { number: {} });
+			const result = convertDatabaseToBase(db);
+			expect(result.schema.properties!['test-prop'].type).toBe('number');
+		});
+
+		it('should map checkbox property to checkbox', () => {
+			const db = createDatabase('checkbox', { checkbox: {} });
+			const result = convertDatabaseToBase(db);
+			expect(result.schema.properties!['test-prop'].type).toBe('checkbox');
+		});
+
+		it('should map date property to date', () => {
+			const db = createDatabase('date', { date: {} });
+			const result = convertDatabaseToBase(db);
+			expect(result.schema.properties!['test-prop'].type).toBe('date');
+		});
+
+		it('should map select property to select with options', () => {
+			const db = createDatabase('select', {
+				select: {
+					options: [
+						{ name: 'Option 1', color: 'blue' },
+						{ name: 'Option 2', color: 'red' }
+					]
+				}
+			});
+			const result = convertDatabaseToBase(db);
+			expect(result.schema.properties!['test-prop'].type).toBe('select');
+			expect(result.schema.properties!['test-prop'].options).toEqual(['Option 1', 'Option 2']);
+		});
+
+		it('should map multi_select property to multi-select with options', () => {
+			const db = createDatabase('multi_select', {
+				multi_select: {
+					options: [
+						{ name: 'Tag 1', color: 'blue' },
+						{ name: 'Tag 2', color: 'green' }
+					]
+				}
+			});
+			const result = convertDatabaseToBase(db);
+			expect(result.schema.properties!['test-prop'].type).toBe('multi-select');
+			expect(result.schema.properties!['test-prop'].options).toEqual(['Tag 1', 'Tag 2']);
+		});
+
+		it('should map url property to link', () => {
+			const db = createDatabase('url', { url: {} });
+			const result = convertDatabaseToBase(db);
+			expect(result.schema.properties!['test-prop'].type).toBe('link');
+		});
+	});
+
+	describe('serializeBaseSchema', () => {
+		it('should serialize schema to valid YAML', () => {
+			const schema = {
+				version: '1.0',
+				filters: {
+					property: 'notion-database',
+					operator: '=' as const,
+					value: 'test-id'
+				},
+				properties: {
+					'name': {
+						type: 'text' as const,
+						name: 'name',
+						displayName: 'Name'
+					}
+				},
+				views: [{ name: 'Table', type: 'table' as const }]
+			};
+
+			const yaml = serializeBaseSchema(schema);
+
+			expect(yaml).toContain('version: "1.0"');
+			expect(yaml).toContain('filters:');
+			expect(yaml).toContain('property: "notion-database"');
+			expect(yaml).toContain('properties:');
+			expect(yaml).toContain('views:');
+		});
+
+		it('should handle formulas in YAML', () => {
+			const schema = {
+				version: '1.0',
+				filters: { property: 'test', operator: '=' as const, value: 'id' },
+				formulas: {
+					'calc': {
+						name: 'calc',
+						displayName: 'Calculation',
+						expression: '(A + B)'
+					}
+				},
+				views: [{ name: 'Table', type: 'table' as const }]
+			};
+
+			const yaml = serializeBaseSchema(schema);
+
+			expect(yaml).toContain('formulas:');
+			expect(yaml).toContain('expression: "(A + B)"');
+		});
+	});
+
+	describe('createBaseFileContent', () => {
+		it('should create markdown with code block and title', () => {
+			const schema = {
+				version: '1.0',
+				filters: { property: 'test', operator: '=' as const, value: 'id' },
+				views: [{ name: 'Table', type: 'table' as const }]
+			};
+
+			const content = createBaseFileContent(schema, 'My Database');
+
+			expect(content).toContain('# My Database');
+			expect(content).toContain('```base');
+			expect(content).toContain('version: "1.0"');
+			expect(content).toContain('```');
+		});
+
+		it('should create markdown without title if not provided', () => {
+			const schema = {
+				version: '1.0',
+				filters: { property: 'test', operator: '=' as const, value: 'id' },
+				views: [{ name: 'Table', type: 'table' as const }]
+			};
+
+			const content = createBaseFileContent(schema);
+
+			expect(content).not.toContain('# ');
+			expect(content).toContain('```base');
+		});
+	});
+
+	describe('edge cases', () => {
+		it('should handle database with no properties', () => {
+			const database: NotionDatabaseWithProperties = {
+				object: 'database',
+				id: 'empty-db',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				title: [{ type: 'text', text: { content: 'Empty' }, plain_text: 'Empty', annotations: {} as any }],
+				properties: {}
+			} as any;
+
+			const result = convertDatabaseToBase(database);
+
+			expect(result.schema.properties).toBeUndefined();
+			expect(result.schema.formulas).toBeUndefined();
+			expect(result.schema.views).toHaveLength(1);
+		});
+
+		it('should handle complex multi-word database title', () => {
+			const database: NotionDatabaseWithProperties = {
+				object: 'database',
+				id: 'test-id',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				title: [
+					{ type: 'text', text: { content: 'My ' }, plain_text: 'My ', annotations: {} as any },
+					{ type: 'text', text: { content: 'Complex ' }, plain_text: 'Complex ', annotations: {} as any },
+					{ type: 'text', text: { content: 'Database' }, plain_text: 'Database', annotations: {} as any }
+				],
+				properties: {}
+			} as any;
+
+			const result = convertDatabaseToBase(database);
+
+			expect(result.databaseTitle).toBe('My Complex Database');
+		});
+	});
+});

--- a/tests/notion-api/unit-tests/block-converter.spec.ts
+++ b/tests/notion-api/unit-tests/block-converter.spec.ts
@@ -1,0 +1,1453 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BlockConverter } from '../../../src/formats/notion-api/block-converter';
+import type { BlockObjectResponse, RichTextItemResponse } from '@notionhq/client/build/src/api-endpoints';
+
+const mockVault = {
+	create: vi.fn(),
+	createBinary: vi.fn(),
+	exists: vi.fn()
+} as any;
+
+const mockClient = {
+	getAllBlockChildren: vi.fn()
+} as any;
+
+describe('BlockConverter', () => {
+	let converter: BlockConverter;
+
+	beforeEach(() => {
+		converter = new BlockConverter(mockClient, mockVault, '/attachments');
+		vi.clearAllMocks();
+	});
+
+	describe('Rich Text Conversion', () => {
+		it('should convert plain text', () => {
+			const richText: RichTextItemResponse[] = [
+				{
+					type: 'text',
+					text: { content: 'Hello world', link: null },
+					plain_text: 'Hello world',
+					href: null,
+					annotations: {
+						bold: false,
+						italic: false,
+						strikethrough: false,
+						underline: false,
+						code: false,
+						color: 'default'
+					}
+				}
+			];
+
+			const result = (converter as any).convertRichText(richText);
+			expect(result).toBe('Hello world');
+		});
+
+		it('should convert bold text', () => {
+			const richText: RichTextItemResponse[] = [
+				{
+					type: 'text',
+					text: { content: 'bold text', link: null },
+					plain_text: 'bold text',
+					href: null,
+					annotations: {
+						bold: true,
+						italic: false,
+						strikethrough: false,
+						underline: false,
+						code: false,
+						color: 'default'
+					}
+				}
+			];
+
+			const result = (converter as any).convertRichText(richText);
+			expect(result).toBe('**bold text**');
+		});
+
+		it('should convert italic text', () => {
+			const richText: RichTextItemResponse[] = [
+				{
+					type: 'text',
+					text: { content: 'italic text', link: null },
+					plain_text: 'italic text',
+					href: null,
+					annotations: {
+						bold: false,
+						italic: true,
+						strikethrough: false,
+						underline: false,
+						code: false,
+						color: 'default'
+					}
+				}
+			];
+
+			const result = (converter as any).convertRichText(richText);
+			expect(result).toBe('*italic text*');
+		});
+
+		it('should convert strikethrough text', () => {
+			const richText: RichTextItemResponse[] = [
+				{
+					type: 'text',
+					text: { content: 'deleted text', link: null },
+					plain_text: 'deleted text',
+					href: null,
+					annotations: {
+						bold: false,
+						italic: false,
+						strikethrough: true,
+						underline: false,
+						code: false,
+						color: 'default'
+					}
+				}
+			];
+
+			const result = (converter as any).convertRichText(richText);
+			expect(result).toBe('~~deleted text~~');
+		});
+
+		it('should convert inline code', () => {
+			const richText: RichTextItemResponse[] = [
+				{
+					type: 'text',
+					text: { content: 'console.log()', link: null },
+					plain_text: 'console.log()',
+					href: null,
+					annotations: {
+						bold: false,
+						italic: false,
+						strikethrough: false,
+						underline: false,
+						code: true,
+						color: 'default'
+					}
+				}
+			];
+
+			const result = (converter as any).convertRichText(richText);
+			expect(result).toBe('`console.log()`');
+		});
+
+		it('should convert text with link', () => {
+			const richText: RichTextItemResponse[] = [
+				{
+					type: 'text',
+					text: {
+						content: 'click here',
+						link: { url: 'https://example.com' }
+					},
+					plain_text: 'click here',
+					href: 'https://example.com',
+					annotations: {
+						bold: false,
+						italic: false,
+						strikethrough: false,
+						underline: false,
+						code: false,
+						color: 'default'
+					}
+				}
+			];
+
+			const result = (converter as any).convertRichText(richText);
+			expect(result).toBe('[click here](https://example.com)');
+		});
+
+		it('should combine multiple formatting styles', () => {
+			const richText: RichTextItemResponse[] = [
+				{
+					type: 'text',
+					text: { content: 'bold italic', link: null },
+					plain_text: 'bold italic',
+					href: null,
+					annotations: {
+						bold: true,
+						italic: true,
+						strikethrough: false,
+						underline: false,
+						code: false,
+						color: 'default'
+					}
+				}
+			];
+
+			const result = (converter as any).convertRichText(richText);
+			expect(result).toBe('***bold italic***');
+		});
+
+		it('should handle multiple rich text parts', () => {
+			const richText: RichTextItemResponse[] = [
+				{
+					type: 'text',
+					text: { content: 'Normal ', link: null },
+					plain_text: 'Normal ',
+					href: null,
+					annotations: {
+						bold: false,
+						italic: false,
+						strikethrough: false,
+						underline: false,
+						code: false,
+						color: 'default'
+					}
+				},
+				{
+					type: 'text',
+					text: { content: 'bold', link: null },
+					plain_text: 'bold',
+					href: null,
+					annotations: {
+						bold: true,
+						italic: false,
+						strikethrough: false,
+						underline: false,
+						code: false,
+						color: 'default'
+					}
+				},
+				{
+					type: 'text',
+					text: { content: ' and ', link: null },
+					plain_text: ' and ',
+					href: null,
+					annotations: {
+						bold: false,
+						italic: false,
+						strikethrough: false,
+						underline: false,
+						code: false,
+						color: 'default'
+					}
+				},
+				{
+					type: 'text',
+					text: { content: 'italic', link: null },
+					plain_text: 'italic',
+					href: null,
+					annotations: {
+						bold: false,
+						italic: true,
+						strikethrough: false,
+						underline: false,
+						code: false,
+						color: 'default'
+					}
+				}
+			];
+
+			const result = (converter as any).convertRichText(richText);
+			expect(result).toBe('Normal **bold** and *italic*');
+		});
+
+		it('should convert equation type', () => {
+			const richText: RichTextItemResponse[] = [
+				{
+					type: 'equation',
+					equation: { expression: 'x^2 + y^2 = z^2' },
+					plain_text: 'x^2 + y^2 = z^2',
+					href: null,
+					annotations: {
+						bold: false,
+						italic: false,
+						strikethrough: false,
+						underline: false,
+						code: false,
+						color: 'default'
+					}
+				}
+			];
+
+			const result = (converter as any).convertRichText(richText);
+			expect(result).toBe('$x^2 + y^2 = z^2$');
+		});
+
+		it('should convert page mention', () => {
+			const richText: RichTextItemResponse[] = [
+				{
+					type: 'mention',
+					mention: {
+						type: 'page',
+						page: { id: 'page-id' }
+					},
+					plain_text: 'Referenced Page',
+					href: null,
+					annotations: {
+						bold: false,
+						italic: false,
+						strikethrough: false,
+						underline: false,
+						code: false,
+						color: 'default'
+					}
+				}
+			];
+
+			const result = (converter as any).convertRichText(richText);
+			expect(result).toBe('[[Referenced Page]]');
+		});
+	});
+
+	describe('Block Type Conversion', () => {
+		it('should convert heading_1 block', () => {
+			const block: BlockObjectResponse = {
+				object: 'block',
+				id: 'block-1',
+				type: 'heading_1',
+				heading_1: {
+					rich_text: [{
+						type: 'text',
+						text: { content: 'Main Title' },
+						plain_text: 'Main Title',
+						annotations: {} as any
+					}],
+					is_toggleable: false,
+					color: 'default'
+				},
+				has_children: false,
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				parent: {} as any
+			} as any;
+
+			const result = (converter as any).convertHeading(block, 1);
+			expect(result).toBe('# Main Title');
+		});
+
+		it('should convert heading_2 block', () => {
+			const block: BlockObjectResponse = {
+				object: 'block',
+				id: 'block-2',
+				type: 'heading_2',
+				heading_2: {
+					rich_text: [{
+						type: 'text',
+						text: { content: 'Section' },
+						plain_text: 'Section',
+						annotations: {} as any
+					}],
+					is_toggleable: false,
+					color: 'default'
+				},
+				has_children: false
+			} as any;
+
+			const result = (converter as any).convertHeading(block, 2);
+			expect(result).toBe('## Section');
+		});
+
+		it('should convert heading_3 block', () => {
+			const block: BlockObjectResponse = {
+				object: 'block',
+				id: 'block-3',
+				type: 'heading_3',
+				heading_3: {
+					rich_text: [{
+						type: 'text',
+						text: { content: 'Subsection' },
+						plain_text: 'Subsection',
+						annotations: {} as any
+					}],
+					is_toggleable: false,
+					color: 'default'
+				},
+				has_children: false
+			} as any;
+
+			const result = (converter as any).convertHeading(block, 3);
+			expect(result).toBe('### Subsection');
+		});
+
+		it('should convert code block', () => {
+			const block: BlockObjectResponse = {
+				object: 'block',
+				id: 'block-code',
+				type: 'code',
+				code: {
+					language: 'typescript',
+					rich_text: [{
+						type: 'text',
+						text: { content: 'const x = 10;' },
+						plain_text: 'const x = 10;',
+						annotations: {} as any
+					}],
+					caption: []
+				},
+				has_children: false
+			} as any;
+
+			const result = (converter as any).convertCode(block);
+			expect(result).toBe('```typescript\nconst x = 10;\n```');
+		});
+
+		it('should convert divider block', async () => {
+			const block: BlockObjectResponse = {
+				object: 'block',
+				id: 'block-divider',
+				type: 'divider',
+				divider: {},
+				has_children: false
+			} as any;
+
+			const context = {
+				vault: mockVault,
+				client: mockClient,
+				attachmentFolder: '/attachments',
+				indentLevel: 0,
+				listCounters: new Map()
+			};
+
+			const result = await (converter as any).convertBlock(block, context);
+			expect(result).toBe('---');
+		});
+
+		it('should convert bookmark block', () => {
+			const block: BlockObjectResponse = {
+				object: 'block',
+				id: 'block-bookmark',
+				type: 'bookmark',
+				bookmark: {
+					url: 'https://example.com',
+					caption: [{
+						type: 'text',
+						text: { content: 'Example Site' },
+						plain_text: 'Example Site',
+						annotations: {} as any
+					}]
+				},
+				has_children: false
+			} as any;
+
+			const result = (converter as any).convertBookmark(block);
+			expect(result).toBe('[Example Site](https://example.com)');
+		});
+
+		it('should convert child_page block', () => {
+			const block: BlockObjectResponse = {
+				object: 'block',
+				id: 'block-child',
+				type: 'child_page',
+				child_page: {
+					title: 'Child Page Name'
+				},
+				has_children: false
+			} as any;
+
+			const result = (converter as any).convertChildPage(block);
+			expect(result).toBe('[[Child Page Name]]');
+		});
+
+		it('should convert equation block', () => {
+			const block: BlockObjectResponse = {
+				object: 'block',
+				id: 'block-eq',
+				type: 'equation',
+				equation: {
+					expression: 'E = mc^2'
+				},
+				has_children: false
+			} as any;
+
+			const result = (converter as any).convertEquation(block);
+			expect(result).toBe('$$\nE = mc^2\n$$');
+		});
+	});
+
+	describe('List Block Conversion', () => {
+		it('should convert bulleted list item', async () => {
+			const block: BlockObjectResponse = {
+				object: 'block',
+				id: 'list-1',
+				type: 'bulleted_list_item',
+				bulleted_list_item: {
+					rich_text: [{
+						type: 'text',
+						text: { content: 'List item' },
+						plain_text: 'List item',
+						annotations: {} as any
+					}],
+					color: 'default'
+				},
+				has_children: false
+			} as any;
+
+			const context = {
+				vault: mockVault,
+				client: mockClient,
+				attachmentFolder: '/attachments',
+				indentLevel: 0,
+				listCounters: new Map()
+			};
+
+			const result = await (converter as any).convertBulletedListItem(block, context, '');
+			expect(result).toBe('- List item');
+		});
+
+		it('should convert numbered list item', async () => {
+			const block: BlockObjectResponse = {
+				object: 'block',
+				id: 'list-2',
+				type: 'numbered_list_item',
+				numbered_list_item: {
+					rich_text: [{
+						type: 'text',
+						text: { content: 'First item' },
+						plain_text: 'First item',
+						annotations: {} as any
+					}],
+					color: 'default'
+				},
+				has_children: false
+			} as any;
+
+			const context = {
+				vault: mockVault,
+				client: mockClient,
+				attachmentFolder: '/attachments',
+				indentLevel: 0,
+				listCounters: new Map()
+			};
+
+			const result = await (converter as any).convertNumberedListItem(block, context, '');
+			expect(result).toBe('1. First item');
+		});
+
+		it('should convert to-do item unchecked', async () => {
+			const block: BlockObjectResponse = {
+				object: 'block',
+				id: 'todo-1',
+				type: 'to_do',
+				to_do: {
+					checked: false,
+					rich_text: [{
+						type: 'text',
+						text: { content: 'Task to do' },
+						plain_text: 'Task to do',
+						annotations: {} as any
+					}],
+					color: 'default'
+				},
+				has_children: false
+			} as any;
+
+			const context = {
+				vault: mockVault,
+				client: mockClient,
+				attachmentFolder: '/attachments',
+				indentLevel: 0,
+				listCounters: new Map()
+			};
+
+			const result = await (converter as any).convertToDo(block, context, '');
+			expect(result).toBe('- [ ] Task to do');
+		});
+
+		it('should convert to-do item checked', async () => {
+			const block: BlockObjectResponse = {
+				object: 'block',
+				id: 'todo-2',
+				type: 'to_do',
+				to_do: {
+					checked: true,
+					rich_text: [{
+						type: 'text',
+						text: { content: 'Completed task' },
+						plain_text: 'Completed task',
+						annotations: {} as any
+					}],
+					color: 'default'
+				},
+				has_children: false
+			} as any;
+
+			const context = {
+				vault: mockVault,
+				client: mockClient,
+				attachmentFolder: '/attachments',
+				indentLevel: 0,
+				listCounters: new Map()
+			};
+
+			const result = await (converter as any).convertToDo(block, context, '');
+			expect(result).toBe('- [x] Completed task');
+		});
+	});
+
+	describe('Quote and Callout Blocks', () => {
+		it('should convert quote block', async () => {
+			const block: BlockObjectResponse = {
+				object: 'block',
+				id: 'quote-1',
+				type: 'quote',
+				quote: {
+					rich_text: [{
+						type: 'text',
+						text: { content: 'Important quote' },
+						plain_text: 'Important quote',
+						annotations: {} as any
+					}],
+					color: 'default'
+				},
+				has_children: false
+			} as any;
+
+			mockClient.getAllBlockChildren.mockResolvedValue([]);
+
+			const context = {
+				vault: mockVault,
+				client: mockClient,
+				attachmentFolder: '/attachments',
+				indentLevel: 0,
+				listCounters: new Map()
+			};
+
+			const result = await (converter as any).convertQuote(block, context);
+			expect(result).toBe('> Important quote');
+		});
+
+		it('should convert callout block with emoji', async () => {
+			const block: BlockObjectResponse = {
+				object: 'block',
+				id: 'callout-1',
+				type: 'callout',
+				callout: {
+					icon: {
+						type: 'emoji',
+						emoji: '💡'
+					},
+					rich_text: [{
+						type: 'text',
+						text: { content: 'Tip' },
+						plain_text: 'Tip',
+						annotations: {} as any
+					}],
+					color: 'default'
+				},
+				has_children: false
+			} as any;
+
+			mockClient.getAllBlockChildren.mockResolvedValue([]);
+
+			const context = {
+				vault: mockVault,
+				client: mockClient,
+				attachmentFolder: '/attachments',
+				indentLevel: 0,
+				listCounters: new Map()
+			};
+
+			const result = await (converter as any).convertCallout(block, context);
+			expect(result).toBe('> [!note] 💡\n> Tip');
+		});
+	});
+
+	describe('Edge Cases', () => {
+		it('should handle empty rich text', () => {
+			const richText: RichTextItemResponse[] = [];
+			const result = (converter as any).convertRichText(richText);
+			expect(result).toBe('');
+		});
+
+		it('should handle rich text with no content', () => {
+			const richText: RichTextItemResponse[] = [
+				{
+					type: 'text',
+					text: { content: '', link: null },
+					plain_text: '',
+					href: null,
+					annotations: {} as any
+				}
+			];
+			const result = (converter as any).convertRichText(richText);
+			expect(result).toBe('');
+		});
+
+		it('should handle unsupported block type', async () => {
+			const block = {
+				object: 'block',
+				id: 'unsupported',
+				type: 'unsupported_type',
+				has_children: false
+			} as any;
+
+			const context = {
+				vault: mockVault,
+				client: mockClient,
+				attachmentFolder: '/attachments',
+				indentLevel: 0,
+				listCounters: new Map()
+			};
+
+			const result = await (converter as any).convertBlock(block, context);
+			expect(result).toContain('<!-- Unsupported block type: unsupported_type -->');
+		});
+	});
+
+	describe('Filename Extraction', () => {
+		it('should extract filename from URL', () => {
+			const url = 'https://example.com/path/to/file.png';
+			const result = (converter as any).extractFilenameFromUrl(url);
+			expect(result).toBe('file.png');
+		});
+
+		it('should handle URL with query parameters', () => {
+			const url = 'https://example.com/image.jpg?size=large';
+			const result = (converter as any).extractFilenameFromUrl(url);
+			expect(result).toBe('image.jpg');
+		});
+
+		it('should handle URL with encoded characters', () => {
+			const url = 'https://example.com/my%20file.pdf';
+			const result = (converter as any).extractFilenameFromUrl(url);
+			expect(result).toBe('my file.pdf');
+		});
+
+		it('should return default filename for invalid URL', () => {
+			const url = 'not-a-url';
+			const result = (converter as any).extractFilenameFromUrl(url);
+			expect(result).toBe('attachment');
+		});
+	});
+
+	describe('Table Conversion', () => {
+		it('should convert table with column headers', async () => {
+			const tableBlock: BlockObjectResponse = {
+				object: 'block',
+				id: 'table-1',
+				type: 'table',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: true,
+				archived: false,
+				in_trash: false,
+				table: {
+					table_width: 3,
+					has_column_header: true,
+					has_row_header: false
+				},
+				parent: { type: 'page_id', page_id: 'page-1' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			const row1: BlockObjectResponse = {
+				object: 'block',
+				id: 'row-1',
+				type: 'table_row',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: false,
+				archived: false,
+				in_trash: false,
+				table_row: {
+					cells: [
+						[{ type: 'text', text: { content: 'Name' }, plain_text: 'Name', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' } }],
+						[{ type: 'text', text: { content: 'Age' }, plain_text: 'Age', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' } }],
+						[{ type: 'text', text: { content: 'City' }, plain_text: 'City', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' } }]
+					]
+				},
+				parent: { type: 'block_id', block_id: 'table-1' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			const row2: BlockObjectResponse = {
+				object: 'block',
+				id: 'row-2',
+				type: 'table_row',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: false,
+				archived: false,
+				in_trash: false,
+				table_row: {
+					cells: [
+						[{ type: 'text', text: { content: 'John' }, plain_text: 'John', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' } }],
+						[{ type: 'text', text: { content: '30' }, plain_text: '30', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' } }],
+						[{ type: 'text', text: { content: 'NYC' }, plain_text: 'NYC', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' } }]
+					]
+				},
+				parent: { type: 'block_id', block_id: 'table-1' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			mockClient.getAllBlockChildren.mockResolvedValue([row1, row2]);
+
+			const context = { vault: mockVault, client: mockClient, attachmentFolder: '/attachments', indentLevel: 0, listCounters: new Map() };
+			const result = await (converter as any).convertTable(tableBlock, context);
+
+			expect(result).toBe('| Name | Age | City |\n| --- | --- | --- |\n| John | 30 | NYC |');
+		});
+
+		it('should convert table without headers', async () => {
+			const tableBlock: BlockObjectResponse = {
+				object: 'block',
+				id: 'table-2',
+				type: 'table',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: true,
+				archived: false,
+				in_trash: false,
+				table: {
+					table_width: 2,
+					has_column_header: false,
+					has_row_header: false
+				},
+				parent: { type: 'page_id', page_id: 'page-1' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			const row: BlockObjectResponse = {
+				object: 'block',
+				id: 'row-1',
+				type: 'table_row',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: false,
+				archived: false,
+				in_trash: false,
+				table_row: {
+					cells: [
+						[{ type: 'text', text: { content: 'A' }, plain_text: 'A', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' } }],
+						[{ type: 'text', text: { content: 'B' }, plain_text: 'B', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' } }]
+					]
+				},
+				parent: { type: 'block_id', block_id: 'table-2' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			mockClient.getAllBlockChildren.mockResolvedValue([row]);
+
+			const context = { vault: mockVault, client: mockClient, attachmentFolder: '/attachments', indentLevel: 0, listCounters: new Map() };
+			const result = await (converter as any).convertTable(tableBlock, context);
+
+			expect(result).toBe('| A | B |');
+		});
+
+		it('should handle empty table cells', async () => {
+			const tableBlock: BlockObjectResponse = {
+				object: 'block',
+				id: 'table-3',
+				type: 'table',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: true,
+				archived: false,
+				in_trash: false,
+				table: {
+					table_width: 2,
+					has_column_header: true,
+					has_row_header: false
+				},
+				parent: { type: 'page_id', page_id: 'page-1' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			const row: BlockObjectResponse = {
+				object: 'block',
+				id: 'row-1',
+				type: 'table_row',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: false,
+				archived: false,
+				in_trash: false,
+				table_row: {
+					cells: [
+						[{ type: 'text', text: { content: 'A' }, plain_text: 'A', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' } }],
+						[]
+					]
+				},
+				parent: { type: 'block_id', block_id: 'table-3' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			mockClient.getAllBlockChildren.mockResolvedValue([row]);
+
+			const context = { vault: mockVault, client: mockClient, attachmentFolder: '/attachments', indentLevel: 0, listCounters: new Map() };
+			const result = await (converter as any).convertTable(tableBlock, context);
+
+			expect(result).toBe('| A |  |\n| --- | --- |');
+		});
+
+		it('should return empty string for table with no rows', async () => {
+			const tableBlock: BlockObjectResponse = {
+				object: 'block',
+				id: 'table-4',
+				type: 'table',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: true,
+				archived: false,
+				in_trash: false,
+				table: {
+					table_width: 2,
+					has_column_header: false,
+					has_row_header: false
+				},
+				parent: { type: 'page_id', page_id: 'page-1' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			mockClient.getAllBlockChildren.mockResolvedValue([]);
+
+			const context = { vault: mockVault, client: mockClient, attachmentFolder: '/attachments', indentLevel: 0, listCounters: new Map() };
+			const result = await (converter as any).convertTable(tableBlock, context);
+
+			expect(result).toBe('');
+		});
+	});
+
+	describe('Image Conversion', () => {
+		it('should convert external image to markdown embed', async () => {
+			const imageBlock: BlockObjectResponse = {
+				object: 'block',
+				id: 'image-1',
+				type: 'image',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: false,
+				archived: false,
+				in_trash: false,
+				image: {
+					type: 'external',
+					external: {
+						url: 'https://example.com/image.png'
+					},
+					caption: []
+				},
+				parent: { type: 'page_id', page_id: 'page-1' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			mockVault.createBinary.mockResolvedValue(undefined);
+			global.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				arrayBuffer: async () => new ArrayBuffer(0)
+			});
+
+			const context = { vault: mockVault, client: mockClient, attachmentFolder: '/attachments', indentLevel: 0, listCounters: new Map() };
+			const result = await (converter as any).convertImage(imageBlock, context);
+
+			expect(result).toBe('![](image.png)');
+			expect(mockVault.createBinary).toHaveBeenCalled();
+		});
+
+		it('should convert uploaded image with file URL', async () => {
+			const imageBlock: BlockObjectResponse = {
+				object: 'block',
+				id: 'image-2',
+				type: 'image',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: false,
+				archived: false,
+				in_trash: false,
+				image: {
+					type: 'file',
+					file: {
+						url: 'https://notion.so/signed/file.jpg',
+						expiry_time: '2024-01-02T00:00:00.000Z'
+					},
+					caption: []
+				},
+				parent: { type: 'page_id', page_id: 'page-1' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			mockVault.createBinary.mockResolvedValue(undefined);
+			global.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				arrayBuffer: async () => new ArrayBuffer(0)
+			});
+
+			const context = { vault: mockVault, client: mockClient, attachmentFolder: '/attachments', indentLevel: 0, listCounters: new Map() };
+			const result = await (converter as any).convertImage(imageBlock, context);
+
+			expect(result).toBe('![](file.jpg)');
+		});
+
+		it('should include caption in image markdown', async () => {
+			const imageBlock: BlockObjectResponse = {
+				object: 'block',
+				id: 'image-3',
+				type: 'image',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: false,
+				archived: false,
+				in_trash: false,
+				image: {
+					type: 'external',
+					external: {
+						url: 'https://example.com/photo.jpg'
+					},
+					caption: [
+						{ type: 'text', text: { content: 'My Photo' }, plain_text: 'My Photo', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' } }
+					]
+				},
+				parent: { type: 'page_id', page_id: 'page-1' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			mockVault.createBinary.mockResolvedValue(undefined);
+			global.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				arrayBuffer: async () => new ArrayBuffer(0)
+			});
+
+			const context = { vault: mockVault, client: mockClient, attachmentFolder: '/attachments', indentLevel: 0, listCounters: new Map() };
+			const result = await (converter as any).convertImage(imageBlock, context);
+
+			expect(result).toBe('![My Photo](photo.jpg)');
+		});
+
+		it('should fallback to URL if download fails', async () => {
+			const imageBlock: BlockObjectResponse = {
+				object: 'block',
+				id: 'image-4',
+				type: 'image',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: false,
+				archived: false,
+				in_trash: false,
+				image: {
+					type: 'external',
+					external: {
+						url: 'https://example.com/image.png'
+					},
+					caption: []
+				},
+				parent: { type: 'page_id', page_id: 'page-1' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			global.fetch = vi.fn().mockResolvedValue({
+				ok: false
+			});
+
+			const context = { vault: mockVault, client: mockClient, attachmentFolder: '/attachments', indentLevel: 0, listCounters: new Map() };
+			const result = await (converter as any).convertImage(imageBlock, context);
+
+			expect(result).toBe('![](https://example.com/image.png)');
+		});
+
+		it('should return empty string for image without URL', async () => {
+			const imageBlock: BlockObjectResponse = {
+				object: 'block',
+				id: 'image-5',
+				type: 'image',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: false,
+				archived: false,
+				in_trash: false,
+				image: {
+					type: 'external',
+					external: {
+						url: ''
+					},
+					caption: []
+				},
+				parent: { type: 'page_id', page_id: 'page-1' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			const context = { vault: mockVault, client: mockClient, attachmentFolder: '/attachments', indentLevel: 0, listCounters: new Map() };
+			const result = await (converter as any).convertImage(imageBlock, context);
+
+			expect(result).toBe('');
+		});
+	});
+
+	describe('File Attachment Conversion', () => {
+		it('should convert external file attachment', async () => {
+			const fileBlock: BlockObjectResponse = {
+				object: 'block',
+				id: 'file-1',
+				type: 'file',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: false,
+				archived: false,
+				in_trash: false,
+				file: {
+					type: 'external',
+					external: {
+						url: 'https://example.com/document.pdf'
+					},
+					caption: []
+				},
+				parent: { type: 'page_id', page_id: 'page-1' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			mockVault.createBinary.mockResolvedValue(undefined);
+			global.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				arrayBuffer: async () => new ArrayBuffer(0)
+			});
+
+			const context = { vault: mockVault, client: mockClient, attachmentFolder: '/attachments', indentLevel: 0, listCounters: new Map() };
+			const result = await (converter as any).convertFile(fileBlock, context);
+
+			expect(result).toBe('[document.pdf](document.pdf)');
+			expect(mockVault.createBinary).toHaveBeenCalled();
+		});
+
+		it('should convert uploaded file with caption', async () => {
+			const fileBlock: BlockObjectResponse = {
+				object: 'block',
+				id: 'file-2',
+				type: 'file',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: false,
+				archived: false,
+				in_trash: false,
+				file: {
+					type: 'file',
+					file: {
+						url: 'https://notion.so/signed/report.docx',
+						expiry_time: '2024-01-02T00:00:00.000Z'
+					},
+					caption: [
+						{ type: 'text', text: { content: 'Monthly Report' }, plain_text: 'Monthly Report', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' } }
+					]
+				},
+				parent: { type: 'page_id', page_id: 'page-1' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			mockVault.createBinary.mockResolvedValue(undefined);
+			global.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				arrayBuffer: async () => new ArrayBuffer(0)
+			});
+
+			const context = { vault: mockVault, client: mockClient, attachmentFolder: '/attachments', indentLevel: 0, listCounters: new Map() };
+			const result = await (converter as any).convertFile(fileBlock, context);
+
+			expect(result).toBe('[Monthly Report](Monthly_Report)');
+		});
+
+		it('should fallback to URL if file download fails', async () => {
+			const fileBlock: BlockObjectResponse = {
+				object: 'block',
+				id: 'file-3',
+				type: 'file',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: false,
+				archived: false,
+				in_trash: false,
+				file: {
+					type: 'external',
+					external: {
+						url: 'https://example.com/video.mp4'
+					},
+					caption: []
+				},
+				parent: { type: 'page_id', page_id: 'page-1' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			global.fetch = vi.fn().mockResolvedValue({
+				ok: false
+			});
+
+			const context = { vault: mockVault, client: mockClient, attachmentFolder: '/attachments', indentLevel: 0, listCounters: new Map() };
+			const result = await (converter as any).convertFile(fileBlock, context);
+
+			expect(result).toBe('[video.mp4](https://example.com/video.mp4)');
+		});
+
+		it('should return empty string for file without URL', async () => {
+			const fileBlock: BlockObjectResponse = {
+				object: 'block',
+				id: 'file-4',
+				type: 'file',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: false,
+				archived: false,
+				in_trash: false,
+				file: {
+					type: 'external',
+					external: {
+						url: ''
+					},
+					caption: []
+				},
+				parent: { type: 'page_id', page_id: 'page-1' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			const context = { vault: mockVault, client: mockClient, attachmentFolder: '/attachments', indentLevel: 0, listCounters: new Map() };
+			const result = await (converter as any).convertFile(fileBlock, context);
+
+			expect(result).toBe('');
+		});
+	});
+
+	describe('Toggle Block Conversion', () => {
+		it('should convert toggle block without children', async () => {
+			const toggleBlock: BlockObjectResponse = {
+				object: 'block',
+				id: 'toggle-1',
+				type: 'toggle',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: false,
+				archived: false,
+				in_trash: false,
+				toggle: {
+					rich_text: [
+						{ type: 'text', text: { content: 'Click to expand' }, plain_text: 'Click to expand', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' } }
+					],
+					color: 'default'
+				},
+				parent: { type: 'page_id', page_id: 'page-1' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			const context = { vault: mockVault, client: mockClient, attachmentFolder: '/attachments', indentLevel: 0, listCounters: new Map() };
+			const result = await (converter as any).convertToggle(toggleBlock, context, '');
+
+			expect(result).toBe('- Click to expand');
+		});
+
+		it('should convert toggle block with nested content', async () => {
+			const toggleBlock: BlockObjectResponse = {
+				object: 'block',
+				id: 'toggle-2',
+				type: 'toggle',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: true,
+				archived: false,
+				in_trash: false,
+				toggle: {
+					rich_text: [
+						{ type: 'text', text: { content: 'Details' }, plain_text: 'Details', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' } }
+					],
+					color: 'default'
+				},
+				parent: { type: 'page_id', page_id: 'page-1' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			const childBlock: BlockObjectResponse = {
+				object: 'block',
+				id: 'para-1',
+				type: 'paragraph',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: false,
+				archived: false,
+				in_trash: false,
+				paragraph: {
+					rich_text: [
+						{ type: 'text', text: { content: 'Hidden content' }, plain_text: 'Hidden content', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' } }
+					],
+					color: 'default'
+				},
+				parent: { type: 'block_id', block_id: 'toggle-2' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			mockClient.getAllBlockChildren.mockResolvedValue([childBlock]);
+
+			const context = { vault: mockVault, client: mockClient, attachmentFolder: '/attachments', indentLevel: 0, listCounters: new Map() };
+			const result = await (converter as any).convertToggle(toggleBlock, context, '');
+
+			expect(result).toBe('- Details\n  Hidden content');
+		});
+	});
+
+	describe('Child References', () => {
+		it('should convert child page reference', () => {
+			const childPageBlock: BlockObjectResponse = {
+				object: 'block',
+				id: 'child-page-1',
+				type: 'child_page',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: false,
+				archived: false,
+				in_trash: false,
+				child_page: {
+					title: 'Sub Page'
+				},
+				parent: { type: 'page_id', page_id: 'page-1' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			const result = (converter as any).convertChildPage(childPageBlock);
+			expect(result).toBe('[[Sub Page]]');
+		});
+
+		it('should convert child database reference', () => {
+			const childDbBlock: BlockObjectResponse = {
+				object: 'block',
+				id: 'child-db-1',
+				type: 'child_database',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: false,
+				archived: false,
+				in_trash: false,
+				child_database: {
+					title: 'Projects'
+				},
+				parent: { type: 'page_id', page_id: 'page-1' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			const result = (converter as any).convertChildDatabase(childDbBlock);
+			expect(result).toBe('[[Projects]]');
+		});
+	});
+
+	describe('Link and Bookmark Conversion', () => {
+		it('should convert bookmark with URL and caption', () => {
+			const bookmarkBlock: BlockObjectResponse = {
+				object: 'block',
+				id: 'bookmark-1',
+				type: 'bookmark',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: false,
+				archived: false,
+				in_trash: false,
+				bookmark: {
+					url: 'https://example.com',
+					caption: [
+						{ type: 'text', text: { content: 'Example Site' }, plain_text: 'Example Site', annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' } }
+					]
+				},
+				parent: { type: 'page_id', page_id: 'page-1' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			const result = (converter as any).convertBookmark(bookmarkBlock);
+			expect(result).toBe('[Example Site](https://example.com)');
+		});
+
+		it('should convert bookmark without caption', () => {
+			const bookmarkBlock: BlockObjectResponse = {
+				object: 'block',
+				id: 'bookmark-2',
+				type: 'bookmark',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: false,
+				archived: false,
+				in_trash: false,
+				bookmark: {
+					url: 'https://github.com',
+					caption: []
+				},
+				parent: { type: 'page_id', page_id: 'page-1' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			const result = (converter as any).convertBookmark(bookmarkBlock);
+			expect(result).toBe('[https://github.com](https://github.com)');
+		});
+
+		it('should convert link preview', () => {
+			const linkPreviewBlock: BlockObjectResponse = {
+				object: 'block',
+				id: 'link-1',
+				type: 'link_preview',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: false,
+				archived: false,
+				in_trash: false,
+				link_preview: {
+					url: 'https://obsidian.md'
+				},
+				parent: { type: 'page_id', page_id: 'page-1' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			const result = (converter as any).convertLinkPreview(linkPreviewBlock);
+			expect(result).toBe('[Link](https://obsidian.md)');
+		});
+	});
+
+	describe('Equation Conversion', () => {
+		it('should convert block equation', () => {
+			const equationBlock: BlockObjectResponse = {
+				object: 'block',
+				id: 'eq-1',
+				type: 'equation',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: false,
+				archived: false,
+				in_trash: false,
+				equation: {
+					expression: 'E = mc^2'
+				},
+				parent: { type: 'page_id', page_id: 'page-1' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			const result = (converter as any).convertEquation(equationBlock);
+			expect(result).toBe('$$\nE = mc^2\n$$');
+		});
+
+		it('should handle complex equation', () => {
+			const equationBlock: BlockObjectResponse = {
+				object: 'block',
+				id: 'eq-2',
+				type: 'equation',
+				created_time: '2024-01-01T00:00:00.000Z',
+				last_edited_time: '2024-01-01T00:00:00.000Z',
+				has_children: false,
+				archived: false,
+				in_trash: false,
+				equation: {
+					expression: '\\int_{0}^{\\infty} e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}'
+				},
+				parent: { type: 'page_id', page_id: 'page-1' },
+				created_by: { object: 'user', id: 'user-1' },
+				last_edited_by: { object: 'user', id: 'user-1' }
+			} as any;
+
+			const result = (converter as any).convertEquation(equationBlock);
+			expect(result).toBe('$$\n\\int_{0}^{\\infty} e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}\n$$');
+		});
+	});
+});

--- a/tests/notion-api/unit-tests/formula-converter.spec.ts
+++ b/tests/notion-api/unit-tests/formula-converter.spec.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect } from 'vitest';
+import { convertNotionFormula } from '../../../src/formats/notion-api/formula-converter';
+
+describe('Formula Converter', () => {
+	describe('prop() function handling', () => {
+		it('should convert simple prop() reference', () => {
+			const result = convertNotionFormula('prop("Name")');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('Name');
+		});
+
+		it('should convert prop() with spaces in property name', () => {
+			const result = convertNotionFormula('prop("First Name")');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('First Name');
+		});
+
+		it('should convert prop() in conditional', () => {
+			const result = convertNotionFormula('if(prop("Status") == "Done", true, false)');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('if((Status == "Done"), true, false)');
+		});
+
+		it('should convert prop() in arithmetic operations', () => {
+			const result = convertNotionFormula('prop("Price") * prop("Quantity")');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('(Price * Quantity)');
+		});
+
+		it('should convert multiple prop() in concat', () => {
+			const result = convertNotionFormula('concat(prop("FirstName"), " ", prop("LastName"))');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('concat(FirstName, " ", LastName)');
+		});
+	});
+
+	describe('arithmetic functions', () => {
+		it('should convert add() with two arguments to operator', () => {
+			const result = convertNotionFormula('add(prop("A"), prop("B"))');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('(A + B)');
+		});
+
+		it('should convert add() with multiple arguments to sum()', () => {
+			const result = convertNotionFormula('add(1, 2, 3, 4)');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('sum(1, 2, 3, 4)');
+		});
+
+		it('should convert subtract() function', () => {
+			const result = convertNotionFormula('subtract(10, 5)');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('(10 - 5)');
+		});
+
+		it('should convert multiply() function', () => {
+			const result = convertNotionFormula('multiply(prop("Price"), 1.08)');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('(Price * 1.08)');
+		});
+
+		it('should convert divide() function', () => {
+			const result = convertNotionFormula('divide(100, 4)');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('(100 / 4)');
+		});
+	});
+
+	describe('date functions', () => {
+		it('should convert formatDate() to dateformat()', () => {
+			const result = convertNotionFormula('formatDate(prop("Created"), "YYYY-MM-DD")');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('dateformat(Created, "YYYY-MM-DD")');
+		});
+
+		it('should convert today() to dateonly(now())', () => {
+			const result = convertNotionFormula('today()');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('dateonly(now())');
+		});
+
+		it('should convert now() function', () => {
+			const result = convertNotionFormula('now()');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('now()');
+		});
+
+		it('should convert dateAdd() to dateadd()', () => {
+			const result = convertNotionFormula('dateAdd(prop("StartDate"), 7, "days")');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('dateadd(StartDate, 7, "days")');
+		});
+	});
+
+	describe('string functions', () => {
+		it('should convert upper() function', () => {
+			const result = convertNotionFormula('upper(prop("Name"))');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('upper(Name)');
+		});
+
+		it('should convert lower() function', () => {
+			const result = convertNotionFormula('lower(prop("Name"))');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('lower(Name)');
+		});
+
+		it('should convert concat() function', () => {
+			const result = convertNotionFormula('concat("Hello", " ", "World")');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('concat("Hello", " ", "World")');
+		});
+
+		it('should convert length() function', () => {
+			const result = convertNotionFormula('length(prop("Text"))');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('length(Text)');
+		});
+	});
+
+	describe('comparison operators', () => {
+		it('should convert >= operator', () => {
+			const result = convertNotionFormula('prop("Score") >= 90');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('(Score >= 90)');
+		});
+
+		it('should convert > operator', () => {
+			const result = convertNotionFormula('prop("Value") > 100');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('(Value > 100)');
+		});
+
+		it('should convert <= operator', () => {
+			const result = convertNotionFormula('prop("Count") <= 5');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('(Count <= 5)');
+		});
+
+		it('should convert < operator', () => {
+			const result = convertNotionFormula('prop("Age") < 18');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('(Age < 18)');
+		});
+
+		it('should convert == operator', () => {
+			const result = convertNotionFormula('prop("Status") == "Active"');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('(Status == "Active")');
+		});
+
+		it('should convert != operator', () => {
+			const result = convertNotionFormula('prop("Type") != "Draft"');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('(Type != "Draft")');
+		});
+	});
+
+	describe('boolean logic', () => {
+		it('should convert and() function', () => {
+			const result = convertNotionFormula('and(prop("IsActive"), prop("IsVerified"))');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('and(IsActive, IsVerified)');
+		});
+
+		it('should convert or() function', () => {
+			const result = convertNotionFormula('or(prop("IsPremium"), prop("IsTrial"))');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('or(IsPremium, IsTrial)');
+		});
+
+		it('should convert not() function', () => {
+			const result = convertNotionFormula('not(prop("IsDeleted"))');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('not(IsDeleted)');
+		});
+
+		it('should convert if() function', () => {
+			const result = convertNotionFormula('if(prop("IsActive"), "Yes", "No")');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('if(IsActive, "Yes", "No")');
+		});
+	});
+
+	describe('complex nested formulas', () => {
+		it('should convert deeply nested if statement', () => {
+			const input = 'if(prop("Price") > 100, concat("$", formatDate(prop("ExpensiveDate"), "MM/DD/YYYY")), concat("$", formatDate(prop("CheapDate"), "MM/DD/YYYY")))';
+			const expected = 'if((Price > 100), concat("$", dateformat(ExpensiveDate, "MM/DD/YYYY")), concat("$", dateformat(CheapDate, "MM/DD/YYYY")))';
+			const result = convertNotionFormula(input);
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe(expected);
+		});
+
+		it('should convert nested ifs function', () => {
+			const input = 'if(prop("Price") >= 100, "Premium", if(prop("Price") >= 50, "Standard", "Budget"))';
+			const expected = 'if((Price >= 100), "Premium", if((Price >= 50), "Standard", "Budget"))';
+			const result = convertNotionFormula(input);
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe(expected);
+		});
+	});
+
+	describe('edge cases', () => {
+		it('should handle direct property reference (no prop() wrapper)', () => {
+			const result = convertNotionFormula('Name');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('Name');
+		});
+
+		it('should handle string literals with quotes', () => {
+			const result = convertNotionFormula('concat(prop("Name"), " - ", "Active")');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('concat(Name, " - ", "Active")');
+		});
+
+		it('should handle numeric literals', () => {
+			const result = convertNotionFormula('prop("Price") * 1.08');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('(Price * 1.08)');
+		});
+
+		it('should handle boolean literals', () => {
+			const result = convertNotionFormula('if(prop("IsActive"), true, false)');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('if(IsActive, true, false)');
+		});
+
+		it('should handle empty formula', () => {
+			const result = convertNotionFormula('');
+			expect(result.success).toBe(false);
+			expect(result.error).toBeDefined();
+		});
+
+		it('should handle malformed formula', () => {
+			const result = convertNotionFormula('prop(');
+			expect(result.success).toBe(false);
+			expect(result.error).toBeDefined();
+		});
+	});
+
+	describe('list functions', () => {
+		it('should convert at() function', () => {
+			const result = convertNotionFormula('at(prop("Tags"), 0)');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('at(Tags, 0)');
+		});
+
+		it('should convert first() function', () => {
+			const result = convertNotionFormula('first(prop("Items"))');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('first(Items)');
+		});
+
+		it('should convert last() function', () => {
+			const result = convertNotionFormula('last(prop("Items"))');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('last(Items)');
+		});
+	});
+
+	describe('math functions', () => {
+		it('should convert round() function', () => {
+			const result = convertNotionFormula('round(prop("Value"))');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('round(Value)');
+		});
+
+		it('should convert ceil() function', () => {
+			const result = convertNotionFormula('ceil(prop("Value"))');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('ceil(Value)');
+		});
+
+		it('should convert floor() function', () => {
+			const result = convertNotionFormula('floor(prop("Value"))');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('floor(Value)');
+		});
+
+		it('should convert abs() function', () => {
+			const result = convertNotionFormula('abs(prop("Difference"))');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('abs(Difference)');
+		});
+
+		it('should convert sqrt() function', () => {
+			const result = convertNotionFormula('sqrt(prop("Area"))');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('sqrt(Area)');
+		});
+
+		it('should convert pow() function', () => {
+			const result = convertNotionFormula('pow(prop("Base"), 2)');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('pow(Base, 2)');
+		});
+
+		it('should convert min() function', () => {
+			const result = convertNotionFormula('min(prop("A"), prop("B"))');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('min(A, B)');
+		});
+
+		it('should convert max() function', () => {
+			const result = convertNotionFormula('max(prop("A"), prop("B"))');
+			expect(result.success).toBe(true);
+			expect(result.formula).toBe('max(A, B)');
+		});
+	});
+});

--- a/tests/notion-api/unit-tests/notion-types.spec.ts
+++ b/tests/notion-api/unit-tests/notion-types.spec.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from 'vitest';
+import {
+	isDatabaseObject,
+	isSelectProperty,
+	isMultiSelectProperty,
+	isStatusProperty,
+	isFormulaProperty,
+	PROPERTY_TYPE_MAPPINGS
+} from '../../../src/formats/notion-api/notion-types';
+
+describe('Notion Types', () => {
+	describe('isDatabaseObject', () => {
+		it('should return true for database object', () => {
+			const obj = { object: 'database', id: 'test' };
+			expect(isDatabaseObject(obj)).toBe(true);
+		});
+
+		it('should return true for data_source object', () => {
+			const obj = { object: 'data_source', id: 'test' };
+			expect(isDatabaseObject(obj)).toBe(true);
+		});
+
+		it('should return false for page object', () => {
+			const obj = { object: 'page', id: 'test' };
+			expect(isDatabaseObject(obj)).toBe(false);
+		});
+
+		it('should return false for undefined object', () => {
+			const obj = { id: 'test' };
+			expect(isDatabaseObject(obj as any)).toBe(false);
+		});
+	});
+
+	describe('isSelectProperty', () => {
+		it('should return true for select property', () => {
+			const prop = {
+				id: 'test',
+				name: 'Status',
+				type: 'select',
+				select: {
+					options: []
+				}
+			};
+			expect(isSelectProperty(prop as any)).toBe(true);
+		});
+
+		it('should return false for non-select property', () => {
+			const prop = {
+				id: 'test',
+				name: 'Name',
+				type: 'title',
+				title: {}
+			};
+			expect(isSelectProperty(prop as any)).toBe(false);
+		});
+
+		it('should return false for select type without select field', () => {
+			const prop = {
+				id: 'test',
+				name: 'Status',
+				type: 'select'
+			};
+			expect(isSelectProperty(prop as any)).toBe(false);
+		});
+	});
+
+	describe('isMultiSelectProperty', () => {
+		it('should return true for multi_select property', () => {
+			const prop = {
+				id: 'test',
+				name: 'Tags',
+				type: 'multi_select',
+				multi_select: {
+					options: []
+				}
+			};
+			expect(isMultiSelectProperty(prop as any)).toBe(true);
+		});
+
+		it('should return false for select property', () => {
+			const prop = {
+				id: 'test',
+				name: 'Status',
+				type: 'select',
+				select: { options: [] }
+			};
+			expect(isMultiSelectProperty(prop as any)).toBe(false);
+		});
+	});
+
+	describe('isStatusProperty', () => {
+		it('should return true for status property', () => {
+			const prop = {
+				id: 'test',
+				name: 'Progress',
+				type: 'status',
+				status: {
+					options: []
+				}
+			};
+			expect(isStatusProperty(prop as any)).toBe(true);
+		});
+
+		it('should return false for non-status property', () => {
+			const prop = {
+				id: 'test',
+				name: 'Name',
+				type: 'title',
+				title: {}
+			};
+			expect(isStatusProperty(prop as any)).toBe(false);
+		});
+	});
+
+	describe('isFormulaProperty', () => {
+		it('should return true for formula property', () => {
+			const prop = {
+				id: 'test',
+				name: 'Total',
+				type: 'formula',
+				formula: {
+					expression: 'prop("A") + prop("B")'
+				}
+			};
+			expect(isFormulaProperty(prop as any)).toBe(true);
+		});
+
+		it('should return false for non-formula property', () => {
+			const prop = {
+				id: 'test',
+				name: 'Price',
+				type: 'number',
+				number: {}
+			};
+			expect(isFormulaProperty(prop as any)).toBe(false);
+		});
+	});
+
+	describe('PROPERTY_TYPE_MAPPINGS', () => {
+		it('should map title to text', () => {
+			expect(PROPERTY_TYPE_MAPPINGS['title']).toBe('text');
+		});
+
+		it('should map rich_text to text', () => {
+			expect(PROPERTY_TYPE_MAPPINGS['rich_text']).toBe('text');
+		});
+
+		it('should map number to number', () => {
+			expect(PROPERTY_TYPE_MAPPINGS['number']).toBe('number');
+		});
+
+		it('should map date to date', () => {
+			expect(PROPERTY_TYPE_MAPPINGS['date']).toBe('date');
+		});
+
+		it('should map checkbox to checkbox', () => {
+			expect(PROPERTY_TYPE_MAPPINGS['checkbox']).toBe('checkbox');
+		});
+
+		it('should map select to select', () => {
+			expect(PROPERTY_TYPE_MAPPINGS['select']).toBe('select');
+		});
+
+		it('should map multi_select to multi-select', () => {
+			expect(PROPERTY_TYPE_MAPPINGS['multi_select']).toBe('multi-select');
+		});
+
+		it('should map url to link', () => {
+			expect(PROPERTY_TYPE_MAPPINGS['url']).toBe('link');
+		});
+
+		it('should map email to link', () => {
+			expect(PROPERTY_TYPE_MAPPINGS['email']).toBe('link');
+		});
+
+		it('should map phone_number to text', () => {
+			expect(PROPERTY_TYPE_MAPPINGS['phone_number']).toBe('text');
+		});
+
+		it('should map files to file', () => {
+			expect(PROPERTY_TYPE_MAPPINGS['files']).toBe('file');
+		});
+
+		it('should map status to select', () => {
+			expect(PROPERTY_TYPE_MAPPINGS['status']).toBe('select');
+		});
+
+		it('should map created_time to date', () => {
+			expect(PROPERTY_TYPE_MAPPINGS['created_time']).toBe('date');
+		});
+
+		it('should map last_edited_time to date', () => {
+			expect(PROPERTY_TYPE_MAPPINGS['last_edited_time']).toBe('date');
+		});
+
+		it('should map all Notion property types', () => {
+			expect(PROPERTY_TYPE_MAPPINGS['relation']).toBe('link');
+			expect(PROPERTY_TYPE_MAPPINGS['rollup']).toBe('text');
+			expect(PROPERTY_TYPE_MAPPINGS['formula']).toBe('text');
+			expect(PROPERTY_TYPE_MAPPINGS['people']).toBe('text');
+			expect(PROPERTY_TYPE_MAPPINGS['created_by']).toBe('text');
+			expect(PROPERTY_TYPE_MAPPINGS['last_edited_by']).toBe('text');
+			expect(PROPERTY_TYPE_MAPPINGS['unique_id']).toBe('text');
+		});
+
+		it('should return undefined for truly unsupported types', () => {
+			expect(PROPERTY_TYPE_MAPPINGS['fake_type']).toBeUndefined();
+			expect(PROPERTY_TYPE_MAPPINGS['non_existent']).toBeUndefined();
+		});
+	});
+});

--- a/tests/notion-api/verify-formulas.js
+++ b/tests/notion-api/verify-formulas.js
@@ -1,0 +1,134 @@
+const { convertNotionFormula } = require('../../main.js');
+
+const testCases = [
+	{
+		name: 'Test 1: Simple prop() reference',
+		input: 'prop("Name")',
+		expected: 'Name',
+	},
+	{
+		name: 'Test 2: prop() in conditional',
+		input: 'if(prop("Status") == "Done", true, false)',
+		expected: 'if((Status == "Done"), true, false)',
+	},
+	{
+		name: 'Test 3: prop() in arithmetic',
+		input: 'prop("Price") * prop("Quantity")',
+		expected: '(Price * Quantity)',
+	},
+	{
+		name: 'Test 4: Multiple prop() in concat',
+		input: 'concat(prop("FirstName"), " ", prop("LastName"))',
+		expected: 'concat(FirstName, " ", LastName)',
+	},
+	{
+		name: 'Test 5: prop() with spaces',
+		input: 'prop("First Name")',
+		expected: 'First Name',
+	},
+	{
+		name: 'Test 6: add() function',
+		input: 'add(prop("A"), prop("B"))',
+		expected: '(A + B)',
+	},
+	{
+		name: 'Test 7: Multiple add() arguments',
+		input: 'add(1, 2, 3, 4)',
+		expected: 'sum(1, 2, 3, 4)',
+	},
+	{
+		name: 'Test 8: Date formatting',
+		input: 'formatDate(prop("Created"), "YYYY-MM-DD")',
+		expected: 'dateformat(Created, "YYYY-MM-DD")',
+	},
+	{
+		name: 'Test 9: today() function',
+		input: 'today()',
+		expected: 'dateonly(now())',
+	},
+	{
+		name: 'Test 10: String operations',
+		input: 'upper(prop("Name"))',
+		expected: 'upper(Name)',
+	},
+	{
+		name: 'Test 11: Comparison operators',
+		input: 'prop("Score") >= 90',
+		expected: '(Score >= 90)',
+	},
+	{
+		name: 'Test 12: Boolean logic',
+		input: 'and(prop("IsActive"), prop("IsVerified"))',
+		expected: 'and(IsActive, IsVerified)',
+	},
+	{
+		name: 'Test 13: Complex nested formula',
+		input: 'if(prop("Price") > 100, concat("$", formatDate(prop("ExpensiveDate"), "MM/DD/YYYY")), concat("$", formatDate(prop("CheapDate"), "MM/DD/YYYY")))',
+		expected: 'if((Price > 100), concat("$", dateformat(ExpensiveDate, "MM/DD/YYYY")), concat("$", dateformat(CheapDate, "MM/DD/YYYY")))',
+	},
+	{
+		name: 'Test 14: Direct property reference',
+		input: 'Name',
+		expected: 'Name',
+	},
+	{
+		name: 'Test 15: String literals with quotes',
+		input: 'concat(prop("Name"), " - ", "Active")',
+		expected: 'concat(Name, " - ", "Active")',
+	},
+	{
+		name: 'Test 16: Numeric literals',
+		input: 'prop("Price") * 1.08',
+		expected: '(Price * 1.08)',
+	},
+	{
+		name: 'Test 17: Boolean literals',
+		input: 'if(prop("IsActive"), true, false)',
+		expected: 'if(IsActive, true, false)',
+	},
+];
+
+console.log('=== Notion Formula Converter Test Suite ===\n');
+
+let passed = 0;
+let failed = 0;
+
+for (const test of testCases) {
+	const result = convertNotionFormula(test.input);
+
+	if (!result.success) {
+		console.log(`❌ ${test.name}`);
+		console.log(`   Input:    ${test.input}`);
+		console.log(`   Error:    ${result.error}`);
+		console.log('');
+		failed++;
+		continue;
+	}
+
+	if (result.formula === test.expected) {
+		console.log(`✅ ${test.name}`);
+		passed++;
+	} else {
+		console.log(`❌ ${test.name}`);
+		console.log(`   Input:    ${test.input}`);
+		console.log(`   Expected: ${test.expected}`);
+		console.log(`   Got:      ${result.formula}`);
+		if (result.warnings && result.warnings.length > 0) {
+			console.log(`   Warnings: ${result.warnings.join(', ')}`);
+		}
+		console.log('');
+		failed++;
+	}
+}
+
+console.log(`\n=== Summary ===`);
+console.log(`Passed: ${passed}/${testCases.length}`);
+console.log(`Failed: ${failed}/${testCases.length}`);
+
+if (failed === 0) {
+	console.log('\n✅ All tests passed!');
+	process.exit(0);
+} else {
+	console.log(`\n❌ ${failed} test(s) failed`);
+	process.exit(1);
+}

--- a/tests/notion-api/verify-mock-data.md
+++ b/tests/notion-api/verify-mock-data.md
@@ -1,0 +1,137 @@
+# Mock Data Verification Guide
+
+This guide explains how to manually verify the converters using the mock data files.
+
+## Testing Base Converter
+
+### Test 1: Simple Database
+
+**Input:** `mock-data/database-simple.json`
+
+**Expected Output:** `expected-outputs/simple-database.base`
+
+**Steps:**
+1. Load the database JSON
+2. Pass through `convertDatabaseToBase()`
+3. Use `createBaseFileContent()` to generate markdown
+4. Compare with expected output
+
+**Verification Points:**
+- Database ID in filters matches: `abc123-456def-789ghi`
+- All 5 properties present (Name, Status, Priority, Due Date, Completed)
+- Property types mapped correctly:
+  - title → text
+  - select → select (with 3 options for Status, 3 for Priority)
+  - date → date
+  - checkbox → checkbox
+- No formulas section (database has none)
+- Views array has one table view
+
+### Test 2: Database with Formulas
+
+**Input:** `mock-data/database-with-formulas.json`
+
+**Expected Output:** `expected-outputs/formula-database.base`
+
+**Steps:**
+1. Load the database JSON
+2. Pass through `convertDatabaseToBase()`
+3. Use `createBaseFileContent()` to generate markdown
+4. Compare with expected output
+
+**Verification Points:**
+- Database ID matches: `formula-test-123`
+- 3 regular properties (Product Name, Price, Quantity)
+- 4 formula properties converted correctly:
+  - `prop("Price") * prop("Quantity")` → `(Price * Quantity)`
+  - `if(prop("Price") > 100, "Expensive", "Affordable")` → `if((Price > 100), "Expensive", "Affordable")`
+  - `concat(prop("Product Name"), " ($", prop("Price"), ")")` → `concat(Product Name, " ($", Price, ")")`
+  - Complex nested if statement converted correctly
+- Formulas section exists with all 4 formulas
+- Formula expressions have correct syntax
+
+## Testing Page Converter
+
+### Test 3: Sample Page
+
+**Input:** `mock-data/page-sample.json`
+
+**Expected Output:** `expected-outputs/sample-page.md`
+
+**Steps:**
+1. Load the page JSON
+2. Pass through `extractPageTitle()` to get title
+3. Use `convertPage()` logic to generate markdown
+4. Compare with expected output
+
+**Verification Points:**
+- Title extracted correctly: "Sample Task"
+- Frontmatter has database tag
+- Heading has title
+
+## Testing Formula Converter Directly
+
+Use the Node.js test script:
+
+```bash
+cd tests/notion-api
+node verify-formulas.js
+```
+
+This will run all 17 formula test cases and report results.
+
+## Manual Testing with TypeScript Console
+
+You can also test individual functions in a TypeScript REPL:
+
+```typescript
+// Test formula converter
+import { convertNotionFormula } from '../../src/formats/notion-api/formula-converter';
+
+const result = convertNotionFormula('prop("Name")');
+console.log(result);
+// Expected: { success: true, formula: 'Name', warnings: [] }
+
+// Test database converter
+import { convertDatabaseToBase } from '../../src/formats/notion-api/base-converter';
+import databaseJson from './mock-data/database-simple.json';
+
+const result = convertDatabaseToBase(databaseJson as any);
+console.log(result);
+// Should have schema with properties, no warnings
+
+// Test base serialization
+import { createBaseFileContent } from '../../src/formats/notion-api/base-converter';
+
+const content = createBaseFileContent(result.schema, result.databaseTitle);
+console.log(content);
+// Compare with expected-outputs/simple-database.base
+```
+
+## Common Issues to Check
+
+### Formula Conversion Issues
+- [ ] `prop()` not removed (shows as UNSUPPORTED_FUNCTION)
+- [ ] Property names in quotes in output (should be bare names)
+- [ ] Missing spaces around operators: `a*b` instead of `(a * b)`
+- [ ] Wrong function names (Notion vs Obsidian differences)
+
+### Base Schema Issues
+- [ ] Missing database ID in filters
+- [ ] Wrong property types
+- [ ] Missing options for select properties
+- [ ] Formulas in properties section (should be separate)
+- [ ] YAML formatting issues (quotes, indentation)
+
+### Page Conversion Issues
+- [ ] Title extraction fails (returns "Untitled" incorrectly)
+- [ ] Frontmatter missing or malformed
+- [ ] Wrong database ID in frontmatter
+
+## Debugging Tips
+
+1. **Enable verbose logging:** Add console.log statements to see intermediate values
+2. **Check AST:** In formula converter, log the AST before translation
+3. **Compare character-by-character:** Use a diff tool to find exact differences
+4. **Test incrementally:** Start with simple cases, then add complexity
+5. **Check warnings:** Formula converter may add warnings for unsupported features

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,27 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+	test: {
+		globals: true,
+		environment: 'node',
+		include: ['src/**/*.{test,spec}.ts', 'tests/**/*.{test,spec}.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html'],
+			exclude: [
+				'node_modules/',
+				'tests/',
+				'**/*.d.ts',
+				'**/*.config.*',
+				'**/mockData',
+			],
+		},
+	},
+	resolve: {
+		alias: {
+			'@': path.resolve(__dirname, './src'),
+		},
+	},
+});


### PR DESCRIPTION
Builds a converter for going from Notion API (through Notion SDK) to Obsidian markdown format, and converts Notion Databases to Obsidian Bases.

Includes (heavily AI-generated but correct) tests that confirm that everything works from a unit test level. Work still needs to be done for creating an integration test suite as well as testing manually on complex Notion databases.

There are also currently implementation details that weren't heavily taken into account in the current implementation yet:

1. Consider that files in a Notion Database are additive (a database is empty by default), while Obsidian Bases are subtractive (a base contains all files in the vault by default). So we'll need to decide the most appropriate way to filter files down, e.g. via a frontmatter property.
2. More complex Database view types like calendar

The remaining work to be done:

1. Test heavily on more complex use cases (i.e. complex Database with multiple rows each with a distinct formula that sits in a timeline format with a full markdown file in the same file)
2. Create an integration test suite
3. Add support for complex view types and/or fallbacks if the implementation doesn't fall within the bounds of what would be an acceptable UX

I also want to clean the commits a bit more and separate them more logically, but I squashed a few too many to clean things up that ended up making the concerns a bit harder to separate after the fact.