### PR TITLE
Fix Evernote importer bug #443

### DIFF
--- a/src/formats/yarle/process-resources.ts
+++ b/src/formats/yarle/process-resources.ts
@@ -72,6 +72,13 @@ const addMediaReference = (content: string, resourceHashes: any, hash: any, work
 
 const processResource = (workDir: string, resource: any): any => {
 	const resourceHash: any = {};
+	
+	// Check if resource data exists
+	if (!resource.data || !resource.data.$text) {
+		console.warn('Resource data is missing or empty, skipping resource:', resource);
+		return resourceHash;
+	}
+	
 	const data = resource.data.$text;
 
 	// Skip unknown type as we don't know how to handle

--- a/src/formats/yarle/utils/filename-utils.ts
+++ b/src/formats/yarle/utils/filename-utils.ts
@@ -8,6 +8,10 @@ import { ResourceFileProperties } from '../models/ResourceFileProperties';
 import { escapeStringRegexp } from './escape-string-regexp';
 import { extensionForMime } from '../../../mime';
 
+// Filename length constants
+const MAX_NOTE_NAME_LENGTH = 100; // Limit note name length to prevent path issues
+const MAX_RESOURCE_FILENAME_PREFIX_LENGTH = 50; // Maximum length for resource filename prefix
+
 export const normalizeTitle = (title: string) => {
 	return sanitizeFileName(title).replace(/[\[\]\#\^]/g, '');
 };
@@ -36,7 +40,7 @@ export const getResourceFileProperties = (workDir: string, resource: any): Resou
 	let fileName = UNKNOWNFILENAME;
 
 	if (resource['resource-attributes'] && resource['resource-attributes']['file-name']) {
-		const fileNamePrefix = resource['resource-attributes']['file-name'].substr(0, 50);
+		const fileNamePrefix = resource['resource-attributes']['file-name'].substr(0, MAX_RESOURCE_FILENAME_PREFIX_LENGTH);
 		fileName = parseFilePath(fileNamePrefix).basename;
 
 	}
@@ -105,11 +109,28 @@ export const getNoteName = (dstPath: string, note: any): string => {
 			zettelPrefix;
 
 		if (!yarleOptions.useZettelIdAsFilename) {
-			noteName += getFilePrefix(note) !== 'Untitled' ? `${separator}${getFilePrefix(note)}` : '';
+			const filePrefix = getFilePrefix(note);
+			if (filePrefix !== 'Untitled') {
+				const combined = `${noteName}${separator}${filePrefix}`;
+				// Truncate if combined name is too long
+				if (combined.length > MAX_NOTE_NAME_LENGTH) {
+					const availableSpace = MAX_NOTE_NAME_LENGTH - noteName.length - separator.length;
+					noteName = `${noteName}${separator}${filePrefix.substring(0, Math.max(0, availableSpace))}`;
+				} else {
+					noteName = combined;
+				}
+			}
 		}
 	}
 	else {
-		const fileNamePrefix = getFilePrefix(note);
+		let fileNamePrefix = getFilePrefix(note);
+		
+		// Truncate file name prefix if it's too long
+		if (fileNamePrefix.length > MAX_NOTE_NAME_LENGTH) {
+			fileNamePrefix = fileNamePrefix.substring(0, MAX_NOTE_NAME_LENGTH);
+			console.warn(`Note title too long (${getFilePrefix(note).length} chars), truncated to ${MAX_NOTE_NAME_LENGTH} chars`);
+		}
+		
 		const nextIndex = getFileIndex(dstPath, fileNamePrefix);
 
 		noteName = (nextIndex === 0) ? fileNamePrefix : `${fileNamePrefix}.${nextIndex}`;


### PR DESCRIPTION
Fix two issues:
1. The import note path may be too long (including the total length of folder + filename), so it is truncated and the rename sequence number is incremented.
2. Notes may lack certain attributes; add fault‑tolerant handling.