### PR TITLE
Add Apple Notes highlight color export

### DIFF
--- a/src/formats/apple-notes/convert-note.ts
+++ b/src/formats/apple-notes/convert-note.ts
@@ -7,6 +7,7 @@ import {
 	ANAttributeRun,
 	ANBaseline,
 	ANColor,
+	ANEmphasisColor,
 	ANConverter,
 	ANDocument,
 	ANFontWeight,
@@ -104,7 +105,7 @@ export class NoteConverter extends ANConverter {
 			else if (attr.attachmentInfo) {
 				converted += await this.formatAttachment(attr, parentNotePath);
 			}
-			else if (attr.superscript || attr.underlined || attr.color || attr.font || this.multiRun == ANMultiRun.Alignment) {
+			else if (attr.superscript || attr.underlined || attr.color || attr.emphasisColor || attr.font || this.multiRun == ANMultiRun.Alignment) {
 				converted += await this.formatHtmlAttr(attr);
 			}
 			else {
@@ -200,6 +201,7 @@ export class NoteConverter extends ANConverter {
 
 		if (attr.font?.pointSize) style += `font-size:${attr.font.pointSize}pt;`;
 		if (attr.color) style += `color:${this.convertColor(attr.color)};`;
+		if (attr.emphasisColor) style += `background-color:${this.convertEmphasisColor(attr.emphasisColor)};`;
 
 		if (attr.link && !NOTE_URI.test(attr.link)) {
 			if (style) style = ` style="${style}"`;
@@ -404,6 +406,23 @@ export class NoteConverter extends ANConverter {
 		}
 
 		return hexcode;
+	}
+
+	convertEmphasisColor(color: ANEmphasisColor): string {
+		switch (color) {
+			case ANEmphasisColor.Purple:
+				return '#dfccff';
+			case ANEmphasisColor.Pink:
+				return '#ffd6ea';
+			case ANEmphasisColor.Orange:
+				return '#ffe1bf';
+			case ANEmphasisColor.Mint:
+				return '#d9f5e8';
+			case ANEmphasisColor.Blue:
+				return '#d7e6ff';
+			default:
+				return '#fff3a3';
+		}
 	}
 
 	convertAlign(alignment: ANAlignment): string {

--- a/src/formats/apple-notes/convert-note.ts
+++ b/src/formats/apple-notes/convert-note.ts
@@ -411,17 +411,17 @@ export class NoteConverter extends ANConverter {
 	convertEmphasisColor(color: ANEmphasisColor): string {
 		switch (color) {
 			case ANEmphasisColor.Purple:
-				return '#dfccff';
+				return '#a357d750';
 			case ANEmphasisColor.Pink:
-				return '#ffd6ea';
+				return '#ea455a50';
 			case ANEmphasisColor.Orange:
-				return '#ffe1bf';
+				return '#f09a3850';
 			case ANEmphasisColor.Mint:
-				return '#d9f5e8';
+				return '#59c4bd50';
 			case ANEmphasisColor.Blue:
-				return '#d7e6ff';
+				return '#3c7df550';
 			default:
-				return '#fff3a3';
+				return '#f0d63850';
 		}
 	}
 

--- a/src/formats/apple-notes/descriptor.ts
+++ b/src/formats/apple-notes/descriptor.ts
@@ -209,6 +209,10 @@ export const descriptor: any = {
 							'type': 'Color',
 							'id': 10
 						},
+						'emphasisColor': {
+							'type': 'int32',
+							'id': 14
+						},
 						'attachmentInfo': {
 							'type': 'AttachmentInfo',
 							'id': 12

--- a/src/formats/apple-notes/models.ts
+++ b/src/formats/apple-notes/models.ts
@@ -82,6 +82,7 @@ export interface ANAttributeRun extends Message {
 	superscript?: ANBaseline;
 	link?: string;
 	color?: ANColor;
+	emphasisColor?: ANEmphasisColor;
 	attachmentInfo?: ANAttachmentInfo;
 
 	// internal additions, not part of the protobufs
@@ -145,6 +146,14 @@ export interface ANColor extends Message {
 	green: number;
 	blue: number;
 	alpha: number;
+}
+
+export enum ANEmphasisColor {
+	Purple = 1,
+	Pink = 2,
+	Orange = 3,
+	Mint = 4,
+	Blue = 5
 }
 
 export enum ANFolderType {


### PR DESCRIPTION
This PR adds support for importing text highlights from Apple Notes. 

Apple Notes stores emphasis colors in field 14 of the `AttributeRun` protobuf message. This update extracts that field and maps the 5 available colors (Purple, Pink, Orange, Mint, Blue) to corresponding HTML `background-color` styles, allowing highlights to be preserved in the exported Markdown files.