### PR TITLE
Make tsconfig stricter and reflect build script

### DIFF
--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -4,7 +4,7 @@ import { ANAccount, ANAttachment, ANConverter, ANConverterType, ANFolderType } f
 import { descriptor } from './apple-notes/descriptor';
 import { ImportContext } from '../main';
 import { fsPromises, nodeBufferToArrayBuffer, os, parseFilePath, path, splitext, zlib } from '../filesystem';
-import { sanitizeFileName } from '../util';
+import { extractErrorMessage, sanitizeFileName } from '../util';
 import { FormatImporter } from '../format-importer';
 import { Root } from 'protobufjs';
 import SQLiteTag from './apple-notes/sqlite/index';
@@ -182,7 +182,7 @@ export class AppleNotesImporter extends FormatImporter {
 				await this.resolveFolder(f.Z_PK);
 			}
 			catch (e) {
-				this.ctx.reportFailed(f.ZTITLE2, e?.message);
+				this.ctx.reportFailed(f.ZTITLE2, extractErrorMessage(e));
 				console.error(e);
 			}
 		}
@@ -202,7 +202,7 @@ export class AppleNotesImporter extends FormatImporter {
 				await this.resolveNote(n.Z_PK);
 			}
 			catch (e) {
-				this.ctx.reportFailed(n.ZTITLE1, e?.message);
+				this.ctx.reportFailed(n.ZTITLE1, extractErrorMessage(e));
 				console.error(e);
 			}
 		}

--- a/src/formats/notion-api.ts
+++ b/src/formats/notion-api.ts
@@ -2,7 +2,7 @@ import { Notice, Setting, normalizePath, requestUrl, TFile, TFolder, setIcon, Da
 import { FormatImporter } from '../format-importer';
 import { ImportContext } from '../main';
 import { Client, PageObjectResponse } from '@notionhq/client';
-import { sanitizeFileName, serializeFrontMatter } from '../util';
+import { extractErrorMessage, sanitizeFileName, serializeFrontMatter } from '../util';
 import { parseFilePath } from '../filesystem';
 
 // Import helper modules
@@ -147,7 +147,7 @@ export class NotionAPIImporter extends FormatImporter {
 					}
 					catch (error) {
 						console.error('[Notion Importer] Error in loadPageTree:', error);
-						new Notice(`Failed to load pages: ${error.message}`);
+						new Notice(`Failed to load pages: ${extractErrorMessage(error)}`);
 					}
 				});
 
