### PR TITLE
fix: Add embed prefix for Apple Notes attachments and scans

### DIFF
--- a/src/formats/apple-notes/convert-note.ts
+++ b/src/formats/apple-notes/convert-note.ts
@@ -371,7 +371,7 @@ export class NoteConverter extends ANConverter {
 
 		const attachment = await this.importer.resolveAttachment(id, attr.attachmentInfo!.typeUti);
 		let link = attachment
-			? `\n${this.app.fileManager.generateMarkdownLink(attachment, parentNotePath)}\n` 
+			? `\n!${this.app.fileManager.generateMarkdownLink(attachment, parentNotePath)}\n` 
 			: ` **(error reading attachment)**`;
 		
 		if (this.importer.includeHandwriting && row.ZHANDWRITINGSUMMARY) {

--- a/src/formats/apple-notes/convert-scan.ts
+++ b/src/formats/apple-notes/convert-scan.ts
@@ -32,7 +32,7 @@ export class ScanConverter extends ANConverter {
 			if (!file) file = await this.importer.resolveAttachment(row.ZMEDIA, row.ZTYPEUTI);
 
 			if (file) {
-				links.push(this.importer.app.fileManager.generateMarkdownLink(file!, parentNotePath));
+				links.push('!' + this.importer.app.fileManager.generateMarkdownLink(file!, parentNotePath));
 			}
 			else {
 				return '**Cannot decode scan**';


### PR DESCRIPTION
## Summary

- Attachments imported from Apple Notes render as text links instead of inline embeds because the `!` prefix is missing from the generated markdown link
- This adds the `!` prefix in both `convert-note.ts` (attachments) and `convert-scan.ts` (scans/drawings)
- The third `generateMarkdownLink` call in `getInternalLink()` is intentionally left unchanged — it produces note-to-note links (`[[note]]`), not embeds

This matches Apple Notes' own behavior where all attachments are rendered inline.

## Test plan

- Import an Apple Notes database containing image attachments and scanned documents
- Verify that images render inline in the resulting markdown files rather than appearing as `[[filename.jpg]]` text links
- Verify that internal note links (applenotes://...) still render as `[[note]]` links, not embeds

Addresses #471 (item 3: attachments not embedded inline)