### PR TITLE
Fix : Notion zip import flattened attachment and file renaming when case insensitively duplicates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ data.json
 # Exclude files specific to personal development process
 .hotreload
 .devtarget
+
+output/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Development build with watch mode
+npm run dev
+
+# Production build (type-checks first)
+npm run build
+
+# Lint and auto-fix
+npm run lint
+```
+
+No test runner is configured — the plugin is tested manually inside Obsidian.
+
+## Architecture
+
+This is an Obsidian community plugin. The build outputs `main.js` (bundled via esbuild) which Obsidian loads directly.
+
+### Core abstractions
+
+- **`src/format-importer.ts`** — Base class `FormatImporter` that all importers extend. Provides helpers for UI settings, file choosers, folder creation, and vault write operations.
+- **`src/main.ts`** — Plugin entry point; registers all importers via `ImportContext`, which tracks progress/cancellation.
+- **`src/filesystem.ts`** — Filesystem abstractions (`PickedFile`, `PickedFolder`). `ZipEntryFile` (in `src/zip.ts`) also implements `PickedFile` for files inside ZIPs.
+
+### Notion importer (most complex format)
+
+Located in `src/formats/notion/` with entry point `src/formats/notion.ts`. Uses a **two-pass approach**:
+
+**Pass 1 — `parseFileInfo`** (`parse-info.ts`): Iterates all zip entries to build two lookup maps in `NotionResolverInfo`:
+- `idsToFileInfo`: maps Notion UUID → `NotionFileInfo` (title, path, parentIds)
+- `pathsToAttachmentInfo`: maps zip filepath → `NotionAttachmentInfo` (nameWithExtension, targetParentFolder)
+
+**Pass 2 — conversion** (`notion.ts`): Resolves paths via `cleanDuplicates`, creates vault folders, then converts HTML→Markdown and writes files.
+
+**Key types** (`notion-types.ts`):
+- `NotionFileInfo` / `NotionAttachmentInfo` — per-file metadata populated during pass 1, mutated during dedup
+- `NotionResolverInfo` — container for both maps + `getPathForFile()` which reconstructs vault-relative folder paths from `parentIds`
+
+**Link conversion** (`convert-to-md.ts` → `convertLinksToObsidian`): Converts Notion HTML anchor tags to Obsidian `[[wikilinks]]`. For attachments, currently generates `![[filename.ext]]` (filename only) unless `fullLinkPathNeeded` is true (in which case it prepends `targetParentFolder`).
+
+**Deduplication** (`clean-duplicates.ts` → `cleanDuplicateAttachments`): Sets `attachmentInfo.targetParentFolder` for each attachment. When the user has configured attachments in the current folder (Obsidian setting `./subfolder`), it calls `info.getPathForFile(attachmentInfo)` to place the attachment alongside its parent note.
+
+### Known bugs (as of this writing)
+
+**Bug 1 — Filename collision for same-named files in different zip folders** (e.g. `p1/1.png` and `p2/1.png`):
+In `parse-info.ts`, `nameWithExtension` is set to `sanitizeFileName(decodeURIComponent(file.name))` — just the bare filename, not the path. Both files end up as `nameWithExtension: '1.png'` and the second overwrites the first in `pathsToAttachmentInfo` (keyed by full zip path), but the dedup check in `cleanDuplicateAttachments` only checks `attachmentPaths` *after* `targetParentFolder` is determined, so the collision isn't caught for files that land in different vault folders. When copying, `vault.createBinary` will attempt to write both to their respective `targetParentFolder`, but the wikilink reference will still only use the bare filename.
+
+**Bug 2 — Attachment links use filename only, not relative path**:
+In `convertLinksToObsidian` (`convert-to-md.ts`, ~line 662), attachment links are formatted as:
+```ts
+attachmentInfo.fullLinkPathNeeded
+  ? attachmentInfo.targetParentFolder + attachmentInfo.nameWithExtension + '|' + attachmentInfo.nameWithExtension
+  : attachmentInfo.nameWithExtension
+```
+The user wants wikilinks in the form `![[./p1/1.png]]` (path relative to the markdown file's location) rather than `![[1.png]]`. The `targetParentFolder` is an absolute vault path, not a relative path from the note, so it cannot be used directly for this purpose. A relative path needs to be computed from the note's resolved path to the attachment's resolved path.

--- a/src/formats/notion.ts
+++ b/src/formats/notion.ts
@@ -150,7 +150,24 @@ export class NotionImporter extends FormatImporter {
 					return;
 				}
 
-				ctx.reportFailed(file.fullpath, e);
+				// Include target vault path in error for easier debugging
+				let targetPath = '';
+				if (file.extension === 'html') {
+					const id = getNotionId(file.name);
+					const fileInfo = id ? info.idsToFileInfo[id] : undefined;
+					if (fileInfo) {
+						targetPath = `${targetFolderPath}${info.getPathForFile(fileInfo)}${fileInfo.title}.md`;
+					}
+				}
+				else {
+					const attachmentInfo = info.pathsToAttachmentInfo[file.filepath];
+					if (attachmentInfo) {
+						targetPath = `${attachmentInfo.targetParentFolder}${attachmentInfo.nameWithExtension}`;
+					}
+				}
+
+				const detail = targetPath ? `${e} (target: ${targetPath})` : e;
+				ctx.reportFailed(file.fullpath, detail);
 			}
 		});
 	}

--- a/src/formats/notion.ts
+++ b/src/formats/notion.ts
@@ -114,7 +114,8 @@ export class NotionImporter extends FormatImporter {
 
 					ctx.status(`Importing note ${fileInfo.title}`);
 
-					const markdownBody = await readToMarkdown(info, file);
+					const noteDir = `${targetFolderPath}${info.getPathForFile(fileInfo)}`;
+					const markdownBody = await readToMarkdown(info, file, noteDir);
 					let writeOptions: DataWriteOptions = {};
 
 					if (fileInfo.ctime) {

--- a/src/formats/notion/clean-duplicates.ts
+++ b/src/formats/notion/clean-duplicates.ts
@@ -115,7 +115,10 @@ function cleanDuplicateAttachments({
 			);
 		}
 		else {
-			parentFolderPath = normalizePath(attachmentFolderPath + '/');
+			const basePath = attachmentFolderPath && attachmentFolderPath !== '/'
+				? attachmentFolderPath + '/'
+				: targetFolderPath;
+			parentFolderPath = normalizePath(basePath + info.getPathForFile(attachmentInfo));
 		}
 		if (!parentFolderPath.endsWith('/')) parentFolderPath += '/';
 

--- a/src/formats/notion/clean-duplicates.ts
+++ b/src/formats/notion/clean-duplicates.ts
@@ -46,15 +46,23 @@ function cleanDuplicateNotes({
 	pathDuplicateChecks: Set<string>;
 	titleDuplicateChecks: Set<string>;
 }) {
-	for (let fileInfo of Object.values(info.idsToFileInfo)) {
-		let path = info.getPathForFile(fileInfo);
+	// Use case-insensitive checks to handle filesystems like Windows/macOS
+	// that treat "Getting started.md" and "Getting Started.md" as the same file.
+	const pathDuplicateChecksLower = new Set<string>();
 
-		if (pathDuplicateChecks.has(`${path}${fileInfo.title}`)) {
-			let duplicateResolutionIndex = 2;
-			fileInfo.title = fileInfo.title + ' ' + duplicateResolutionIndex;
-			while (pathDuplicateChecks.has(`${path}${fileInfo.title}`)) {
-				duplicateResolutionIndex++;
-				fileInfo.title = `${fileInfo.title.replace(/ \d+$/, '')} ${duplicateResolutionIndex}`;
+	for (let [id, fileInfo] of Object.entries(info.idsToFileInfo)) {
+		let path = info.getPathForFile(fileInfo);
+		const fullPathLower = `${path}${fileInfo.title}`.toLowerCase();
+
+		if (pathDuplicateChecksLower.has(fullPathLower)) {
+			// Case-insensitive collision: append first 4 chars of Notion ID
+			fileInfo.title = `${fileInfo.title}_${id.slice(0, 4)}`;
+
+			// If still collides (unlikely), keep appending more of the ID
+			let idLen = 4;
+			while (pathDuplicateChecksLower.has(`${path}${fileInfo.title}`.toLowerCase())) {
+				idLen = Math.min(idLen + 4, id.length);
+				fileInfo.title = `${fileInfo.title.replace(/_[a-z0-9]+$/, '')}_${id.slice(0, idLen)}`;
 			}
 		}
 
@@ -63,6 +71,7 @@ function cleanDuplicateNotes({
 		}
 
 		pathDuplicateChecks.add(`${path}${fileInfo.title}`);
+		pathDuplicateChecksLower.add(`${path}${fileInfo.title}`.toLowerCase());
 		titleDuplicateChecks.add(fileInfo.title + '.md');
 	}
 }
@@ -97,6 +106,10 @@ function cleanDuplicateAttachments({
 			.filter((file) => !file.path.endsWith('.md'))
 			.map((file) => file.path)
 	);
+	// Case-insensitive set for Windows/macOS filesystem collision detection
+	const attachmentPathsLower = new Set(
+		[...attachmentPaths].map((p) => p.toLowerCase())
+	);
 
 	let attachmentFolderPath = info.attachmentPath;
 	let attachmentsInCurrentFolder = /^\.\//.test(attachmentFolderPath);
@@ -122,11 +135,12 @@ function cleanDuplicateAttachments({
 		}
 		if (!parentFolderPath.endsWith('/')) parentFolderPath += '/';
 
-		if (attachmentPaths.has(parentFolderPath + attachmentInfo.nameWithExtension)) {
+		// Use case-insensitive check for filesystems like Windows/macOS
+		if (attachmentPathsLower.has((parentFolderPath + attachmentInfo.nameWithExtension).toLowerCase())) {
 			let duplicateResolutionIndex = 2;
 			const { basename, extension } = parseFilePath(attachmentInfo.path);
-			while (attachmentPaths.has(
-				`${parentFolderPath}${basename} ${duplicateResolutionIndex}.${extension}`
+			while (attachmentPathsLower.has(
+				`${parentFolderPath}${basename} ${duplicateResolutionIndex}.${extension}`.toLowerCase()
 			)) {
 				duplicateResolutionIndex++;
 			}
@@ -136,6 +150,7 @@ function cleanDuplicateAttachments({
 		attachmentInfo.targetParentFolder = parentFolderPath;
 
 		attachmentPaths.add(parentFolderPath + attachmentInfo.nameWithExtension);
+		attachmentPathsLower.add((parentFolderPath + attachmentInfo.nameWithExtension).toLowerCase());
 		titleDuplicateChecks.add(attachmentInfo.nameWithExtension);
 	}
 }

--- a/src/formats/notion/convert-to-md.ts
+++ b/src/formats/notion/convert-to-md.ts
@@ -13,13 +13,14 @@ import {
 import {
 	escapeHashtags,
 	getNotionId,
+	getRelativePath,
 	hoistChildren,
 	parseDate,
 	stripNotionId,
 	stripParentDirectories,
 } from './notion-utils';
 
-export async function readToMarkdown(info: NotionResolverInfo, file: ZipEntryFile): Promise<string> {
+export async function readToMarkdown(info: NotionResolverInfo, file: ZipEntryFile, noteDir?: string): Promise<string> {
 	const text = await file.readText();
 
 	const dom = parseHTML(text);
@@ -31,14 +32,14 @@ export async function readToMarkdown(info: NotionResolverInfo, file: ZipEntryFil
 	}
 
 	const notionLinks = getNotionLinks(info, body);
-	convertLinksToObsidian(info, notionLinks, true);
+	convertLinksToObsidian(info, notionLinks, true, noteDir);
 
 	let frontMatter: FrontMatterCache = {};
 
 	const rawProperties = dom.find('table[class=properties] > tbody') as HTMLTableSectionElement | undefined;
 	if (rawProperties) {
 		const propertyLinks = getNotionLinks(info, rawProperties);
-		convertLinksToObsidian(info, propertyLinks, false);
+		convertLinksToObsidian(info, propertyLinks, false, noteDir);
 		// YAML only takes raw URLS
 		convertHtmlLinksToURLs(rawProperties);
 
@@ -629,7 +630,7 @@ function convertHtmlLinksToURLs(content: HTMLElement) {
 	}
 }
 
-function convertLinksToObsidian(info: NotionResolverInfo, notionLinks: NotionLink[], embedAttachments: boolean) {
+function convertLinksToObsidian(info: NotionResolverInfo, notionLinks: NotionLink[], embedAttachments: boolean, noteDir?: string) {
 	for (let link of notionLinks) {
 		let obsidianLink = createSpan();
 		let linkContent: string = '';
@@ -659,13 +660,18 @@ function convertLinksToObsidian(info: NotionResolverInfo, notionLinks: NotionLin
 					console.warn('missing attachment data for: ' + link.path);
 					continue;
 				}
-				linkContent = `${embedAttachments ? '!' : ''}[[${attachmentInfo.fullLinkPathNeeded
-					? attachmentInfo.targetParentFolder +
-					attachmentInfo.nameWithExtension +
-					'|' +
-					attachmentInfo.nameWithExtension
-					: attachmentInfo.nameWithExtension
-				}]]`;
+				const attachmentFullPath = `${attachmentInfo.targetParentFolder}${attachmentInfo.nameWithExtension}`;
+				let attachmentRef: string;
+				if (noteDir) {
+					attachmentRef = getRelativePath(noteDir, attachmentFullPath);
+				}
+				else if (attachmentInfo.fullLinkPathNeeded) {
+					attachmentRef = attachmentFullPath + '|' + attachmentInfo.nameWithExtension;
+				}
+				else {
+					attachmentRef = attachmentInfo.nameWithExtension;
+				}
+				linkContent = `${embedAttachments ? '!' : ''}[[${attachmentRef}]]`;
 				break;
 			case 'toc-item':
 				// trailing space required in case link ends with ']'

--- a/src/formats/notion/notion-utils.ts
+++ b/src/formats/notion/notion-utils.ts
@@ -86,3 +86,26 @@ export function escapeHashtags(body: string) {
 export function hoistChildren(el: ChildNode) {
 	el.replaceWith(...Array.from(el.childNodes));
 }
+
+/**
+ * Compute a relative path from a directory to a file path.
+ * Both paths must use '/' separators and share the same root.
+ * Returns './file' for same-dir, './sub/file' for subdirs, '../sibling/file' for siblings.
+ */
+export function getRelativePath(fromDir: string, toFilePath: string): string {
+	const from = fromDir.replace(/\/+$/, '').split('/').filter(p => p.length > 0);
+	const to = toFilePath.split('/').filter(p => p.length > 0);
+
+	let common = 0;
+	while (common < from.length && common < to.length && from[common] === to[common]) {
+		common++;
+	}
+
+	const upCount = from.length - common;
+	const remaining = to.slice(common).join('/');
+
+	if (upCount === 0) {
+		return './' + remaining;
+	}
+	return '../'.repeat(upCount) + remaining;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -163,7 +163,9 @@ export class ImportContext {
 
 		this.importLogEl.createDiv('list-item', el => {
 			el.createSpan({ cls: 'importer-error', text: 'Skipped: ' });
-			el.createSpan({ text: `"${truncateText(name, this.maxFileNameLength)}"` + (reason ? ` because ${truncateText(String(reason), this.maxFileNameLength)}` : '') });
+			const fullText = `"${name}"` + (reason ? ` because ${String(reason)}` : '');
+			const displayText = `"${truncateText(name, this.maxFileNameLength)}"` + (reason ? ` because ${truncateText(String(reason), this.maxFileNameLength)}` : '');
+			el.createSpan({ text: displayText, attr: { title: fullText } });
 		});
 		importLogEl.scrollTop = importLogEl.scrollHeight;
 		importLogEl.show();
@@ -184,7 +186,9 @@ export class ImportContext {
 
 		this.importLogEl.createDiv('list-item', el => {
 			el.createSpan({ cls: 'importer-error', text: 'Failed: ' });
-			el.createSpan({ text: `"${truncateText(name, this.maxFileNameLength)}"` + (reason ? ` because ${truncateText(String(reason), this.maxFileNameLength)}` : '') });
+			const fullText = `"${name}"` + (reason ? ` because ${String(reason)}` : '');
+			const displayText = `"${truncateText(name, this.maxFileNameLength)}"` + (reason ? ` because ${truncateText(String(reason), this.maxFileNameLength)}` : '');
+			el.createSpan({ text: displayText, attr: { title: fullText } });
 		});
 		importLogEl.scrollTop = importLogEl.scrollHeight;
 		importLogEl.show();

--- a/tests/notion/run-test.mjs
+++ b/tests/notion/run-test.mjs
@@ -1,0 +1,362 @@
+/**
+ * Standalone test for Notion importer path resolution and relative link generation.
+ *
+ * Usage: node tests/notion/run-test.mjs
+ *
+ * Extracts tests/notion/notion-testspace.zip, runs the path computation logic,
+ * and writes converted output to output/notion.test/.
+ */
+
+import { execSync } from 'child_process';
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs';
+import { basename, dirname, join, relative } from 'path';
+
+const ROOT = join(dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Z]:)/, '$1')), '../..');
+const ZIP_PATH = join(ROOT, 'tests/notion/notion-testspace.zip');
+const OUTPUT_DIR = join(ROOT, 'output/notion.test');
+const EXTRACT_DIR = join(OUTPUT_DIR, '_extracted');
+
+// ─── Utility functions (mirrors the fixed source code) ───
+
+function getNotionId(str) {
+	return str.replace(/-/g, '').match(/([a-z0-9]{32})(\?|\.|$)/)?.[1];
+}
+
+function parseFilePath(filepath) {
+	const lastIndex = Math.max(filepath.lastIndexOf('/'), filepath.lastIndexOf('\\'));
+	let name = filepath;
+	let parent = '';
+	if (lastIndex >= 0) {
+		name = filepath.substring(lastIndex + 1);
+		parent = filepath.substring(0, lastIndex);
+	}
+	const dotIndex = name.lastIndexOf('.');
+	let ext = '';
+	let base = name;
+	if (dotIndex > 0) {
+		ext = name.substring(dotIndex + 1).toLowerCase();
+		base = name.substring(0, dotIndex);
+	}
+	return { parent, name, basename: base, extension: ext };
+}
+
+function parseParentIds(filepath) {
+	const { parent } = parseFilePath(filepath);
+	return parent
+		.split('/')
+		.map((p) => getNotionId(p))
+		.filter((id) => id);
+}
+
+function sanitizeFileName(name) {
+	return name.replace(/[\x00-\x1f\x7f<>:"/\\|?*]/g, '').trim();
+}
+
+function getRelativePath(fromDir, toFilePath) {
+	const from = fromDir.replace(/\/+$/, '').split('/').filter((p) => p.length > 0);
+	const to = toFilePath.split('/').filter((p) => p.length > 0);
+	let common = 0;
+	while (common < from.length && common < to.length && from[common] === to[common]) {
+		common++;
+	}
+	const upCount = from.length - common;
+	const remaining = to.slice(common).join('/');
+	if (upCount === 0) {
+		return './' + remaining;
+	}
+	return '../'.repeat(upCount) + remaining;
+}
+
+function getPathForFile(fileInfo, idsToFileInfo) {
+	const pathNames = fileInfo.path.split('/');
+	if (fileInfo.parentIds.length > 0) {
+		const mapped = fileInfo.parentIds
+			.map((pid) =>
+				idsToFileInfo[pid]?.title ??
+				pathNames.find((seg) => seg.includes(pid))?.replace(new RegExp(` ?${pid}`), '')
+			)
+			.filter((x) => x)
+			.map((folder) => folder.replace(/[. ]+$/, ''));
+		if (mapped.length > 0) {
+			return mapped.join('/') + '/';
+		}
+	}
+	const { parent } = parseFilePath(fileInfo.path);
+	if (!parent) return '';
+	const segs = parent.split('/').filter((s) => s.length > 0);
+	const folderPath = segs
+		.map((s) => s.replace(/\s+[a-z0-9]{32}$/, '').trim())
+		.filter((s) => s.length > 0)
+		.map((f) => f.replace(/[. ]+$/, ''))
+		.join('/');
+	return folderPath ? folderPath + '/' : '';
+}
+
+// ─── Extract zip ───
+
+function extractZip() {
+	if (existsSync(EXTRACT_DIR)) rmSync(EXTRACT_DIR, { recursive: true });
+	mkdirSync(EXTRACT_DIR, { recursive: true });
+	const pyScript = join(EXTRACT_DIR, '_extract.py');
+	writeFileSync(pyScript, `
+import zipfile, io, os, sys
+sys.stdout.reconfigure(encoding='utf-8')
+out = os.path.abspath(sys.argv[1])
+# Use extended-length path prefix on Windows
+if sys.platform == 'win32' and not out.startswith('\\\\\\\\?\\\\'):
+    out = '\\\\\\\\?\\\\' + out
+with zipfile.ZipFile(sys.argv[2], 'r') as outer:
+    for name in outer.namelist():
+        if name.endswith('.zip'):
+            data = outer.read(name)
+            with zipfile.ZipFile(io.BytesIO(data)) as inner:
+                for info in inner.infolist():
+                    if info.is_dir():
+                        continue
+                    target = os.path.normpath(os.path.join(out, info.filename))
+                    os.makedirs(os.path.dirname(target), exist_ok=True)
+                    with inner.open(info) as src, open(target, 'wb') as dst:
+                        dst.write(src.read())
+        else:
+            target = os.path.normpath(os.path.join(out, name))
+            os.makedirs(os.path.dirname(target), exist_ok=True)
+            with outer.open(name) as src, open(target, 'wb') as dst:
+                dst.write(src.read())
+print('ok')
+`);
+	const result = execSync(`python "${pyScript}" "${EXTRACT_DIR}" "${ZIP_PATH}"`, { encoding: 'utf-8' });
+	if (!result.includes('ok')) throw new Error('Extraction failed: ' + result);
+	rmSync(pyScript);
+}
+
+// ─── Collect files from extracted dir ───
+
+function walkDir(dir, prefix = '') {
+	const results = [];
+	for (const entry of readdirSync(dir)) {
+		const full = join(dir, entry);
+		const rel = prefix ? prefix + '/' + entry : entry;
+		if (statSync(full).isDirectory()) {
+			results.push(...walkDir(full, rel));
+		}
+		else {
+			results.push({ fullPath: full, relativePath: rel, name: entry });
+		}
+	}
+	return results;
+}
+
+// ─── Main test ───
+
+function main() {
+	console.log('=== Notion Importer Path Resolution Test ===\n');
+
+	// Step 1: Extract
+	console.log('1. Extracting zip...');
+	extractZip();
+	const files = walkDir(EXTRACT_DIR);
+	console.log(`   Found ${files.length} files\n`);
+
+	// Step 2: Parse file info (pass 1)
+	console.log('2. Parsing file info...');
+	const idsToFileInfo = {};
+	const pathsToAttachmentInfo = {};
+
+	for (const file of files) {
+		const ext = parseFilePath(file.name).extension;
+		const relPath = file.relativePath.replace(/\\/g, '/');
+
+		if (ext === 'html') {
+			const content = readFileSync(file.fullPath, 'utf-8');
+			// Extract ID from body children
+			const idMatch = content.match(/id="([^"]*[a-z0-9]{32}[^"]*)"/);
+			const id = idMatch ? getNotionId(idMatch[1]) : getNotionId(file.name);
+			if (!id) continue;
+
+			const titleMatch = content.match(/<title>([^<]*)<\/title>/);
+			const title = sanitizeFileName((titleMatch?.[1] || 'Untitled').replace(/\n/g, ' ').replace(/[:/]/g, '-').replace(/#/g, '').trim());
+
+			idsToFileInfo[id] = {
+				path: relPath,
+				parentIds: parseParentIds(relPath),
+				title,
+				fullLinkPathNeeded: false,
+			};
+		}
+		else if (file.name !== 'index.html') {
+			const decodedName = sanitizeFileName(decodeURIComponent(file.name));
+			pathsToAttachmentInfo[relPath] = {
+				path: relPath,
+				parentIds: parseParentIds(relPath),
+				nameWithExtension: decodedName,
+				targetParentFolder: '',
+				fullLinkPathNeeded: false,
+			};
+		}
+	}
+
+	console.log(`   Notes: ${Object.keys(idsToFileInfo).length}`);
+	console.log(`   Attachments: ${Object.keys(pathsToAttachmentInfo).length}\n`);
+
+	// Step 3: Resolve paths (simulates cleanDuplicates)
+	console.log('3. Resolving paths...');
+	const targetFolderPath = 'Notion/';  // Simulated target folder
+	const attachmentFolderPath = '';  // Default: vault root (tests global mode)
+	const attachmentsInCurrentFolder = /^\.\//.test(attachmentFolderPath);
+	const attachmentSubfolder = attachmentFolderPath.match(/\.\/(.*)/)?.[1];
+
+	// Set targetParentFolder for each attachment (mirrors cleanDuplicateAttachments)
+	const attachmentPaths = new Set();
+	for (const attachmentInfo of Object.values(pathsToAttachmentInfo)) {
+		let parentFolderPath;
+		if (attachmentsInCurrentFolder) {
+			parentFolderPath = targetFolderPath + getPathForFile(attachmentInfo, idsToFileInfo) + (attachmentSubfolder ?? '');
+		}
+		else {
+			// FIXED: preserve subfolder structure; use targetFolderPath when no specific attachment folder
+			const basePath = attachmentFolderPath && attachmentFolderPath !== '/'
+				? attachmentFolderPath + '/'
+				: targetFolderPath;
+			parentFolderPath = basePath + getPathForFile(attachmentInfo, idsToFileInfo);
+		}
+		// Normalize
+		parentFolderPath = parentFolderPath.replace(/\/+/g, '/').replace(/^\//, '');
+		if (!parentFolderPath.endsWith('/')) parentFolderPath += '/';
+
+		// Dedup
+		if (attachmentPaths.has(parentFolderPath + attachmentInfo.nameWithExtension)) {
+			let idx = 2;
+			const { basename: bn, extension: ext } = parseFilePath(attachmentInfo.path);
+			while (attachmentPaths.has(`${parentFolderPath}${bn} ${idx}.${ext}`)) idx++;
+			attachmentInfo.nameWithExtension = `${bn} ${idx}.${ext}`;
+		}
+
+		attachmentInfo.targetParentFolder = parentFolderPath;
+		attachmentPaths.add(parentFolderPath + attachmentInfo.nameWithExtension);
+	}
+
+	// Step 4: Generate output
+	console.log('4. Generating output...\n');
+	if (existsSync(OUTPUT_DIR + '/notes')) rmSync(OUTPUT_DIR + '/notes', { recursive: true });
+	mkdirSync(OUTPUT_DIR + '/notes', { recursive: true });
+
+	const report = [];
+
+	for (const [id, fileInfo] of Object.entries(idsToFileInfo)) {
+		const noteDir = targetFolderPath + getPathForFile(fileInfo, idsToFileInfo);
+		const notePath = noteDir + fileInfo.title + '.md';
+
+		// Read HTML and find attachment links
+		const htmlFile = files.find((f) => f.relativePath.replace(/\\/g, '/') === fileInfo.path);
+		if (!htmlFile) continue;
+
+		const content = readFileSync(htmlFile.fullPath, 'utf-8');
+		const hrefRegex = /<a[^>]*href="([^"]*)"[^>]*>([^<]*)<\/a>/g;
+
+		let mdContent = `# ${fileInfo.title}\n\nNote path: ${notePath}\nNote dir: ${noteDir}\n\n## Attachment Links\n\n`;
+
+		let match;
+		while ((match = hrefRegex.exec(content)) !== null) {
+			const href = decodeURIComponent(match[1]).replace(/^(\.\.\/)+/, '');
+			const linkText = match[2];
+
+			// Find matching attachment
+			const attachmentKey = Object.keys(pathsToAttachmentInfo).find((k) => k.includes(href));
+			if (attachmentKey) {
+				const attInfo = pathsToAttachmentInfo[attachmentKey];
+				const attachmentFullPath = attInfo.targetParentFolder + attInfo.nameWithExtension;
+				const relativePath = getRelativePath(noteDir, attachmentFullPath);
+
+				mdContent += `- \`![[${relativePath}]]\`\n`;
+				mdContent += `  - Original href: ${href}\n`;
+				mdContent += `  - Attachment vault path: ${attachmentFullPath}\n`;
+				mdContent += `  - Note dir: ${noteDir}\n\n`;
+
+				report.push({
+					note: fileInfo.title,
+					attachment: attInfo.nameWithExtension,
+					vaultPath: attachmentFullPath,
+					relativePath,
+				});
+			}
+		}
+
+		// Write mock markdown
+		const outPath = join(OUTPUT_DIR, 'notes', fileInfo.title + '.md');
+		writeFileSync(outPath, mdContent, 'utf-8');
+	}
+
+	// Step 5: Write file structure report
+	console.log('=== File Structure ===\n');
+	console.log('Notes:');
+	for (const [id, fi] of Object.entries(idsToFileInfo)) {
+		const noteDir = targetFolderPath + getPathForFile(fi, idsToFileInfo);
+		console.log(`  ${noteDir}${fi.title}.md`);
+	}
+	console.log('\nAttachments:');
+	for (const ai of Object.values(pathsToAttachmentInfo)) {
+		console.log(`  ${ai.targetParentFolder}${ai.nameWithExtension}`);
+	}
+
+	console.log('\n=== Link Resolution ===\n');
+	for (const r of report) {
+		console.log(`Note: "${r.note}"`);
+		console.log(`  Attachment: ${r.attachment}`);
+		console.log(`  Vault path: ${r.vaultPath}`);
+		console.log(`  Relative:   ${r.relativePath}`);
+		console.log();
+	}
+
+	// Step 6: Verification
+	console.log('=== Verification ===\n');
+	let pass = true;
+
+	// Check 1: All relative paths start with './' or '../'
+	for (const r of report) {
+		if (!r.relativePath.startsWith('./') && !r.relativePath.startsWith('../')) {
+			console.log(`FAIL: relative path doesn't start with ./ or ../: ${r.relativePath}`);
+			pass = false;
+		}
+	}
+
+	// Check 2: No two attachments have the same full vault path
+	const vaultPaths = Object.values(pathsToAttachmentInfo).map((a) => a.targetParentFolder + a.nameWithExtension);
+	const uniquePaths = new Set(vaultPaths);
+	if (vaultPaths.length !== uniquePaths.size) {
+		console.log('FAIL: duplicate attachment vault paths detected');
+		pass = false;
+	}
+
+	// Check 3: Attachments preserve folder structure (not all in same folder)
+	const folders = new Set(Object.values(pathsToAttachmentInfo).map((a) => a.targetParentFolder));
+	if (Object.keys(pathsToAttachmentInfo).length > 0) {
+		console.log(`Attachment folders used: ${folders.size} (${[...folders].join(', ')})`);
+	}
+
+	if (pass) {
+		console.log('\nAll checks PASSED');
+	}
+	else {
+		console.log('\nSome checks FAILED');
+		process.exit(1);
+	}
+
+	// Write summary
+	const summary = {
+		notes: Object.entries(idsToFileInfo).map(([id, fi]) => ({
+			title: fi.title,
+			path: targetFolderPath + getPathForFile(fi, idsToFileInfo) + fi.title + '.md',
+		})),
+		attachments: Object.values(pathsToAttachmentInfo).map((ai) => ({
+			name: ai.nameWithExtension,
+			vaultPath: ai.targetParentFolder + ai.nameWithExtension,
+			originalZipPath: ai.path,
+		})),
+		links: report,
+	};
+	writeFileSync(join(OUTPUT_DIR, 'test-report.json'), JSON.stringify(summary, null, 2), 'utf-8');
+	console.log(`\nReport written to ${OUTPUT_DIR}/test-report.json`);
+	console.log(`Mock notes written to ${OUTPUT_DIR}/notes/`);
+}
+
+main();


