### PR TITLE
Fix/bear import

### DIFF
--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -167,32 +167,31 @@ export class Bear2bkImporter extends FormatImporter {
 
 	private transformOutsideInlineCode(line: string, transformLine: (line: string) => string): string {
 		let inInline = false;
-		let current = '';
-		let result = '';
+		let currentStart = 0;
+		const parts: string[] = [];
 
 		for (let i = 0; i < line.length; i += 1) {
-			const ch = line[i];
-			if (ch === '`') {
-				if (!inInline) {
-					result += transformLine(current);
-					current = '';
-					inInline = true;
-				}
-				else {
-					result += '`' + current + '`';
-					current = '';
-					inInline = false;
-				}
+			if (line[i] !== '`') {
 				continue;
 			}
-			current += ch;
+
+			if (!inInline) {
+				parts.push(transformLine(line.slice(currentStart, i)));
+				inInline = true;
+			}
+			else {
+				parts.push('`' + line.slice(currentStart, i) + '`');
+				inInline = false;
+			}
+			currentStart = i + 1;
 		}
 
 		if (inInline) {
 			return line;
 		}
 
-		return result + transformLine(current);
+		parts.push(transformLine(line.slice(currentStart)));
+		return parts.join('');
 	}
 
 	private extractTagsFromContent(content: string): string[] {

--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -27,10 +27,8 @@ export class Bear2bkImporter extends FormatImporter {
 	private static readonly nonAlphaStart = /^[0-9_\-]/;
 	private static readonly invalidChar = /[^A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ0-9_\/-]/;
 	private static readonly hexColorTag = /^[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$/;
-	private static readonly hexColorInline = /(?<!\S)#([0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?)(?=\s|$|[^A-Za-z0-9_\/-])#?/g;
 	private static readonly tagCandidate = /(?<!\S)#([^\s#]+)/g;
-	private static readonly enclosedTagWithFollowingChar = /#(?!\s)((?:(?!\s#)[^\n#])*?\S)#(?=\S)/g;
-	private static readonly enclosedTag = /#(?!\s)((?:(?!\s#)[^\n#])*?\S)#/g;
+	private static readonly tagNormalizationMatcher = /(?<!\S)#([0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?)(?=\s|$|[^A-Za-z0-9_\/-])#?|#(?!\s)((?:(?!\s#)[^\n#])*?\S)#(?=\S)|#(?!\s)((?:(?!\s#)[^\n#])*?\S)#|(?<!\S)#([^\s#]+)/g;
 	private static readonly assetMatcher = /\[[^\]]*\]\((assets\/[^\)]+)\)/gm;
 	private static readonly bearLinkMatcher = /bear:\/\/x-callback-url\/open-note\?id=([A-Z0-9\-]+)/g;
 	private static readonly numericOnly = /^\d+$/;
@@ -294,30 +292,28 @@ export class Bear2bkImporter extends FormatImporter {
 								}
 							}
 
-							// Escape hex color tags, normalize enclosed tags, then normalize simple tags (single pass)
+							// Normalize tags and escape hex color tags (single pass)
+							const tagMatcher = Bear2bkImporter.tagNormalizationMatcher;
 							mdContent = this.transformOutsideCodeBlocks(mdContent, (line) => {
-								const hexEscaped = line.replace(Bear2bkImporter.hexColorInline, (_match, hex) => {
-									return `\\#${hex}`;
-								});
-								const enclosedNormalized = hexEscaped.replace(Bear2bkImporter.enclosedTagWithFollowingChar, (match, tag) => {
-									if (this.isHexColorTag(tag)) {
-										return match;
+								return line.replace(tagMatcher, (match, hexTag, enclosedFollowing, enclosedTag, rawTag) => {
+									if (hexTag) {
+										return `\\#${hexTag}`;
 									}
-									return this.normalizeEnclosedTag(tag, match, true);
-								}).replace(Bear2bkImporter.enclosedTag, (match, tag) => {
-									if (this.isHexColorTag(tag)) {
-										return match;
+									if (enclosedFollowing) {
+										return this.normalizeEnclosedTag(enclosedFollowing, match, true);
 									}
-									return this.normalizeEnclosedTag(tag, match, false);
-								});
-
-								return enclosedNormalized.replace(Bear2bkImporter.tagCandidate, (match, rawTag) => {
-									const splitTag = this.splitTrailingPunctuation(rawTag);
-									const normalizedTag = this.normalizeSimpleTag(splitTag ? splitTag.tag : rawTag);
-									if (!normalizedTag) {
-										return match;
+									if (enclosedTag) {
+										return this.normalizeEnclosedTag(enclosedTag, match, false);
 									}
-									return '#' + normalizedTag + (splitTag ? splitTag.trailing : '');
+									if (rawTag) {
+										const splitTag = this.splitTrailingPunctuation(rawTag);
+										const normalizedTag = this.normalizeSimpleTag(splitTag ? splitTag.tag : rawTag);
+										if (!normalizedTag) {
+											return match;
+										}
+										return '#' + normalizedTag + (splitTag ? splitTag.trailing : '');
+									}
+									return match;
 								});
 							});
 

--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -220,9 +220,9 @@ export class Bear2bkImporter extends FormatImporter {
 								}
 							}
 
-							// Replace spaces in enclosed tags with underscores and make them classic tags
+							// Replace spaces in enclosed tags, then normalize simple tags (single pass)
 							mdContent = this.transformOutsideCodeBlocks(mdContent, (line) => {
-								return line.replace(Bear2bkImporter.enclosedTagWithFollowingChar, (match, tag) => {
+								const enclosedNormalized = line.replace(Bear2bkImporter.enclosedTagWithFollowingChar, (match, tag) => {
 									if (this.isHexColorTag(tag)) {
 										return match;
 									}
@@ -233,11 +233,8 @@ export class Bear2bkImporter extends FormatImporter {
 									}
 									return '#' + tag.replace(/\s+/g, '_');
 								});
-							});
 
-							// Remove special characters in simple tags
-							mdContent = this.transformOutsideCodeBlocks(mdContent, (line) => {
-								return line.replace(Bear2bkImporter.tagCandidate, (match, rawTag) => {
+								return enclosedNormalized.replace(Bear2bkImporter.tagCandidate, (match, rawTag) => {
 									const normalizedTag = this.normalizeSimpleTag(rawTag);
 									if (!normalizedTag) {
 										return match;

--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -119,6 +119,7 @@ export class Bear2bkImporter extends FormatImporter {
 							ctx.status('Importing note ' + mdFilename);
 							let mdContent = await entry.readText();
 							mdContent = this.removeMarkdownHeader(mdFilename, mdContent);
+							mdContent = this.fixListIndentation(mdContent);
 
 							const assetMatches = [...mdContent.matchAll(assetMatcher)];
 							if (assetMatches.length > 0) {
@@ -340,5 +341,55 @@ export class Bear2bkImporter extends FormatImporter {
 		return idx > 0
 			? mdContent.substring(idx + 1)
 			: '';
+	}
+
+	private fixListIndentation(text: string): string {
+		const hasTrailingNewline = text.endsWith('\n');
+		const lines = hasTrailingNewline ? text.slice(0, -1).split('\n') : text.split('\n');
+
+		const out: string[] = [];
+		let inFrontmatter = false;
+		let inCode = false;
+
+		for (let i = 0; i < lines.length; i += 1) {
+			let line = lines[i];
+
+			if (i === 0 && line.trim() === '---') {
+				inFrontmatter = true;
+				out.push(line);
+				continue;
+			}
+
+			if (inFrontmatter) {
+				out.push(line);
+				if (line.trim() === '---') {
+					inFrontmatter = false;
+				}
+				continue;
+			}
+
+			const stripped = line.trimStart();
+			if (stripped.startsWith('```')) {
+				inCode = !inCode;
+				out.push(line);
+				continue;
+			}
+
+			if (inCode) {
+				out.push(line);
+				continue;
+			}
+
+			const match = line.match(/^( +)([-*+]\s|\d+\.)/);
+			if (match) {
+				const spaces = match[1];
+				const newIndent = ' '.repeat(spaces.length * 2);
+				line = newIndent + line.slice(spaces.length);
+			}
+
+			out.push(line);
+		}
+
+		return out.join('\n') + (hasTrailingNewline ? '\n' : '');
 	}
 }

--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -91,6 +91,15 @@ export class Bear2bkImporter extends FormatImporter {
 		return null;
 	}
 
+	private normalizeEnclosedTag(tag: string, match: string, addTrailingSpace: boolean): string {
+		const normalizedSingle = tag.replace(/\s+/g, '_');
+		const normalized = this.normalizeSimpleTag(normalizedSingle);
+		if (!normalized) {
+			return match;
+		}
+		return '#' + normalized + (addTrailingSpace ? ' ' : '');
+	}
+
 	private isHexColorTag(rawTag: string): boolean {
 		return Bear2bkImporter.hexColorTag.test(rawTag);
 	}
@@ -220,12 +229,12 @@ export class Bear2bkImporter extends FormatImporter {
 									if (this.isHexColorTag(tag)) {
 										return match;
 									}
-									return '#' + tag.replace(/\s+/g, '_') + ' ';
+									return this.normalizeEnclosedTag(tag, match, true);
 								}).replace(Bear2bkImporter.enclosedTag, (match, tag) => {
 									if (this.isHexColorTag(tag)) {
 										return match;
 									}
-									return '#' + tag.replace(/\s+/g, '_');
+									return this.normalizeEnclosedTag(tag, match, false);
 								});
 
 								return enclosedNormalized.replace(Bear2bkImporter.tagCandidate, (match, rawTag) => {

--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -76,31 +76,54 @@ export class Bear2bkImporter extends FormatImporter {
 		return null;
 	}
 
+	private transformOutsideCodeBlocks(content: string, transformLine: (line: string) => string): string {
+		const hasTrailingNewline = content.endsWith('\n');
+		const lines = hasTrailingNewline ? content.slice(0, -1).split('\n') : content.split('\n');
+		let inCode = false;
+		const out: string[] = [];
+
+		for (const line of lines) {
+			const trimmed = line.trimStart();
+			if (trimmed.startsWith('```')) {
+				inCode = !inCode;
+				out.push(line);
+				continue;
+			}
+
+			out.push(inCode ? line : transformLine(line));
+		}
+
+		return out.join('\n') + (hasTrailingNewline ? '\n' : '');
+	}
+
 	private extractTagsFromContent(content: string): string[] {
 		const tags = new Set<string>();
 		const isNumericOnly = (value: string) => /^\d+$/.test(value);
 		const tagCandidateRegex = /(?<!\S)#([^\s#]+)/g;
 
-		let match;
-		while ((match = tagCandidateRegex.exec(content)) !== null) {
-			const rawTag = match[1].trim();
-			const normalizedTag = this.normalizeSimpleTag(rawTag);
-			if (!normalizedTag) {
-				continue;
-			}
+		this.transformOutsideCodeBlocks(content, (line) => {
+			let match;
+			while ((match = tagCandidateRegex.exec(line)) !== null) {
+				const rawTag = match[1].trim();
+				const normalizedTag = this.normalizeSimpleTag(rawTag);
+				if (!normalizedTag) {
+					continue;
+				}
 
-			if (this.flattenTags && normalizedTag.includes('/')) {
-				const parts = normalizedTag.split('/');
-				for (const part of parts) {
-					if (part !== '' && !isNumericOnly(part)) {
-						tags.add(part);
+				if (this.flattenTags && normalizedTag.includes('/')) {
+					const parts = normalizedTag.split('/');
+					for (const part of parts) {
+						if (part !== '' && !isNumericOnly(part)) {
+							tags.add(part);
+						}
 					}
 				}
+				else if (!isNumericOnly(normalizedTag)) {
+					tags.add(normalizedTag);
+				}
 			}
-			else if (!isNumericOnly(normalizedTag)) {
-				tags.add(normalizedTag);
-			}
-		}
+			return line;
+		});
 
 		return Array.from(tags);
 	}
@@ -174,12 +197,14 @@ export class Bear2bkImporter extends FormatImporter {
 							});
 
 							// Remove special characters in simple tags
-							mdContent = mdContent.replace(/(?<!\S)#([^\s#]+)/g, (match, rawTag) => {
-								const normalizedTag = this.normalizeSimpleTag(rawTag);
-								if (!normalizedTag) {
-									return match;
-								}
-								return '#' + normalizedTag;
+							mdContent = this.transformOutsideCodeBlocks(mdContent, (line) => {
+								return line.replace(/(?<!\S)#([^\s#]+)/g, (match, rawTag) => {
+									const normalizedTag = this.normalizeSimpleTag(rawTag);
+									if (!normalizedTag) {
+										return match;
+									}
+									return '#' + normalizedTag;
+								});
 							});
 
 							// Extract tags from content

--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -118,10 +118,45 @@ export class Bear2bkImporter extends FormatImporter {
 				continue;
 			}
 
-			out.push(inCode ? line : transformLine(line));
+			if (inCode) {
+				out.push(line);
+				continue;
+			}
+
+			out.push(this.transformOutsideInlineCode(line, transformLine));
 		}
 
 		return out.join('\n') + (hasTrailingNewline ? '\n' : '');
+	}
+
+	private transformOutsideInlineCode(line: string, transformLine: (line: string) => string): string {
+		let inInline = false;
+		let current = '';
+		let result = '';
+
+		for (let i = 0; i < line.length; i += 1) {
+			const ch = line[i];
+			if (ch === '`') {
+				if (!inInline) {
+					result += transformLine(current);
+					current = '';
+					inInline = true;
+				}
+				else {
+					result += '`' + current + '`';
+					current = '';
+					inInline = false;
+				}
+				continue;
+			}
+			current += ch;
+		}
+
+		if (inInline) {
+			return line;
+		}
+
+		return result + transformLine(current);
 	}
 
 	private extractTagsFromContent(content: string): string[] {

--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -27,10 +27,10 @@ export class Bear2bkImporter extends FormatImporter {
 	private static readonly nonAlphaStart = /^[0-9_\-]/;
 	private static readonly invalidChar = /[^A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ0-9_\/-]/;
 	private static readonly hexColorTag = /^[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$/;
-	private static readonly hexColorInline = /(?<!\S)#([0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?)(?![0-9a-fA-F])#?/g;
+	private static readonly hexColorInline = /(?<!\S)#([0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?)(?=\s|$|[^A-Za-z0-9_\/-])#?/g;
 	private static readonly tagCandidate = /(?<!\S)#([^\s#]+)/g;
-	private static readonly enclosedTagWithFollowingChar = /#(?!\s)([^\n#]*?\S)#(?=\S)/g;
-	private static readonly enclosedTag = /#(?!\s)([^\n#]*?\S)#/g;
+	private static readonly enclosedTagWithFollowingChar = /#(?!\s)((?:(?!\s#)[^\n#])*?\S)#(?=\S)/g;
+	private static readonly enclosedTag = /#(?!\s)((?:(?!\s#)[^\n#])*?\S)#/g;
 	private static readonly assetMatcher = /\[[^\]]*\]\((assets\/[^\)]+)\)/gm;
 	private static readonly bearLinkMatcher = /bear:\/\/x-callback-url\/open-note\?id=([A-Z0-9\-]+)/g;
 	private static readonly numericOnly = /^\d+$/;
@@ -91,7 +91,21 @@ export class Bear2bkImporter extends FormatImporter {
 		return null;
 	}
 
+	private splitTrailingPunctuation(rawTag: string): { tag: string; trailing: string } | null {
+		const match = rawTag.match(/^(.*?)([.,]+)$/);
+		if (!match) {
+			return null;
+		}
+		if (match[1] === '') {
+			return null;
+		}
+		return { tag: match[1], trailing: match[2] };
+	}
+
 	private normalizeEnclosedTag(tag: string, match: string, addTrailingSpace: boolean): string {
+		if (/\s#$/.test(match)) {
+			return match;
+		}
 		const normalizedSingle = tag.replace(/\s+/g, '_');
 		const normalized = this.normalizeSimpleTag(normalizedSingle);
 		if (!normalized) {
@@ -169,7 +183,8 @@ export class Bear2bkImporter extends FormatImporter {
 			tagCandidateRegex.lastIndex = 0;
 			while ((match = tagCandidateRegex.exec(line)) !== null) {
 				const rawTag = match[1].trim();
-				const normalizedTag = this.normalizeSimpleTag(rawTag);
+				const splitTag = this.splitTrailingPunctuation(rawTag);
+				const normalizedTag = this.normalizeSimpleTag(splitTag ? splitTag.tag : rawTag);
 				if (!normalizedTag) {
 					continue;
 				}
@@ -273,11 +288,12 @@ export class Bear2bkImporter extends FormatImporter {
 								});
 
 								return enclosedNormalized.replace(Bear2bkImporter.tagCandidate, (match, rawTag) => {
-									const normalizedTag = this.normalizeSimpleTag(rawTag);
+									const splitTag = this.splitTrailingPunctuation(rawTag);
+									const normalizedTag = this.normalizeSimpleTag(splitTag ? splitTag.tag : rawTag);
 									if (!normalizedTag) {
 										return match;
 									}
-									return '#' + normalizedTag;
+									return '#' + normalizedTag + (splitTag ? splitTag.trailing : '');
 								});
 							});
 

--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -92,7 +92,7 @@ export class Bear2bkImporter extends FormatImporter {
 		return null;
 	}
 
-	private splitTrailingPunctuation(rawTag: string): { tag: string; trailing: string } | null {
+	private splitTrailingPunctuation(rawTag: string): { tag: string, trailing: string } | null {
 		const match = rawTag.match(/^(.*?)([.,]+)$/);
 		if (!match) {
 			return null;
@@ -199,7 +199,7 @@ export class Bear2bkImporter extends FormatImporter {
 		}
 	}
 
-	private normalizeTagsAndCollect(content: string): { content: string; tags: string[] } {
+	private normalizeTagsAndCollect(content: string): { content: string, tags: string[] } {
 		const tags = new Set<string>();
 		const tagMatcher = Bear2bkImporter.tagNormalizationMatcher;
 
@@ -552,7 +552,7 @@ export class Bear2bkImporter extends FormatImporter {
 			return newIndent + lineValue.slice(leadingSpaces);
 		};
 
-		const listFenceMatch = (lineValue: string): { indent: number; marker: string; fence: string } | null => {
+		const listFenceMatch = (lineValue: string): { indent: number, marker: string, fence: string } | null => {
 			const match = lineValue.match(/^(\s*)([-*+]\s|\d+\.\s)(```.*)$/);
 			if (!match) {
 				return null;

--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -23,6 +23,19 @@ export class Bear2bkImporter extends FormatImporter {
 	private flattenTags: boolean = false;
 	private storeId: boolean = false;
 
+	private static readonly alphaStart = /^[A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ]/;
+	private static readonly nonAlphaStart = /^[0-9_\-]/;
+	private static readonly invalidChar = /[^A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ0-9_\/-]/;
+	private static readonly hexColorTag = /^[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$/;
+	private static readonly hexColorInline = /(?<!\S)#([0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?)(?![0-9a-fA-F])#?/g;
+	private static readonly tagCandidate = /(?<!\S)#([^\s#]+)/g;
+	private static readonly enclosedTagWithFollowingChar = /#(?!\s)([^\n#]*?\S)#(?=\S)/g;
+	private static readonly enclosedTag = /#(?!\s)([^\n#]*?\S)#/g;
+	private static readonly assetMatcher = /\[[^\]]*\]\((assets\/[^\)]+)\)/gm;
+	private static readonly bearLinkMatcher = /bear:\/\/x-callback-url\/open-note\?id=([A-Z0-9\-]+)/g;
+	private static readonly numericOnly = /^\d+$/;
+	private static readonly collapseUnderscores = /_+/g;
+
 	init() {
 		this.addFileChooserSetting('Bear2bk', ['bear2bk']);
 		this.addOutputLocationSetting('Bear');
@@ -57,13 +70,11 @@ export class Bear2bkImporter extends FormatImporter {
 			return null;
 		}
 
-		const alphaStart = /^[A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ]/;
-		const nonAlphaStart = /^[0-9_\-]/;
-		const invalidChar = /[^A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ0-9_\/-]/;
+		const { alphaStart, nonAlphaStart, invalidChar } = Bear2bkImporter;
 
 		if (alphaStart.test(rawTag)) {
 			let cleanTag = rawTag.replace(invalidChar, '_');
-			cleanTag = cleanTag.replace(/_+/g, '_');
+			cleanTag = cleanTag.replace(Bear2bkImporter.collapseUnderscores, '_');
 			return cleanTag;
 		}
 
@@ -71,7 +82,7 @@ export class Bear2bkImporter extends FormatImporter {
 			if (invalidChar.test(rawTag)) {
 				return null;
 			}
-			if (/^\d+$/.test(rawTag)) {
+			if (Bear2bkImporter.numericOnly.test(rawTag)) {
 				return null;
 			}
 			return rawTag;
@@ -81,12 +92,12 @@ export class Bear2bkImporter extends FormatImporter {
 	}
 
 	private isHexColorTag(rawTag: string): boolean {
-		return /^[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$/.test(rawTag);
+		return Bear2bkImporter.hexColorTag.test(rawTag);
 	}
 
 	private escapeHexColorTags(content: string): string {
 		return this.transformOutsideCodeBlocks(content, (line) => {
-			return line.replace(/(?<!\S)#([0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?)(?![0-9a-fA-F])#?/g, (_match, hex) => {
+			return line.replace(Bear2bkImporter.hexColorInline, (_match, hex) => {
 				return `\\#${hex}`;
 			});
 		});
@@ -114,11 +125,12 @@ export class Bear2bkImporter extends FormatImporter {
 
 	private extractTagsFromContent(content: string): string[] {
 		const tags = new Set<string>();
-		const isNumericOnly = (value: string) => /^\d+$/.test(value);
-		const tagCandidateRegex = /(?<!\S)#([^\s#]+)/g;
+		const isNumericOnly = (value: string) => Bear2bkImporter.numericOnly.test(value);
+		const tagCandidateRegex = Bear2bkImporter.tagCandidate;
 
 		this.transformOutsideCodeBlocks(content, (line) => {
 			let match;
+			tagCandidateRegex.lastIndex = 0;
 			while ((match = tagCandidateRegex.exec(line)) !== null) {
 				const rawTag = match[1].trim();
 				const normalizedTag = this.normalizeSimpleTag(rawTag);
@@ -164,7 +176,7 @@ export class Bear2bkImporter extends FormatImporter {
 		let outputFolder = folder;
 
 		// match 1: assets/something.jpg
-		const assetMatcher = new RegExp('\\[[^\\]]*\\]\\((assets/[^\\)]+)\\)', 'gm');
+		const assetMatcher = Bear2bkImporter.assetMatcher;
 
 		const archiveFolder = await this.createFolders(`${folder.path}/archive`);
 		const trashFolder = await this.createFolders(`${folder.path}/trash`);
@@ -210,12 +222,12 @@ export class Bear2bkImporter extends FormatImporter {
 
 							// Replace spaces in enclosed tags with underscores and make them classic tags
 							mdContent = this.transformOutsideCodeBlocks(mdContent, (line) => {
-								return line.replace(/#(?!\s)([^\n#]*?\S)#(?=\S)/g, (match, tag) => {
+								return line.replace(Bear2bkImporter.enclosedTagWithFollowingChar, (match, tag) => {
 									if (this.isHexColorTag(tag)) {
 										return match;
 									}
 									return '#' + tag.replace(/\s+/g, '_') + ' ';
-								}).replace(/#(?!\s)([^\n#]*?\S)#/g, (match, tag) => {
+								}).replace(Bear2bkImporter.enclosedTag, (match, tag) => {
 									if (this.isHexColorTag(tag)) {
 										return match;
 									}
@@ -225,7 +237,7 @@ export class Bear2bkImporter extends FormatImporter {
 
 							// Remove special characters in simple tags
 							mdContent = this.transformOutsideCodeBlocks(mdContent, (line) => {
-								return line.replace(/(?<!\S)#([^\s#]+)/g, (match, rawTag) => {
+								return line.replace(Bear2bkImporter.tagCandidate, (match, rawTag) => {
 									const normalizedTag = this.normalizeSimpleTag(rawTag);
 									if (!normalizedTag) {
 										return match;
@@ -344,7 +356,7 @@ export class Bear2bkImporter extends FormatImporter {
 				mtime: metadata?.mtime,
 			};
 			await this.vault.process(file, (mdContent) => {
-				return mdContent.replace(/bear:\/\/x-callback-url\/open-note\?id=([A-Z0-9\-]+)/g,
+				return mdContent.replace(Bear2bkImporter.bearLinkMatcher,
 					(match, noteId) => {
 						const noteTitle = idMapping[noteId]?.filename;
 						if (noteTitle) {

--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -48,32 +48,61 @@ export class Bear2bkImporter extends FormatImporter {
 			);
 	}
 
+	private normalizeSimpleTag(rawTag: string): string | null {
+		if (!rawTag) {
+			return null;
+		}
+
+		const alphaStart = /^[A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ]/;
+		const nonAlphaStart = /^[0-9_\-]/;
+		const invalidChar = /[^A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ0-9_\/-]/;
+
+		if (alphaStart.test(rawTag)) {
+			let cleanTag = rawTag.replace(invalidChar, '_');
+			cleanTag = cleanTag.replace(/_+/g, '_');
+			return cleanTag;
+		}
+
+		if (nonAlphaStart.test(rawTag)) {
+			if (invalidChar.test(rawTag)) {
+				return null;
+			}
+			if (/^\d+$/.test(rawTag)) {
+				return null;
+			}
+			return rawTag;
+		}
+
+		return null;
+	}
+
 	private extractTagsFromContent(content: string): string[] {
 		const tags = new Set<string>();
+		const isNumericOnly = (value: string) => /^\d+$/.test(value);
+		const tagCandidateRegex = /(?<!\S)#([^\s#]+)/g;
 
-		// Extract simple #tags (alphanumeric, underscore, hyphen, and slash, no spaces)
-		//    Ensures it's not part of a URL or an already processed enclosed tag.
-		//    Allows / in the middle of the tag, but not at the start or end of the simple tag.
-		//    Diacritics regex range from https://stackoverflow.com/questions/30225552/regex-for-diacritics
-		const simpleTagRegex = /(?<!\S)#([A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ0-9_][A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ0-9_/\-]*[A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ0-9_]|[A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ0-9_]+)(?![#\w/])/g;
-		let matchSimple;
-		while ((matchSimple = simpleTagRegex.exec(content)) !== null) {
-			const rawSimpleTag = matchSimple[1].trim();
-			if (rawSimpleTag !== '') {
-				if (this.flattenTags && rawSimpleTag.includes('/')) {
-					const parts = rawSimpleTag.split('/');
-					for (const part of parts) {
+		let match;
+		while ((match = tagCandidateRegex.exec(content)) !== null) {
+			const rawTag = match[1].trim();
+			const normalizedTag = this.normalizeSimpleTag(rawTag);
+			if (!normalizedTag) {
+				continue;
+			}
+
+			if (this.flattenTags && normalizedTag.includes('/')) {
+				const parts = normalizedTag.split('/');
+				for (const part of parts) {
+					if (part !== '' && !isNumericOnly(part)) {
 						tags.add(part);
 					}
 				}
-				else {
-					tags.add(rawSimpleTag);
-				}
+			}
+			else if (!isNumericOnly(normalizedTag)) {
+				tags.add(normalizedTag);
 			}
 		}
 
-		const finalTags = Array.from(tags);
-		return finalTags;
+		return Array.from(tags);
 	}
 
 	async import(ctx: ImportContext): Promise<void> {
@@ -145,10 +174,12 @@ export class Bear2bkImporter extends FormatImporter {
 							});
 
 							// Remove special characters in simple tags
-							mdContent = mdContent.replace(/#([^0-9\s#]+)/g, (_match, tag) => {
-								let cleanTag = tag.replace(/[^A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ0-9_/\-]/g, '_');
-								cleanTag = cleanTag.replace(/_+/g, '_'); // collapse multiple underscores
-								return '#' + cleanTag;
+							mdContent = mdContent.replace(/(?<!\S)#([^\s#]+)/g, (match, rawTag) => {
+								const normalizedTag = this.normalizeSimpleTag(rawTag);
+								if (!normalizedTag) {
+									return match;
+								}
+								return '#' + normalizedTag;
 							});
 
 							// Extract tags from content

--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -95,14 +95,6 @@ export class Bear2bkImporter extends FormatImporter {
 		return Bear2bkImporter.hexColorTag.test(rawTag);
 	}
 
-	private escapeHexColorTags(content: string): string {
-		return this.transformOutsideCodeBlocks(content, (line) => {
-			return line.replace(Bear2bkImporter.hexColorInline, (_match, hex) => {
-				return `\\#${hex}`;
-			});
-		});
-	}
-
 	private transformOutsideCodeBlocks(content: string, transformLine: (line: string) => string): string {
 		const hasTrailingNewline = content.endsWith('\n');
 		const lines = hasTrailingNewline ? content.slice(0, -1).split('\n') : content.split('\n');
@@ -199,7 +191,6 @@ export class Bear2bkImporter extends FormatImporter {
 							ctx.status('Importing note ' + mdFilename);
 							let mdContent = await entry.readText();
 							mdContent = this.removeMarkdownHeader(mdFilename, mdContent);
-							mdContent = this.escapeHexColorTags(mdContent);
 							mdContent = this.fixListIndentation(mdContent);
 
 							const assetMatches = [...mdContent.matchAll(assetMatcher)];
@@ -220,9 +211,12 @@ export class Bear2bkImporter extends FormatImporter {
 								}
 							}
 
-							// Replace spaces in enclosed tags, then normalize simple tags (single pass)
+							// Escape hex color tags, normalize enclosed tags, then normalize simple tags (single pass)
 							mdContent = this.transformOutsideCodeBlocks(mdContent, (line) => {
-								const enclosedNormalized = line.replace(Bear2bkImporter.enclosedTagWithFollowingChar, (match, tag) => {
+								const hexEscaped = line.replace(Bear2bkImporter.hexColorInline, (_match, hex) => {
+									return `\\#${hex}`;
+								});
+								const enclosedNormalized = hexEscaped.replace(Bear2bkImporter.enclosedTagWithFollowingChar, (match, tag) => {
 									if (this.isHexColorTag(tag)) {
 										return match;
 									}

--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -53,6 +53,10 @@ export class Bear2bkImporter extends FormatImporter {
 			return null;
 		}
 
+		if (this.isHexColorTag(rawTag)) {
+			return null;
+		}
+
 		const alphaStart = /^[A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ]/;
 		const nonAlphaStart = /^[0-9_\-]/;
 		const invalidChar = /[^A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ0-9_\/-]/;
@@ -74,6 +78,18 @@ export class Bear2bkImporter extends FormatImporter {
 		}
 
 		return null;
+	}
+
+	private isHexColorTag(rawTag: string): boolean {
+		return /^[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$/.test(rawTag);
+	}
+
+	private escapeHexColorTags(content: string): string {
+		return this.transformOutsideCodeBlocks(content, (line) => {
+			return line.replace(/(?<!\S)#([0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?)(?![0-9a-fA-F])#?/g, (_match, hex) => {
+				return `\\#${hex}`;
+			});
+		});
 	}
 
 	private transformOutsideCodeBlocks(content: string, transformLine: (line: string) => string): string {
@@ -171,6 +187,7 @@ export class Bear2bkImporter extends FormatImporter {
 							ctx.status('Importing note ' + mdFilename);
 							let mdContent = await entry.readText();
 							mdContent = this.removeMarkdownHeader(mdFilename, mdContent);
+							mdContent = this.escapeHexColorTags(mdContent);
 							mdContent = this.fixListIndentation(mdContent);
 
 							const assetMatches = [...mdContent.matchAll(assetMatcher)];
@@ -193,9 +210,15 @@ export class Bear2bkImporter extends FormatImporter {
 
 							// Replace spaces in enclosed tags with underscores and make them classic tags
 							mdContent = this.transformOutsideCodeBlocks(mdContent, (line) => {
-								return line.replace(/#(?!\s)([^\n#]*?\S)#(?=\S)/g, (_match, tag) => {
+								return line.replace(/#(?!\s)([^\n#]*?\S)#(?=\S)/g, (match, tag) => {
+									if (this.isHexColorTag(tag)) {
+										return match;
+									}
 									return '#' + tag.replace(/\s+/g, '_') + ' ';
-								}).replace(/#(?!\s)([^\n#]*?\S)#/g, (_match, tag) => {
+								}).replace(/#(?!\s)([^\n#]*?\S)#/g, (match, tag) => {
+									if (this.isHexColorTag(tag)) {
+										return match;
+									}
 									return '#' + tag.replace(/\s+/g, '_');
 								});
 							});

--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -119,28 +119,52 @@ export class Bear2bkImporter extends FormatImporter {
 	}
 
 	private transformOutsideCodeBlocks(content: string, transformLine: (line: string) => string): string {
-		const hasTrailingNewline = content.endsWith('\n');
-		const lines = hasTrailingNewline ? content.slice(0, -1).split('\n') : content.split('\n');
-		let inCode = false;
 		const out: string[] = [];
+		let inCode = false;
+		let lineStart = 0;
+		const length = content.length;
 
-		for (const line of lines) {
-			const trimmed = line.trimStart();
-			if (trimmed.startsWith('```')) {
+		const isCodeFenceLine = (lineValue: string): boolean => {
+			let idx = 0;
+			while (idx < lineValue.length) {
+				const code = lineValue.charCodeAt(idx);
+				if (code !== 32 && code !== 9) {
+					break;
+				}
+				idx += 1;
+			}
+			return lineValue.startsWith('```', idx);
+		};
+
+		for (let i = 0; i <= length; i += 1) {
+			const atLineEnd = i === length || content.charCodeAt(i) === 10;
+			if (!atLineEnd) {
+				continue;
+			}
+
+			if (i === length && lineStart === length) {
+				break;
+			}
+
+			const line = content.slice(lineStart, i);
+			if (isCodeFenceLine(line)) {
 				inCode = !inCode;
 				out.push(line);
-				continue;
 			}
-
-			if (inCode) {
+			else if (inCode) {
 				out.push(line);
-				continue;
+			}
+			else {
+				out.push(this.transformOutsideInlineCode(line, transformLine));
 			}
 
-			out.push(this.transformOutsideInlineCode(line, transformLine));
+			if (i < length) {
+				out.push('\n');
+			}
+			lineStart = i + 1;
 		}
 
-		return out.join('\n') + (hasTrailingNewline ? '\n' : '');
+		return out.join('');
 	}
 
 	private transformOutsideInlineCode(line: string, transformLine: (line: string) => string): string {

--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -480,6 +480,33 @@ export class Bear2bkImporter extends FormatImporter {
 		const out: string[] = [];
 		let inFrontmatter = false;
 		let inCode = false;
+		let codeIndentSourceBase: number | null = null;
+		let codeIndentTargetBase: number | null = null;
+
+		const countLeadingSpaces = (value: string): number => {
+			let count = 0;
+			while (count < value.length && value[count] === ' ') {
+				count += 1;
+			}
+			return count;
+		};
+
+		const adjustCodeIndent = (lineValue: string, sourceBase: number, targetBase: number): string => {
+			const leadingSpaces = countLeadingSpaces(lineValue);
+			if (leadingSpaces < sourceBase) {
+				return lineValue;
+			}
+			const newIndent = ' '.repeat(targetBase + (leadingSpaces - sourceBase));
+			return newIndent + lineValue.slice(leadingSpaces);
+		};
+
+		const listFenceMatch = (lineValue: string): { indent: number; marker: string; fence: string } | null => {
+			const match = lineValue.match(/^(\s*)([-*+]\s|\d+\.\s)(```.*)$/);
+			if (!match) {
+				return null;
+			}
+			return { indent: match[1].length, marker: match[2], fence: match[3] };
+		};
 
 		for (let i = 0; i < lines.length; i += 1) {
 			let line = lines[i];
@@ -498,14 +525,42 @@ export class Bear2bkImporter extends FormatImporter {
 				continue;
 			}
 
+			const listFence = listFenceMatch(line);
 			const stripped = line.trimStart();
-			if (stripped.startsWith('```')) {
+			if (listFence || stripped.startsWith('```')) {
+				if (listFence) {
+					const targetIndent = listFence.indent * 2;
+					line = ' '.repeat(targetIndent) + listFence.marker + listFence.fence;
+					if (!inCode) {
+						codeIndentSourceBase = listFence.indent + listFence.marker.length;
+						codeIndentTargetBase = targetIndent + listFence.marker.length;
+					}
+					else {
+						codeIndentSourceBase = null;
+						codeIndentTargetBase = null;
+					}
+				}
+				else {
+					const leadingSpaces = countLeadingSpaces(line);
+					line = ' '.repeat(leadingSpaces * 2) + line.slice(leadingSpaces);
+					if (!inCode) {
+						codeIndentSourceBase = leadingSpaces;
+						codeIndentTargetBase = leadingSpaces * 2;
+					}
+					else {
+						codeIndentSourceBase = null;
+						codeIndentTargetBase = null;
+					}
+				}
 				inCode = !inCode;
 				out.push(line);
 				continue;
 			}
 
 			if (inCode) {
+				if (codeIndentSourceBase !== null && codeIndentTargetBase !== null) {
+					line = adjustCodeIndent(line, codeIndentSourceBase, codeIndentTargetBase);
+				}
 				out.push(line);
 				continue;
 			}

--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -203,7 +203,7 @@ export class Bear2bkImporter extends FormatImporter {
 			let match;
 			tagCandidateRegex.lastIndex = 0;
 			while ((match = tagCandidateRegex.exec(line)) !== null) {
-				const rawTag = match[1].trim();
+				const rawTag = match[1];
 				const splitTag = this.splitTrailingPunctuation(rawTag);
 				const normalizedTag = this.normalizeSimpleTag(splitTag ? splitTag.tag : rawTag);
 				if (!normalizedTag) {
@@ -526,6 +526,34 @@ export class Bear2bkImporter extends FormatImporter {
 			return count;
 		};
 
+		const countLeadingWhitespace = (value: string): number => {
+			let count = 0;
+			while (count < value.length) {
+				const code = value.charCodeAt(count);
+				if (code !== 32 && code !== 9 && code !== 13) {
+					break;
+				}
+				count += 1;
+			}
+			return count;
+		};
+
+		const isFrontmatterFence = (lineValue: string): boolean => {
+			const start = countLeadingWhitespace(lineValue);
+			if (!lineValue.startsWith('---', start)) {
+				return false;
+			}
+			let idx = start + 3;
+			while (idx < lineValue.length) {
+				const code = lineValue.charCodeAt(idx);
+				if (code !== 32 && code !== 9 && code !== 13) {
+					return false;
+				}
+				idx += 1;
+			}
+			return true;
+		};
+
 		const adjustCodeIndent = (lineValue: string, sourceBase: number, targetBase: number): string => {
 			const leadingSpaces = countLeadingSpaces(lineValue);
 			if (leadingSpaces < sourceBase) {
@@ -546,7 +574,7 @@ export class Bear2bkImporter extends FormatImporter {
 		for (let i = 0; i < lines.length; i += 1) {
 			let line = lines[i];
 
-			if (i === 0 && line.trim() === '---') {
+			if (i === 0 && isFrontmatterFence(line)) {
 				inFrontmatter = true;
 				out.push(line);
 				continue;
@@ -554,15 +582,15 @@ export class Bear2bkImporter extends FormatImporter {
 
 			if (inFrontmatter) {
 				out.push(line);
-				if (line.trim() === '---') {
+				if (isFrontmatterFence(line)) {
 					inFrontmatter = false;
 				}
 				continue;
 			}
 
 			const listFence = listFenceMatch(line);
-			const stripped = line.trimStart();
-			if (listFence || stripped.startsWith('```')) {
+			const hasFence = listFence !== null || line.startsWith('```', countLeadingWhitespace(line));
+			if (hasFence) {
 				if (listFence) {
 					const targetIndent = listFence.indent * 2;
 					line = ' '.repeat(targetIndent) + listFence.marker + listFence.fence;

--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -26,9 +26,9 @@ export class Bear2bkImporter extends FormatImporter {
 	private static readonly alphaStart = /^[A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ]/;
 	private static readonly nonAlphaStart = /^[0-9_\-]/;
 	private static readonly invalidChar = /[^A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ0-9_\/-]/;
+	private static readonly invalidCharGlobal = /[^A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ0-9_\/-]/g;
 	private static readonly hexColorTag = /^[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$/;
-	private static readonly tagCandidate = /(?<!\S)#([^\s#]+)/g;
-	private static readonly tagNormalizationMatcher = /(?<!\S)#([0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?)(?=\s|$|[^A-Za-z0-9_\/-])#?|#(?!\s)((?:(?!\s#)[^\n#])*?\S)#(?=\S)|#(?!\s)((?:(?!\s#)[^\n#])*?\S)#|(?<!\S)#([^\s#]+)/g;
+	private static readonly tagNormalizationMatcher = /(?<!\\)(?<!\S)#([0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?)(?=\s|$|[^A-Za-z0-9_\/-])#?|(?<!\\)(?<![A-Za-z0-9_./:-])#(?!\s)((?:(?!\s#)[^\n#])*?\S)#(?=\S)|(?<!\\)(?<![A-Za-z0-9_./:-])#(?!\s)((?:(?!\s#)[^\n#])*?\S)#|(?<!\\)(?<!\S)#([^\s#]+)/g;
 	private static readonly assetMatcher = /\[[^\]]*\]\((assets\/[^\)]+)\)/gm;
 	private static readonly bearLinkMatcher = /bear:\/\/x-callback-url\/open-note\?id=([A-Z0-9\-]+)/g;
 	private static readonly numericOnly = /^\d+$/;
@@ -68,11 +68,14 @@ export class Bear2bkImporter extends FormatImporter {
 			return null;
 		}
 
-		const { alphaStart, nonAlphaStart, invalidChar } = Bear2bkImporter;
+		const { alphaStart, nonAlphaStart, invalidChar, invalidCharGlobal } = Bear2bkImporter;
 
 		if (alphaStart.test(rawTag)) {
-			let cleanTag = rawTag.replace(invalidChar, '_');
+			let cleanTag = rawTag.replace(invalidCharGlobal, '_');
 			cleanTag = cleanTag.replace(Bear2bkImporter.collapseUnderscores, '_');
+			if (cleanTag.endsWith('_') && invalidChar.test(rawTag[rawTag.length - 1])) {
+				cleanTag = cleanTag.replace(/_+$/g, '');
+			}
 			return cleanTag;
 		}
 
@@ -98,18 +101,6 @@ export class Bear2bkImporter extends FormatImporter {
 			return null;
 		}
 		return { tag: match[1], trailing: match[2] };
-	}
-
-	private normalizeEnclosedTag(tag: string, match: string, addTrailingSpace: boolean): string {
-		if (/\s#$/.test(match)) {
-			return match;
-		}
-		const normalizedSingle = tag.replace(/\s+/g, '_');
-		const normalized = this.normalizeSimpleTag(normalizedSingle);
-		if (!normalized) {
-			return match;
-		}
-		return '#' + normalized + (addTrailingSpace ? ' ' : '');
 	}
 
 	private isHexColorTag(rawTag: string): boolean {
@@ -194,38 +185,59 @@ export class Bear2bkImporter extends FormatImporter {
 		return parts.join('');
 	}
 
-	private extractTagsFromContent(content: string): string[] {
-		const tags = new Set<string>();
-		const isNumericOnly = (value: string) => Bear2bkImporter.numericOnly.test(value);
-		const tagCandidateRegex = Bear2bkImporter.tagCandidate;
-
-		this.transformOutsideCodeBlocks(content, (line) => {
-			let match;
-			tagCandidateRegex.lastIndex = 0;
-			while ((match = tagCandidateRegex.exec(line)) !== null) {
-				const rawTag = match[1];
-				const splitTag = this.splitTrailingPunctuation(rawTag);
-				const normalizedTag = this.normalizeSimpleTag(splitTag ? splitTag.tag : rawTag);
-				if (!normalizedTag) {
-					continue;
-				}
-
-				if (this.flattenTags && normalizedTag.includes('/')) {
-					const parts = normalizedTag.split('/');
-					for (const part of parts) {
-						if (part !== '' && !isNumericOnly(part)) {
-							tags.add(part);
-						}
-					}
-				}
-				else if (!isNumericOnly(normalizedTag)) {
-					tags.add(normalizedTag);
+	private addNormalizedTag(tags: Set<string>, normalizedTag: string): void {
+		if (this.flattenTags && normalizedTag.includes('/')) {
+			const parts = normalizedTag.split('/');
+			for (const part of parts) {
+				if (part !== '' && !Bear2bkImporter.numericOnly.test(part)) {
+					tags.add(part);
 				}
 			}
-			return line;
+		}
+		else if (!Bear2bkImporter.numericOnly.test(normalizedTag)) {
+			tags.add(normalizedTag);
+		}
+	}
+
+	private normalizeTagsAndCollect(content: string): { content: string; tags: string[] } {
+		const tags = new Set<string>();
+		const tagMatcher = Bear2bkImporter.tagNormalizationMatcher;
+
+		const normalizedContent = this.transformOutsideCodeBlocks(content, (line) => {
+			return line.replace(tagMatcher, (match, hexTag, enclosedFollowing, enclosedTag, rawTag) => {
+				if (hexTag) {
+					return `\\#${hexTag}`;
+				}
+
+				if (enclosedFollowing || enclosedTag) {
+					const enclosedValue = enclosedFollowing ?? enclosedTag;
+					if (/\s#$/.test(match)) {
+						return match;
+					}
+					const normalizedSingle = enclosedValue.replace(/\s+/g, '_');
+					const normalizedTag = this.normalizeSimpleTag(normalizedSingle);
+					if (!normalizedTag) {
+						return match;
+					}
+					this.addNormalizedTag(tags, normalizedTag);
+					return '#' + normalizedTag + (enclosedFollowing ? ' ' : '');
+				}
+
+				if (rawTag) {
+					const splitTag = this.splitTrailingPunctuation(rawTag);
+					const normalizedTag = this.normalizeSimpleTag(splitTag ? splitTag.tag : rawTag);
+					if (!normalizedTag) {
+						return match;
+					}
+					this.addNormalizedTag(tags, normalizedTag);
+					return '#' + normalizedTag + (splitTag ? splitTag.trailing : '');
+				}
+
+				return match;
+			});
 		});
 
-		return Array.from(tags);
+		return { content: normalizedContent, tags: Array.from(tags) };
 	}
 
 	async import(ctx: ImportContext): Promise<void> {
@@ -291,33 +303,10 @@ export class Bear2bkImporter extends FormatImporter {
 								}
 							}
 
-							// Normalize tags and escape hex color tags (single pass)
-							const tagMatcher = Bear2bkImporter.tagNormalizationMatcher;
-							mdContent = this.transformOutsideCodeBlocks(mdContent, (line) => {
-								return line.replace(tagMatcher, (match, hexTag, enclosedFollowing, enclosedTag, rawTag) => {
-									if (hexTag) {
-										return `\\#${hexTag}`;
-									}
-									if (enclosedFollowing) {
-										return this.normalizeEnclosedTag(enclosedFollowing, match, true);
-									}
-									if (enclosedTag) {
-										return this.normalizeEnclosedTag(enclosedTag, match, false);
-									}
-									if (rawTag) {
-										const splitTag = this.splitTrailingPunctuation(rawTag);
-										const normalizedTag = this.normalizeSimpleTag(splitTag ? splitTag.tag : rawTag);
-										if (!normalizedTag) {
-											return match;
-										}
-										return '#' + normalizedTag + (splitTag ? splitTag.trailing : '');
-									}
-									return match;
-								});
-							});
-
-							// Extract tags from content
-							const tags = this.extractTagsFromContent(mdContent);
+							// Normalize tags and collect tag list (single pass)
+							const normalized = this.normalizeTagsAndCollect(mdContent);
+							mdContent = normalized.content;
+							const tags = normalized.tags;
 
 							// Use just the filename without extension
 							const fileName = mdFilename;

--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -257,7 +257,7 @@ export class Bear2bkImporter extends FormatImporter {
 								await this.updateNoteFrontmatter(metadata, file, tags);
 							}
 							if (metadata?.ctime && metadata?.mtime) {
-								await this.modifFileTimestamps(metadata, file);
+								await this.modifyFileTimestamps(metadata, file);
 							}
 
 							idMapping[metadata?.id] = {
@@ -331,7 +331,7 @@ export class Bear2bkImporter extends FormatImporter {
 		}, writeOptions);
 	}
 
-	private async modifFileTimestamps(metaData: Metadata, file: TFile) {
+	private async modifyFileTimestamps(metaData: Metadata, file: TFile) {
 		const writeOptions: DataWriteOptions = {
 			ctime: metaData.ctime,
 			mtime: metaData.mtime,

--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -192,8 +192,10 @@ export class Bear2bkImporter extends FormatImporter {
 							}
 
 							// Replace spaces in enclosed tags with underscores and make them classic tags
-							mdContent = mdContent.replace(/#([^\n#]+?[^\s])#/g, (_match, tag) => { // require non-space before closing to avoid using next tag's opening #
-								return '#' + tag.replace(/\s+/g, '_');
+							mdContent = this.transformOutsideCodeBlocks(mdContent, (line) => {
+								return line.replace(/#(?!\s)([^\n#]*?\S)#/g, (_match, tag) => {
+									return '#' + tag.replace(/\s+/g, '_');
+								});
 							});
 
 							// Remove special characters in simple tags

--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -193,7 +193,9 @@ export class Bear2bkImporter extends FormatImporter {
 
 							// Replace spaces in enclosed tags with underscores and make them classic tags
 							mdContent = this.transformOutsideCodeBlocks(mdContent, (line) => {
-								return line.replace(/#(?!\s)([^\n#]*?\S)#/g, (_match, tag) => {
+								return line.replace(/#(?!\s)([^\n#]*?\S)#(?=\S)/g, (_match, tag) => {
+									return '#' + tag.replace(/\s+/g, '_') + ' ';
+								}).replace(/#(?!\s)([^\n#]*?\S)#/g, (_match, tag) => {
 									return '#' + tag.replace(/\s+/g, '_');
 								});
 							});


### PR DESCRIPTION
This is intended to fix several issues I was having with the Bear importer.
- list indentation, specifically if the list contained a code block
- tag processing for multi-word tags in Bear
- tag processing for tag-like text in inline code
- tag processing for tag-like text in code blocks
- tag processing for hex color text (e.g., #00ff00)
- other edge-case tag processing issues that may or may not have been a result of my changes
    -  I ended up typing out many "possible" tags in Obsidian, noting whether they were considered tags internally or not, and then putting that logic into the various regex and processing steps.

I tested these changes by running my Bear export of +1600 notes through the changes over and over. My settings for the import were to to flatten nested tags and not to store note identifiers in front matter. The "flatten" option may have side-effects, but from what I understand, as Bear user, I would not expect that sort of result.