### PR TITLE
Apple Notes: fix "incorrect header check" decompression error (#517)

### DIFF
--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -482,7 +482,7 @@ export class AppleNotesImporter extends FormatImporter {
 	}
 
 	decodeData<T extends ANConverter>(hexdata: string, converterType: ANConverterType<T>) {
-		const unzipped = zlib.gunzipSync(Buffer.from(hexdata, 'hex'));
+		const unzipped = zlib.unzipSync(Buffer.from(hexdata, 'hex'));
 		const decoded = this.protobufRoot.lookupType(converterType.protobufType).decode(unzipped);
 		return new converterType(this, decoded);
 	}


### PR DESCRIPTION
Use unzipSync instead of gunzipSync to automatically detect and handle different compression formats (gzip, deflate) used by Apple Notes.

The gunzipSync method only handles gzip format, but Apple Notes may uses different compression formats (gzip, deflate) which has a different header format causing "incorrect header check" when decompressing note data.