### PR TITLE
Add Apple Journal Importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Import guides are hosted on the [official Obsidian Help site](https://help.obsid
 - [Import from Roam Research](https://help.obsidian.md/import/roam)
 - [Import from HTML files](https://help.obsidian.md/import/html)
 - [Import from Markdown files](https://help.obsidian.md/import/markdown)
+- Import from Apple Journal (HTML export)
 
 ## Contributing
 
@@ -40,3 +41,4 @@ This plugin relies on important contributions:
 - [@8bitgentleman](https://github.com/8bitgentleman) for Roam import
 - [@p3rid0t](https://github.com/p3rid0t) for Microsoft OneNote import
 - [@mirnovov](https://github.com/mirnovov) for Apple Notes import
+- [@wzs](https://github.com/wzs) for Apple Journal import

--- a/src/formats/apple-journal.ts
+++ b/src/formats/apple-journal.ts
@@ -149,9 +149,7 @@ export class AppleJournalImporter extends FormatImporter {
 
 		const sanitizedName = sanitizeFileName(file.basename);
 		const folderPath = folder.path === '/' ? '' : folder.path;
-		const fullPath = normalizePath(
-			folderPath ? `${folderPath}/${sanitizedName}.md` : `${sanitizedName}.md`
-		);
+		const fullPath = normalizePath(path.join(folderPath, sanitizedName + '.md'));
 		const existingFile = this.vault.getAbstractFileByPath(fullPath)
 			?? this.vault.getAbstractFileByPathInsensitive(fullPath);
 

--- a/src/formats/apple-journal.ts
+++ b/src/formats/apple-journal.ts
@@ -1,0 +1,294 @@
+import { htmlToMarkdown, moment, Notice, Setting } from 'obsidian';
+import type { FrontMatterCache, TFolder } from 'obsidian';
+import type { PickedFile } from '../filesystem';
+import { fs, os, path } from '../filesystem';
+import { FormatImporter } from '../format-importer';
+import type { ImportContext } from '../main';
+import { parseHTML, serializeFrontMatter } from '../util';
+
+const DATE_FORMAT = 'dddd, D MMMM YYYY';
+const DEFAULT_OUTPUT_FOLDER = 'Journal';
+const IGNORED_ASSET_TYPES = new Set<string>(['photo', 'live-photo', 'video']);
+const ASSET_TYPE_ALIASES = new Map<string, string>([
+	['generic-map', 'location'],
+	['multi-pin-map', 'location'],
+]);
+const BODY_PARAGRAPH_SELECTOR = '.p2, .p3';
+const OVERLAY_TEXT_SELECTORS = [
+	'.gridItemOverlayHeader',
+	'.gridItemOverlayFooter',
+	'.gridItemOverlayText',
+	'.activityType',
+	'.activityMetrics',
+	'.activityMetricsDistance',
+	'.activityMetricsCalories',
+	'.activityMetricsDuration',
+	'.mediaTitle',
+	'.mediaArtist',
+	'.mediaCategory',
+];
+
+export class AppleJournalImporter extends FormatImporter {
+	private frontMatterEnabled = true;
+
+	init(): void {
+		const defaultImportPath = detectDefaultEntriesPath();
+		this.addFileChooserSetting(
+			'Journal entries',
+			['htm', 'html'],
+			true,
+			'Pick the Journal app exported folder',
+			defaultImportPath
+		);
+
+		new Setting(this.modal.contentEl)
+			.setName('Journal metadata')
+			.setHeading();
+
+		new Setting(this.modal.contentEl)
+			.setName('Add metadata as frontmatter')
+			.setDesc('Capture state-of-mind, contact, and similar tokens in YAML when available.')
+			.addToggle(toggle => {
+				toggle.setValue(this.frontMatterEnabled);
+				toggle.onChange(value => {
+					this.frontMatterEnabled = value;
+				});
+			});
+
+		this.addOutputLocationSetting(DEFAULT_OUTPUT_FOLDER);
+	}
+
+	async import(ctx: ImportContext): Promise<void> {
+		if (this.files.length === 0) {
+			new Notice('Please pick at least one file to import.');
+			return;
+		}
+
+		const folder = await this.getOutputFolder();
+		if (!folder) {
+			new Notice('Please select a location to export to.');
+			return;
+		}
+
+		ctx.reportProgress(0, this.files.length);
+		for (let index = 0; index < this.files.length; index++) {
+			if (ctx.isCancelled()) return;
+
+			const file = this.files[index];
+			if (file.name === 'index.html') {
+				ctx.reportProgress(index + 1, this.files.length);
+				continue;
+			}
+
+			try {
+				ctx.status(`Importing note ${file.basename}`);
+				await this.importEntry(folder, file);
+				ctx.reportNoteSuccess(file.fullpath);
+			}
+			catch (error) {
+				ctx.reportFailed(file.fullpath, error as Error);
+			}
+
+			ctx.reportProgress(index + 1, this.files.length);
+		}
+	}
+
+	private async importEntry(folder: TFolder, file: PickedFile): Promise<void> {
+		const htmlContent = await file.readText();
+		const documentEl = parseHTML(htmlContent);
+		const frontMatter: FrontMatterCache = {};
+
+		if (this.frontMatterEnabled) {
+			const tokens = collectFrontMatterTokens(documentEl);
+			if (tokens) {
+				for (const [key, value] of Object.entries(tokens)) {
+					frontMatter[key] = value;
+				}
+			}
+		}
+
+		const entryDate = extractEntryDate(documentEl);
+		if (entryDate) {
+			frontMatter.date = entryDate;
+		}
+
+		const finalDocument = buildEntryDocument(documentEl);
+		let mdContent = htmlToMarkdown(finalDocument);
+
+		if (Object.keys(frontMatter).length > 0) {
+			const frontMatterText = serializeFrontMatter(frontMatter);
+			if (frontMatterText) {
+				mdContent = frontMatterText + mdContent;
+			}
+		}
+
+		await this.saveAsMarkdownFile(folder, file.basename, mdContent);
+	}
+}
+
+function extractEntryDate(source: HTMLElement): string | undefined {
+	const headerText = source.querySelector('.pageHeader')?.textContent?.trim();
+	if (!headerText) return undefined;
+
+	/**
+	 * Journal exports format the date as "Sunday, 3 November 2024".
+	 */
+	const parsed = moment(headerText, DATE_FORMAT);
+	if (!parsed.isValid()) return undefined;
+
+	return parsed.format('YYYY-MM-DD');
+}
+
+/**
+ * Builds a clean document that only contains the reflection prompt and entry body paragraphs.
+ */
+function buildEntryDocument(source: HTMLElement): HTMLElement {
+	const doc = document.implementation.createHTMLDocument('');
+	const wrapper = doc.createElement('article');
+	doc.body.appendChild(wrapper);
+
+	const promptText = source.querySelector('.reflectionPrompt')?.textContent;
+	appendParagraph(doc, wrapper, promptText);
+
+	const paragraphs = Array.from(source.querySelectorAll(BODY_PARAGRAPH_SELECTOR));
+	for (const paragraph of paragraphs) {
+		wrapper.appendChild(doc.importNode(paragraph, true));
+	}
+
+	return doc.documentElement;
+}
+
+function appendParagraph(doc: Document, parent: HTMLElement, text: string | undefined | null): void {
+	const trimmed = text?.trim();
+	if (!trimmed) return;
+
+	const paragraph = doc.createElement('p');
+	paragraph.textContent = trimmed;
+	parent.appendChild(paragraph);
+}
+
+function collectFrontMatterTokens(source: HTMLElement): FrontMatterCache | null {
+	const tokensByType = new Map<string, Set<string>>();
+	const items = Array.from(source.querySelectorAll('.assetGrid .gridItem'));
+
+	for (const item of items) {
+		const assetType = normalizeAssetType(item);
+		if (!assetType || IGNORED_ASSET_TYPES.has(assetType)) continue;
+
+		const tokens = parseOverlayTokens(item);
+		if (tokens.length === 0) continue;
+
+		const normalizedTokens = assetType === 'state-of-mind'
+			? tokens.map(token => token.toLowerCase())
+			: tokens;
+
+		const bucket = tokensByType.get(assetType) ?? new Set<string>();
+		for (const token of normalizedTokens) {
+			bucket.add(token);
+		}
+		tokensByType.set(assetType, bucket);
+	}
+
+	if (tokensByType.size === 0) return null;
+
+	const frontMatter: FrontMatterCache = {};
+	for (const [key, values] of tokensByType) {
+		const list = Array.from(values);
+		if (list.length > 0) {
+			frontMatter[key] = list;
+		}
+	}
+
+	return Object.keys(frontMatter).length === 0 ? null : frontMatter;
+}
+
+/**
+ * Turns assetType class names into kebab-case frontmatter keys.
+ */
+function normalizeAssetType(item: Element): string | undefined {
+	const className = Array.from(item.classList).find(cls => cls.startsWith('assetType_'));
+	if (!className) return undefined;
+
+	const rawType = className.slice('assetType_'.length);
+	if (!rawType) return undefined;
+
+	const normalized = rawType
+		.replace(/([a-z])([A-Z])/g, '$1-$2')
+		.replace(/_/g, '-')
+		.toLowerCase();
+
+	return ASSET_TYPE_ALIASES.get(normalized) ?? normalized;
+}
+
+function parseOverlayTokens(item: Element): string[] {
+	const collected = collectOverlayText(item);
+	return splitTokens(collected);
+}
+
+/**
+ * Splits overlay strings into tokens while keeping title-like text intact.
+ */
+function splitTokens(values: string[]): string[] {
+	const tokens = new Set<string>();
+	for (const value of values) {
+		for (const token of value.split(',')) {
+			const trimmed = token.trim();
+			if (trimmed) tokens.add(trimmed);
+		}
+	}
+	return Array.from(tokens);
+}
+
+function collectOverlayText(item: Element): string[] {
+	const values = new Set<string>();
+	const addValue = (text: string | null | undefined): void => {
+		const trimmed = text?.trim();
+		if (trimmed) values.add(trimmed);
+	};
+
+	for (const selector of OVERLAY_TEXT_SELECTORS) {
+		const elements = Array.from(item.querySelectorAll(selector));
+		for (const element of elements) {
+			addValue(element.textContent);
+		}
+	}
+
+	const attributedElements = Array.from(item.querySelectorAll('[aria-label],[title],[alt]'));
+	for (const element of attributedElements) {
+		addValue(element.getAttribute('aria-label'));
+		addValue(element.getAttribute('title'));
+		addValue(element.getAttribute('alt'));
+	}
+
+	return Array.from(values);
+}
+
+function detectDefaultEntriesPath(): string | undefined {
+	if (!fs || !path || !os) {
+		return undefined;
+	}
+
+	if (os.platform() !== 'darwin') {
+		return undefined;
+	}
+
+	const candidate = path.join(
+		os.homedir(),
+		'Library',
+		'Mobile Documents',
+		'com~apple~CloudDocs',
+		'Journal',
+		'AppleJournalEntries'
+	);
+
+	try {
+		if (fs.existsSync(candidate)) {
+			return candidate;
+		}
+	}
+	catch {
+		return undefined;
+	}
+
+	return undefined;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { App, Modal, Notice, Plugin, Setting } from 'obsidian';
 import { FormatImporter } from './format-importer';
 import { AppleNotesImporter } from './formats/apple-notes';
+import { AppleJournalImporter } from './formats/apple-journal';
 import { Bear2bkImporter } from './formats/bear-bear2bk';
 import { CSVImporter } from './formats/csv';
 import { EvernoteEnexImporter } from './formats/evernote-enex';
@@ -250,6 +251,12 @@ export default class ImporterPlugin extends Plugin {
 				optionText: 'Apple Notes',
 				importer: AppleNotesImporter,
 				helpPermalink: 'import/apple-notes'
+			},
+			'apple-journal': {
+				name: 'Apple Journal',
+				optionText: 'Apple Journal (HTML export)',
+				importer: AppleJournalImporter,
+				formatDescription: 'Import your Journal app entries to Obsidian',
 			},
 			'bear': {
 				name: 'Bear',

--- a/tests/journal/entry-complex-metadata.html
+++ b/tests/journal/entry-complex-metadata.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html dir="auto">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title></title>
+</head>
+<body>
+<p class="p1"><span class="s1"><div class='pageContainer'>    <div class="pageHeader">Sunday, 17 December 2023</div>    <div class="assetGrid">
+    <div id="LOC1" class="gridItem assetType_multiPinMap">
+        <div class="gridItemOverlayFooter">Old Town Market Place</div>
+    </div>
+    <div id="ACT1" class="gridItem assetType_motionActivity">
+        <div class="activityType">Walking</div>
+        <div class="activityMetrics">2.5 km</div>
+    </div>
+    <div id="MEDIA1" class="gridItem assetType_thirdPartyMedia">
+        <div class="thirdPartyAssetOverlay">
+            <div class="mediaTitle">Bohemian Rhapsody</div>
+            <div class="mediaCategory">Music</div>
+        </div>
+    </div>
+    <div id="PODCAST1" class="gridItem assetType_thirdPartyMedia">
+        <div class="thirdPartyAssetOverlay">
+            <div class="mediaTitle">Tech News</div>
+            <div class="mediaCategory">Podcast</div>
+        </div>
+    </div>
+</div><div class='reflectionPrompt'>How was your day?</div><div class='title'>Complex Metadata Entry</div><div class='bodyText'></span></p>
+<p class="p2"><span class="s2">Entry body text.</span></p>
+<p class="p1"><span class="s1"></div></div></span></p>
+</body>
+</html>

--- a/tests/journal/entry-complex-metadata.md
+++ b/tests/journal/entry-complex-metadata.md
@@ -1,0 +1,16 @@
+---
+date: 2023-12-17
+location:
+  - Old Town Market Place
+motion-activity:
+  - Walking
+  - 2.5 km
+third-party-media:
+  - Bohemian Rhapsody
+  - Music
+  - Tech News
+  - Podcast
+---
+How was your day?
+
+Entry body text.

--- a/tests/journal/entry-with-assets.html
+++ b/tests/journal/entry-with-assets.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html dir="auto">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title></title>
+</head>
+<body>
+<p class="p1"><span class="s1"><div class='pageContainer'>    <div class="pageHeader">Sunday, 3 November 2024</div>    <div class="assetGrid">    <div id="IMG1" class="gridItem assetType_stateOfMind">
+        <div class="gridItemOverlayText gridItemOverlayHeader">Sad, Overwhelmed</div>
+        <img src="../Resources/IMG1.heic" class="asset_image"/>
+        <div class="gridItemOverlayText gridItemOverlayFooter">Health</div>
+    </div>    <div id="CONTACT1" class="gridItem assetType_contact">
+        <div class="gridItemOverlayText gridItemOverlayHeader">Mom</div>
+        <img src="../Resources/CONTACT1.png" class="asset_image"/>
+    </div>    <div id="IMG2" class="gridItem assetType_photo">
+        <img src="../Resources/IMG2.heic" class="asset_image"/>
+    </div></div><div class='title'>Youve Connected</div><div class='bodyText'></span></p>
+<p class="p2"><span class="s2">Paragraph one.</span></p>
+<p class="p2"><span class="s2">Paragraph two.</span></p>
+<p class="p1"><span class="s1"></div></div></span></p>
+</body>
+</html>

--- a/tests/journal/entry-with-assets.md
+++ b/tests/journal/entry-with-assets.md
@@ -1,7 +1,7 @@
 ---
 state-of-mind:
-  - sad
-  - overwhelmed
+  - Sad
+  - Overwhelmed
 contact:
   - Mom
 date: 2024-11-03

--- a/tests/journal/entry-with-assets.md
+++ b/tests/journal/entry-with-assets.md
@@ -1,0 +1,11 @@
+---
+state-of-mind:
+  - sad
+  - overwhelmed
+contact:
+  - Mom
+date: 2024-11-03
+---
+Paragraph one.
+
+Paragraph two.


### PR DESCRIPTION
Hey! I'm a new Obsidian users and wanted to add a proper way to migrate my Apple Journal entries, along with some metadata
- fixes #230

### Features

- **HTML parsing** - imports individual journal entry HTML files from the [exported data](https://support.apple.com/guide/iphone/print-and-export-entries-iph4cad323fe/ios)
- **Date extraction** - parses the formatted date header
- **Frontmatter metadata** - _optionally_ captures metadata including: state-of-mind, contacts mentioned, locations visited, music/media, workouts activity