### PR DESCRIPTION
Fix 1:
    Notion: Fix case-insensitive filename collisions on Windows/macOS

    On case-insensitive filesystems, "Getting started.md" and "Getting
    Started.md" collide. The dedup logic only checked case-sensitively,
    so both files would attempt to create the same path.

    For notes: detect case-insensitive collisions and rename the second
    file by appending _<first4ofNotionID> (e.g. "Getting Started_6ec2.md"),
    keeping wikilinks correct since the title is updated before link
    generation.

    For attachments: use a parallel lowercase Set for O(1) collision
    checks instead of case-sensitive Set.has().

Fix 2:
    Show full paths in error/skip messages for easier debugging

    The import UI truncated file names and error reasons to 100 chars,
    making "File already exists" errors impossible to act on. Now the
    full untruncated text is available as a tooltip on hover. Also
    include the target vault path in Notion import errors so users can
    see which output file caused the collision.

Fix 3:
    Notion: Fix attachment flattening and use relative paths in wikilinks

    Attachments from Notion zip exports were all placed in a single folder,
    causing filename collisions (e.g. p1/1.png and p2/1.png). Wikilinks
    used bare filenames (![[1.png]]) instead of paths relative to the note.

    - Add getRelativePath() to compute ./relative/path from note to attachment
    - Preserve subfolder structure in cleanDuplicateAttachments for all
      attachment folder modes (not just ./ current-folder mode)
    - Thread noteDir through readToMarkdown → convertLinksToObsidian so
      attachment links render as ![[./Attachment Tests/file.jpg]]
    - Add standalone test script for path resolution verification
    - Add CLAUDE.md with architecture docs and known bug analysis

    Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>