@@ -462,7 +462,7 @@ export class NotionAPIImporter extends FormatImporter {
 		}
 		catch (error) {
 			console.error('[Notion Importer] Failed to load pages:', error);
-			new Notice(`Failed to load pages: ${error.message || 'Unknown error'}`);
+			new Notice(`Failed to load pages: ${extractErrorMessage(error) ?? 'Unknown error'}`);
 		}
 		finally {
 			// Re-enable button
@@ -1058,7 +1058,7 @@ export class NotionAPIImporter extends FormatImporter {
 		catch (error) {
 			console.error('Notion API import error:', error);
 			ctx.reportFailed('Notion API import', error);
-			new Notice(`Import failed: ${error.message}`);
+			new Notice(`Import failed: ${extractErrorMessage(error)}`);
 		}
 	}
 

--- a/src/formats/notion.ts
+++ b/src/formats/notion.ts
@@ -2,6 +2,7 @@ import { normalizePath, Notice, Setting, DataWriteOptions } from 'obsidian';
 import { PickedFile } from '../filesystem';
 import { FormatImporter } from '../format-importer';
 import { ImportContext } from '../main';
+import { extractErrorMessage } from '../util';
 import { readZip, ZipEntryFile } from '../zip';
 import { cleanDuplicates } from './notion/clean-duplicates';
 import { readToMarkdown } from './notion/convert-to-md';
@@ -143,7 +144,7 @@ export class NotionImporter extends FormatImporter {
 				}
 			}
 			catch (e) {
-				if (e.message === 'page body was not found') {
+				if (extractErrorMessage(e) === 'page body was not found') {
 					ctx.reportSkipped(file.fullpath, 'page body was not found');
 					return;
 				}

--- a/src/formats/notion/convert-to-md.ts
+++ b/src/formats/notion/convert-to-md.ts
@@ -95,25 +95,28 @@ export async function readToMarkdown(info: NotionResolverInfo, file: ZipEntryFil
 	return serializeFrontMatter(frontMatter) + markdownBody;
 }
 
-const typesMap: Record<NotionProperty['type'], NotionPropertyType[]> = {
-	checkbox: ['checkbox'],
-	date: ['created_time', 'last_edited_time', 'date'],
-	list: ['file', 'multi_select', 'relation'],
-	number: ['number', 'auto_increment_id'],
-	text: [
-		'email',
-		'person',
-		'phone_number',
+const typesMap = new Map<NotionProperty['type'], NotionPropertyType[]>([
+	['checkbox', ['checkbox']],
+	['date', ['created_time', 'last_edited_time', 'date']],
+	['list', ['file', 'multi_select', 'relation']],
+	['number', ['number', 'auto_increment_id']],
+	[
 		'text',
-		'url',
-		'status',
-		'select',
-		'formula',
-		'rollup',
-		'last_edited_by',
-		'created_by',
+		[
+			'email',
+			'person',
+			'phone_number',
+			'text',
+			'url',
+			'status',
+			'select',
+			'formula',
+			'rollup',
+			'last_edited_by',
+			'created_by',
+		],
 	],
-};
+]);
 
 function parseProperty(property: HTMLTableRowElement): YamlProperty | undefined {
 	const notionType = property.className.match(/property-row-(.*)/)?.[1] as NotionPropertyType;
@@ -125,9 +128,13 @@ function parseProperty(property: HTMLTableRowElement): YamlProperty | undefined 
 
 	const body = property.cells[1];
 
-	let type = Object.keys(typesMap).find((type: keyof typeof typesMap) =>
-		typesMap[type].includes(notionType)
-	) as NotionProperty['type'];
+	let type: NotionProperty['type'] | undefined;
+	for (const [key, notionTypes] of typesMap.entries()) {
+		if (notionTypes.includes(notionType)) {
+			type = key;
+			break;
+		}
+	}
 
 	if (!type) throw new Error('type not found for: ' + body);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,7 +27,7 @@ interface ImporterDefinition {
 	optionText: string;
 	helpPermalink?: string;
 	formatDescription?: string;
-	importer: new (app: App, modal: Modal) => FormatImporter;
+	importer: new (app: App, modal: ImporterModal) => FormatImporter;
 }
 
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -64,3 +64,10 @@ export function truncateText(text: string, limit: number, ellipses: string = '..
 
 	return text.substring(0, limit) + ellipses;
 }
+
+export function extractErrorMessage(error: unknown): string | undefined {
+	if (typeof error === 'object' && error !== null && 'message' in error && typeof error.message === 'string') {
+		return error.message;
+	}
+	return undefined;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,19 @@
 {
 	"compilerOptions": {
+		"noEmit": true,
+		"rootDir": "src",
 		"baseUrl": "src",
 		"inlineSourceMap": true,
 		"inlineSources": true,
 		"module": "ESNext",
 		"target": "ES6",
 		"allowJs": true,
-		"noImplicitAny": true,
-		"moduleResolution": "node",
+		"moduleResolution": "bundler",
 		"importHelpers": true,
 		"isolatedModules": true,
 		"allowSyntheticDefaultImports": true,
-		"strictNullChecks": true,
-		"strictBindCallApply": true,
+		"strict": true,
+		"strictPropertyInitialization": false,
 		"lib": [
 			"DOM",
 			"ES5",


### PR DESCRIPTION
Changes in tsconfig:
- rootDir=src to avoid including files outside src
- moduleResolution=bundler and noEmit=true since we use esbuild
- enabled some of [the strict mode family options](https://www.typescriptlang.org/tsconfig/#strict):
  - strictFunctionTypes
  - noImplicitThis
  - alwaysStrict
  - useUnknownInCatchVariables

Other changes are for resolving new type errors.