### PR TITLE
Google Keep: Add created/modified timestamps & handle duplicates

### DIFF
--- a/src/formats/keep-json.ts
+++ b/src/formats/keep-json.ts
@@ -1,8 +1,8 @@
-import { FrontMatterCache, Notice, Setting, TFolder } from 'obsidian';
+import { FrontMatterCache, Notice, normalizePath, Setting, TFile, TFolder } from 'obsidian';
 import { PickedFile } from '../filesystem';
 import { FormatImporter } from '../format-importer';
 import { ATTACHMENT_EXTS, ImportContext } from '../main';
-import { serializeFrontMatter } from '../util';
+import { sanitizeFileName, serializeFrontMatter } from '../util';
 import { readZip, ZipEntryFile } from '../zip';
 import { KeepJson } from './keep/models';
 import { sanitizeTag, sanitizeTags, toSentenceCase } from './keep/util';
@@ -16,13 +16,61 @@ const NOTE_EXTS = ['json'];
 // - A text file with labels summary
 const ZIP_IGNORED_EXTS = ['html', 'txt'];
 
+type ExistingFileBehavior = 'skip' | 'overwrite' | 'duplicate';
+
+// Keep exports use microseconds since epoch in `*TimestampUsec`
+const KEEP_TIMESTAMP_MIN_MS = Date.UTC(1990, 0, 1);
+const KEEP_TIMESTAMP_MAX_MS = Date.UTC(2100, 0, 1);
+
+function toFiniteNumber(value: unknown): number | undefined {
+	if (typeof value === 'number') return Number.isFinite(value) ? value : undefined;
+	if (typeof value === 'string' && value.trim() !== '') {
+		const num = Number(value);
+		return Number.isFinite(num) ? num : undefined;
+	}
+	return undefined;
+}
+
+/**
+ * Normalize an epoch timestamp to milliseconds.
+ *
+ * Examples:
+ * - `1690426307496000` (usec) -> `1690426307496` (ms)
+ * - `1690426307496` (ms) -> `1690426307496` (ms)
+ * - `1690426307` (sec) -> `1690426307000` (ms)
+ */
+function normalizeEpochMs(value: unknown): number | undefined {
+	const num = toFiniteNumber(value);
+	if (num === undefined || num <= 0) return undefined;
+
+	const candidates = [
+		num, // milliseconds
+		num / 1_000, // microseconds
+		num * 1_000, // seconds
+	];
+
+	const plausible = candidates.filter(ms => ms >= KEEP_TIMESTAMP_MIN_MS && ms <= KEEP_TIMESTAMP_MAX_MS);
+	if (plausible.length === 0) return undefined;
+	if (plausible.length === 1) return plausible[0];
+
+	const now = Date.now();
+	plausible.sort((a, b) => Math.abs(a - now) - Math.abs(b - now));
+	return plausible[0];
+}
+
 export class KeepImporter extends FormatImporter {
 	importArchivedSetting: Setting;
 	importTrashedSetting: Setting;
+	existingFileSetting: Setting;
 	importArchived: boolean = false;
 	importTrashed: boolean = false;
+	existingFileBehavior: ExistingFileBehavior = 'skip';
 
 	init() {
+		this.importArchived = this.importArchived ?? false;
+		this.importTrashed = this.importTrashed ?? false;
+		this.existingFileBehavior = this.existingFileBehavior ?? 'skip';
+
 		this.addFileChooserSetting('Notes & attachments', [...BUNDLE_EXTS, ...NOTE_EXTS, ...ATTACHMENT_EXTS], true);
 
 		this.importArchivedSetting = new Setting(this.modal.contentEl)
@@ -42,6 +90,19 @@ export class KeepImporter extends FormatImporter {
 				toggle.setValue(this.importTrashed);
 				toggle.onChange(async (value) => {
 					this.importTrashed = value;
+				});
+			});
+
+		this.existingFileSetting = new Setting(this.modal.contentEl)
+			.setName('If note or attachment already exists')
+			.setDesc('When importing into the same folder again, choose to skip, overwrite, or create a duplicate.')
+			.addDropdown(dropdown => {
+				dropdown.addOption('skip', 'Skip');
+				dropdown.addOption('overwrite', 'Overwrite');
+				dropdown.addOption('duplicate', 'Create duplicate');
+				dropdown.setValue(this.existingFileBehavior);
+				dropdown.onChange(value => {
+					this.existingFileBehavior = value as ExistingFileBehavior;
 				});
 			});
 
@@ -82,8 +143,10 @@ export class KeepImporter extends FormatImporter {
 			}
 			else if (ATTACHMENT_EXTS.contains(extension)) {
 				ctx.status('Importing attachment ' + name);
-				await this.copyFile(file, assetFolderPath);
-				ctx.reportAttachmentSuccess(fullpath);
+				const imported = await this.copyFile(file, assetFolderPath, ctx);
+				if (imported) {
+					ctx.reportAttachmentSuccess(fullpath);
+				}
 			}
 			// Don't mention skipped files when parsing zips, because
 			else if (!(file instanceof ZipEntryFile) && !ZIP_IGNORED_EXTS.contains(extension)) {
@@ -111,7 +174,14 @@ export class KeepImporter extends FormatImporter {
 		let content = await file.readText();
 
 		const keepJson = JSON.parse(content) as KeepJson;
-		if (!keepJson || !keepJson.userEditedTimestampUsec || !keepJson.createdTimestampUsec) {
+		if (!keepJson || typeof keepJson !== 'object') {
+			ctx.reportFailed(fullpath, 'Invalid Google Keep JSON');
+			return;
+		}
+
+		const createdMs = normalizeEpochMs(keepJson.createdTimestampUsec);
+		const editedMs = normalizeEpochMs(keepJson.userEditedTimestampUsec);
+		if (!createdMs && !editedMs) {
 			ctx.reportFailed(fullpath, 'Invalid Google Keep JSON');
 			return;
 		}
@@ -124,22 +194,57 @@ export class KeepImporter extends FormatImporter {
 			return;
 		}
 
-		await this.convertKeepJson(keepJson, folder, basename);
-		ctx.reportNoteSuccess(fullpath);
+		const imported = await this.convertKeepJson(keepJson, folder, basename, fullpath, ctx);
+		if (imported) {
+			ctx.reportNoteSuccess(fullpath);
+		}
 	}
 
-	// Keep assets have filenames that appear unique, so no duplicate handling isn't implemented
-	async copyFile(file: PickedFile, folderPath: string) {
+	// Keep assets usually have unique filenames, but re-imports can conflict.
+	async copyFile(file: PickedFile, folderPath: string, ctx: ImportContext): Promise<boolean> {
 		let assetFolder = await this.createFolders(folderPath);
+		const defaultPath = normalizePath(`${assetFolder.path}/${file.name}`);
+		const existing = this.vault.getAbstractFileByPath(defaultPath) ?? this.vault.getAbstractFileByPathInsensitive(defaultPath);
+		if (existing) {
+			if (existing instanceof TFile) {
+				if (this.existingFileBehavior === 'skip') {
+					ctx.reportSkipped(file.fullpath, 'Attachment already exists');
+					return false;
+				}
+				if (this.existingFileBehavior === 'overwrite') {
+					let data = await file.read();
+					await this.vault.modifyBinary(existing, data);
+					return true;
+				}
+				// For duplicate notes, prefer reusing existing attachments rather than
+				// creating renamed duplicates that the note wouldn't reference.
+				return false;
+			}
+			else {
+				ctx.reportSkipped(file.fullpath, 'Attachment path exists and is not a file');
+				return false;
+			}
+		}
+
 		let data = await file.read();
-		await this.vault.createBinary(`${assetFolder.path}/${file.name}`, data);
+		await this.vault.createBinary(defaultPath, data);
+		return true;
 	}
 
-	async convertKeepJson(keepJson: KeepJson, folder: TFolder, filename: string) {
+	async convertKeepJson(keepJson: KeepJson, folder: TFolder, filename: string, sourcePath: string, ctx: ImportContext): Promise<boolean> {
 		let mdContent: string[] = [];
 
 		// First let's gather some metadata
 		let frontMatter: FrontMatterCache = {};
+
+		// Store both:
+		// - the original Keep fields (as microseconds, matching the JSON field names)
+		// - ISO strings for easy reading/searching in Obsidian
+		const createdMs = normalizeEpochMs(keepJson.createdTimestampUsec);
+		const editedMs = normalizeEpochMs(keepJson.userEditedTimestampUsec) ?? createdMs;
+
+		if (createdMs !== undefined) frontMatter['keepCreatedAt'] = new Date(createdMs).toISOString();
+		if (editedMs !== undefined) frontMatter['keepUpdatedAt'] = new Date(editedMs).toISOString();
 
 		// Aliases
 		if (keepJson.title) {
@@ -201,12 +306,43 @@ export class KeepImporter extends FormatImporter {
 			}
 		}
 
-		const file = await this.saveAsMarkdownFile(folder, filename, mdContent.join(''));
+		const noteText = mdContent.join('');
+		const sanitizedName = sanitizeFileName(filename);
+		const existingNotePath = normalizePath(`${folder.path}/${sanitizedName}.md`);
+		const existingNote = this.vault.getAbstractFileByPath(existingNotePath) ?? this.vault.getAbstractFileByPathInsensitive(existingNotePath);
+
+		let file: TFile;
+		if (existingNote) {
+			if (existingNote instanceof TFile) {
+				if (this.existingFileBehavior === 'skip') {
+					ctx.reportSkipped(sourcePath, 'Note already exists');
+					return false;
+				}
+				if (this.existingFileBehavior === 'overwrite') {
+					file = existingNote;
+					await this.vault.modify(file, noteText);
+				}
+				else {
+					file = await this.saveAsMarkdownFile(folder, filename, noteText);
+				}
+			}
+			else {
+				ctx.reportSkipped(sourcePath, 'Note path exists and is not a file');
+				return false;
+			}
+		}
+		else {
+			file = await this.saveAsMarkdownFile(folder, filename, noteText);
+		}
 
 		// Modifying the creation and modified timestamps without changing file contents.
-		await this.vault.append(file, '', {
-			ctime: keepJson.createdTimestampUsec / 1000,
-			mtime: keepJson.userEditedTimestampUsec / 1000,
-		});
+		if (createdMs !== undefined || editedMs !== undefined) {
+			await this.vault.append(file, '', {
+				ctime: createdMs,
+				mtime: editedMs,
+			});
+		}
+
+		return true;
 	}
 }

--- a/src/formats/keep/models.ts
+++ b/src/formats/keep/models.ts
@@ -19,8 +19,8 @@ export interface KeepLabel {
 }
 
 export interface KeepJson {
-	createdTimestampUsec: number;
-	userEditedTimestampUsec: number;
+	createdTimestampUsec?: number | string;
+	userEditedTimestampUsec?: number | string;
 	//
 	isArchived?: boolean;
 	isPinned?: boolean;

--- a/src/main.ts
+++ b/src/main.ts
@@ -486,6 +486,10 @@ export class ImporterModal extends Modal {
 						try {
 							await importer.import(ctx);
 						}
+						catch (e) {
+							ctx.reportFailed('Import', e);
+							new Notice('Import failed. See the import log for details.');
+						}
 						finally {
 							if (this.current === ctx) {
 								this.current = null;

--- a/tests/keep/missing-user-edited-timestamp.json
+++ b/tests/keep/missing-user-edited-timestamp.json
@@ -4,5 +4,6 @@
     "isPinned": false,
     "isArchived": false,
     "textContent": "This is just a plain text note.     This sentence has more than one space before it.\n\n\nThis sentence has more than one new line before it.\n\n   This sentence has more than one new line and spaces before it.",
-    "title": "_Text note"
+    "title": "_Text note",
+    "createdTimestampUsec": 1690426307496000
 }


### PR DESCRIPTION
This fixes issues #377 and #385. I've tested it against my local vault (by importing my own Keep takeout with a dozen or so attachments and 675 notes) and this PR adds the following functionality:

1. Adds `keepCreatedAt` and `keepUpdatedAt` to the frontmatter of all imported notes, output using ISO8601.
2. Adds a dropdown for how duplicate notes should be handled (e.g. if the user reimports the same takeout file but with substantial changes months later for example) - the default behaviour is to skip any already imported duplicate notes.

<img width="1054" height="379" alt="2025-12-24_16-40" src="https://github.com/user-attachments/assets/85a29c47-ab38-4b53-b372-ea4862baacc2" />

<img width="552" height="586" alt="2025-12-24_16-41" src="https://github.com/user-attachments/assets/aca087a9-377b-4594-bbad-b4f9d9759f4e" />

I've never contributed to an Obsidian plugin before so I'm happy to take any pointers or suggestions for how my implementation could be refined!