### PR TITLE
OneNote: Fix nested list to-do items being corrupted on import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,14 +22,143 @@
 				"@microsoft/microsoft-graph-types": "2.38.0",
 				"@stylistic/eslint-plugin": "5.7.1",
 				"@types/node": "20.19.27",
+				"@types/turndown": "^5.0.6",
 				"@types/xml-flow": "1.0.1",
+				"@vitest/coverage-v8": "^4.1.4",
 				"builtin-modules": "3.3.0",
 				"esbuild": "0.25.4",
 				"eslint": "9.39.2",
+				"jsdom": "^29.0.2",
 				"obsidian": "latest",
 				"tslib": "2.4.0",
+				"turndown": "^7.2.4",
 				"typescript": "5.9.3",
-				"typescript-eslint": "8.51.0"
+				"typescript-eslint": "8.51.0",
+				"vitest": "^4.1.4"
+			}
+		},
+		"node_modules/@asamuzakjp/css-color": {
+			"version": "5.1.11",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+			"integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/generational-cache": "^1.0.1",
+				"@csstools/css-calc": "^3.2.0",
+				"@csstools/css-color-parser": "^4.1.0",
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/dom-selector": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+			"integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/generational-cache": "^1.0.1",
+				"@asamuzakjp/nwsapi": "^2.3.9",
+				"bidi-js": "^1.0.3",
+				"css-tree": "^3.2.1",
+				"is-potential-custom-element-name": "^1.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/generational-cache": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+			"integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/nwsapi": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+			"integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@babel/helper-string-parser": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/parser": {
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+			"integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.29.0"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@babel/types": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.28.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@bcoe/v8-coverage": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+			"integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@bramus/specificity": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+			"integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"css-tree": "^3.0.0"
+			},
+			"bin": {
+				"specificity": "bin/cli.js"
 			}
 		},
 		"node_modules/@codemirror/state": {
@@ -55,6 +184,180 @@
 				"crelt": "^1.0.6",
 				"style-mod": "^4.1.0",
 				"w3c-keyname": "^2.2.4"
+			}
+		},
+		"node_modules/@csstools/color-helpers": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
+		"node_modules/@csstools/css-calc": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+			"integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-color-parser": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+			"integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/color-helpers": "^6.0.2",
+				"@csstools/css-calc": "^3.2.0"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-syntax-patches-for-csstree": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+			"integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"peerDependencies": {
+				"css-tree": "^3.2.1"
+			},
+			"peerDependenciesMeta": {
+				"css-tree": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@csstools/css-tokenizer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
+		"node_modules/@emnapi/core": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+			"integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.1",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+			"integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -613,6 +916,24 @@
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
+		"node_modules/@exodus/bytes": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+			"integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@noble/hashes": "^1.8.0 || ^2.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@noble/hashes": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@humanfs/core": {
 			"version": "0.19.1",
 			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -671,12 +992,41 @@
 			"integrity": "sha512-Ts7cZ0Y9rIRgNkPtpXYB3BVjjSP2eeWzrPnQvJgNTC+FpopSjoaYjLQvPcEj1d6JcTMegnYoZK98/WJhm02Uaw==",
 			"license": "MIT"
 		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
 		"node_modules/@marijn/find-cluster-break": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
 			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@microsoft/microsoft-graph-types": {
 			"version": "2.38.0",
@@ -685,12 +1035,48 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@mixmark-io/domino": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+			"integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+			"integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@tybys/wasm-util": "^0.10.1"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1"
+			}
+		},
 		"node_modules/@notionhq/client": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/@notionhq/client/-/client-5.3.0.tgz",
 			"integrity": "sha512-pISuJLrP6XwxnmMZ79jT2XkMHFtbQvslfs6Rqdd29ge0KAmJOuhtWZxE1WXO7h03cj/gVAL2PiAjpFuIWrWJ3w==",
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@oxc-project/types": {
+			"version": "0.124.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+			"integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
 			}
 		},
 		"node_modules/@protobufjs/aspromise": {
@@ -757,6 +1143,295 @@
 			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
 			"license": "BSD-3-Clause"
 		},
+		"node_modules/@rolldown/binding-android-arm64": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+			"integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-arm64": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+			"integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-x64": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+			"integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-freebsd-x64": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+			"integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+			"integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-gnu": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+			"integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-musl": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+			"integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+			"integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-s390x-gnu": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+			"integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-gnu": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+			"integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-musl": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+			"integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-openharmony-arm64": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+			"integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+			"integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.9.2",
+				"@emnapi/runtime": "1.9.2",
+				"@napi-rs/wasm-runtime": "^1.1.3"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-arm64-msvc": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+			"integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-x64-msvc": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+			"integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/pluginutils": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+			"integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@stylistic/eslint-plugin": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.7.1.tgz",
@@ -805,17 +1480,26 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/@stylistic/eslint-plugin/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+		"node_modules/@tybys/wasm-util": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+			"integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
 			"dev": true,
 			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
 			}
 		},
 		"node_modules/@types/codemirror": {
@@ -827,6 +1511,13 @@
 			"dependencies": {
 				"@types/tern": "*"
 			}
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
@@ -860,6 +1551,13 @@
 			"dependencies": {
 				"@types/estree": "*"
 			}
+		},
+		"node_modules/@types/turndown": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
+			"integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/xml-flow": {
 			"version": "1.0.1",
@@ -916,7 +1614,6 @@
 			"integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.51.0",
 				"@typescript-eslint/types": "8.51.0",
@@ -1141,6 +1838,123 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/@vitest/coverage-v8": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
+			"integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@bcoe/v8-coverage": "^1.0.2",
+				"@vitest/utils": "4.1.4",
+				"ast-v8-to-istanbul": "^1.0.0",
+				"istanbul-lib-coverage": "^3.2.2",
+				"istanbul-lib-report": "^3.0.1",
+				"istanbul-reports": "^3.2.0",
+				"magicast": "^0.5.2",
+				"obug": "^2.1.1",
+				"std-env": "^4.0.0-rc.1",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@vitest/browser": "4.1.4",
+				"vitest": "4.1.4"
+			},
+			"peerDependenciesMeta": {
+				"@vitest/browser": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/expect": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+			"integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.4",
+				"@vitest/utils": "4.1.4",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+			"integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+			"integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.4",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+			"integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.4",
+				"@vitest/utils": "4.1.4",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+			"integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+			"integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.4",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
 		"node_modules/@xmldom/xmldom": {
 			"version": "0.8.11",
 			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
@@ -1166,7 +1980,6 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1224,12 +2037,44 @@
 			"dev": true,
 			"license": "Python-2.0"
 		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/ast-v8-to-istanbul": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+			"integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.31",
+				"estree-walker": "^3.0.3",
+				"js-tokens": "^10.0.0"
+			}
+		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/bidi-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+			"integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"require-from-string": "^2.0.2"
+			}
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.12",
@@ -1263,6 +2108,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/chalk": {
@@ -1309,12 +2164,20 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/crelt": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
 			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -1329,6 +2192,34 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/css-tree": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
+		"node_modules/data-urls": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+			"integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^16.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
 		"node_modules/debug": {
@@ -1349,10 +2240,47 @@
 				}
 			}
 		},
+		"node_modules/decimal.js": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/entities": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+			"integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+			"integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1416,7 +2344,6 @@
 			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -1581,6 +2508,16 @@
 				"node": ">=4.0"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1589,6 +2526,16 @@
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+			"integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -1663,6 +2610,21 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
 		"node_modules/glob-parent": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -1698,6 +2660,26 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+			"integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.6.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/html-escaper": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
@@ -1759,12 +2741,65 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/istanbul-lib-coverage": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/istanbul-lib-report": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+			"integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"istanbul-lib-coverage": "^3.0.0",
+				"make-dir": "^4.0.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-reports": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+			"integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"html-escaper": "^2.0.0",
+				"istanbul-lib-report": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/js-tokens": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.1",
@@ -1777,6 +2812,47 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/jsdom": {
+			"version": "29.0.2",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+			"integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/css-color": "^5.1.5",
+				"@asamuzakjp/dom-selector": "^7.0.6",
+				"@bramus/specificity": "^2.4.2",
+				"@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+				"@exodus/bytes": "^1.15.0",
+				"css-tree": "^3.2.1",
+				"data-urls": "^7.0.0",
+				"decimal.js": "^10.6.0",
+				"html-encoding-sniffer": "^6.0.0",
+				"is-potential-custom-element-name": "^1.0.1",
+				"lru-cache": "^11.2.7",
+				"parse5": "^8.0.0",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^6.0.1",
+				"undici": "^7.24.5",
+				"w3c-xmlserializer": "^5.0.0",
+				"webidl-conversions": "^8.0.1",
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^16.0.1",
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/json-buffer": {
@@ -1824,6 +2900,279 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/lightningcss": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+			"integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+			"dev": true,
+			"license": "MPL-2.0",
+			"dependencies": {
+				"detect-libc": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"lightningcss-android-arm64": "1.32.0",
+				"lightningcss-darwin-arm64": "1.32.0",
+				"lightningcss-darwin-x64": "1.32.0",
+				"lightningcss-freebsd-x64": "1.32.0",
+				"lightningcss-linux-arm-gnueabihf": "1.32.0",
+				"lightningcss-linux-arm64-gnu": "1.32.0",
+				"lightningcss-linux-arm64-musl": "1.32.0",
+				"lightningcss-linux-x64-gnu": "1.32.0",
+				"lightningcss-linux-x64-musl": "1.32.0",
+				"lightningcss-win32-arm64-msvc": "1.32.0",
+				"lightningcss-win32-x64-msvc": "1.32.0"
+			}
+		},
+		"node_modules/lightningcss-android-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+			"integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+			"integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+			"integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-freebsd-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+			"integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm-gnueabihf": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+			"integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+			"integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+			"integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+			"integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+			"integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-arm64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+			"integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-x64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+			"integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -1853,6 +3202,54 @@
 			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
 			"license": "Apache-2.0"
 		},
+		"node_modules/lru-cache": {
+			"version": "11.3.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+			"integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/magicast": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+			"integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"source-map-js": "^1.2.1"
+			}
+		},
+		"node_modules/make-dir": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/mathml-to-latex": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/mathml-to-latex/-/mathml-to-latex-1.5.0.tgz",
@@ -1861,6 +3258,13 @@
 			"dependencies": {
 				"@xmldom/xmldom": "^0.8.10"
 			}
+		},
+		"node_modules/mdn-data": {
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+			"dev": true,
+			"license": "CC0-1.0"
 		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
@@ -1892,6 +3296,25 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/nanoid": {
+			"version": "3.3.11",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -1913,6 +3336,17 @@
 				"@codemirror/state": "6.5.0",
 				"@codemirror/view": "6.38.6"
 			}
+		},
+		"node_modules/obug": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+			"integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT"
 		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
@@ -1977,6 +3411,19 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/parse5": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+			"integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^8.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -1997,11 +3444,67 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/plain-tag": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/plain-tag/-/plain-tag-0.1.3.tgz",
 			"integrity": "sha512-yyVAOFKTAElc7KdLt2+UKGExNYwYb/Y/WE9i+1ezCQsJE8gbKSjewfpRqK2nQgZ4d4hhAAGgDCOcIZVilqE5UA==",
 			"license": "ISC"
+		},
+		"node_modules/postcss": {
+			"version": "8.5.10",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+			"integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.11",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
 		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
@@ -2047,6 +3550,16 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/resolve-from": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2057,11 +3570,58 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/rolldown": {
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+			"integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@oxc-project/types": "=0.124.0",
+				"@rolldown/pluginutils": "1.0.0-rc.15"
+			},
+			"bin": {
+				"rolldown": "bin/cli.mjs"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"optionalDependencies": {
+				"@rolldown/binding-android-arm64": "1.0.0-rc.15",
+				"@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+				"@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+				"@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+				"@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+				"@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+				"@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+				"@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+				"@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+				"@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+				"@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+			}
+		},
 		"node_modules/sax": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
 			"integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
 			"license": "BlueOak-1.0.0"
+		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
+			}
 		},
 		"node_modules/semver": {
 			"version": "7.7.3",
@@ -2099,11 +3659,42 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/static-params": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/static-params/-/static-params-0.4.0.tgz",
 			"integrity": "sha512-PV5nE992wwLEaXOUtXKrJeyVPBiizGpC8xyqqRrACxc8duz3Ym/pyraEkd/hYOmQFuZPTF9CRaL+Ac+84yxzyg==",
 			"license": "ISC"
+		},
+		"node_modules/std-env": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/strip-json-comments": {
 			"version": "3.1.1",
@@ -2123,7 +3714,8 @@
 			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
 			"integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
@@ -2136,6 +3728,30 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+			"integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/tinyglobby": {
@@ -2173,18 +3789,60 @@
 				}
 			}
 		},
-		"node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+		"node_modules/tinyrainbow": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
-				"node": ">=12"
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tldts": {
+			"version": "7.0.28",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+			"integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tldts-core": "^7.0.28"
 			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/tldts-core": {
+			"version": "7.0.28",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+			"integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tough-cookie": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+			"integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tldts": "^7.0.5"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/ts-api-utils": {
@@ -2207,6 +3865,20 @@
 			"dev": true,
 			"license": "0BSD"
 		},
+		"node_modules/turndown": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+			"integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@mixmark-io/domino": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=18",
+				"npm": ">=9"
+			}
+		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -2226,7 +3898,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -2259,6 +3930,16 @@
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
+		"node_modules/undici": {
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+			"integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.1"
+			}
+		},
 		"node_modules/undici-types": {
 			"version": "6.21.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -2275,12 +3956,256 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"node_modules/vitest": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+			"integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.4",
+				"@vitest/mocker": "4.1.4",
+				"@vitest/pretty-format": "4.1.4",
+				"@vitest/runner": "4.1.4",
+				"@vitest/snapshot": "4.1.4",
+				"@vitest/spy": "4.1.4",
+				"@vitest/utils": "4.1.4",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.4",
+				"@vitest/browser-preview": "4.1.4",
+				"@vitest/browser-webdriverio": "4.1.4",
+				"@vitest/coverage-istanbul": "4.1.4",
+				"@vitest/coverage-v8": "4.1.4",
+				"@vitest/ui": "4.1.4",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/vitest/node_modules/@vitest/mocker": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+			"integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.4",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vitest/node_modules/vite": {
+			"version": "8.0.8",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+			"integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lightningcss": "^1.32.0",
+				"picomatch": "^4.0.4",
+				"postcss": "^8.5.8",
+				"rolldown": "1.0.0-rc.15",
+				"tinyglobby": "^0.2.15"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"@vitejs/devtools": "^0.1.0",
+				"esbuild": "^0.27.0 || ^0.28.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"@vitejs/devtools": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/w3c-keyname": {
 			"version": "2.2.8",
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
 			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/w3c-xmlserializer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+			"integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+			"integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.11.0",
+				"tr46": "^6.0.0",
+				"webidl-conversions": "^8.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
@@ -2296,6 +4221,23 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/word-wrap": {
@@ -2316,6 +4258,23 @@
 			"dependencies": {
 				"sax": "^1.2.4"
 			}
+		},
+		"node_modules/xml-name-validator": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -skipLibCheck && node esbuild.config.mjs production",
 		"version": "node version-bump.mjs && git add manifest.json package.json versions.json",
-		"lint": "eslint src --fix"
+		"lint": "eslint src --fix",
+		"test": "vitest run",
+		"test:watch": "vitest"
 	},
 	"keywords": [],
 	"author": "",
@@ -16,14 +18,19 @@
 		"@microsoft/microsoft-graph-types": "2.38.0",
 		"@stylistic/eslint-plugin": "5.7.1",
 		"@types/node": "20.19.27",
+		"@types/turndown": "^5.0.6",
 		"@types/xml-flow": "1.0.1",
+		"@vitest/coverage-v8": "^4.1.4",
 		"builtin-modules": "3.3.0",
 		"esbuild": "0.25.4",
 		"eslint": "9.39.2",
+		"jsdom": "^29.0.2",
 		"obsidian": "latest",
 		"tslib": "2.4.0",
+		"turndown": "^7.2.4",
 		"typescript": "5.9.3",
-		"typescript-eslint": "8.51.0"
+		"typescript-eslint": "8.51.0",
+		"vitest": "^4.1.4"
 	},
 	"dependencies": {
 		"@joplin/turndown-plugin-gfm": "1.0.62",

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -699,9 +699,47 @@ export class OneNoteImporter extends FormatImporter {
 			// If a to-do tag, then convert it into a Markdown task list
 			if (element.getAttribute('data-tag')?.contains('to-do')) {
 				const isChecked = element.getAttribute('data-tag') === 'to-do:completed';
-				const check = isChecked ? '[x]' : '[ ]';
-				// We need to use innerHTML in case an image was marked as TO-DO
-				element.innerHTML = `- ${check} ${element.innerHTML}`;
+
+				// When the tagged element is inside a <li>, insert an
+				// <input type="checkbox"> as the first child of the <li> so
+				// that the GFM turndown rule emits "- [ ] " / "- [x] ".
+				// Injecting literal "- [ ] " text would be escaped by turndown.
+				// See https://learn.microsoft.com/en-us/graph/onenote-input-output-html
+				const closestLi = element.closest('li');
+				if (closestLi) {
+					const checkbox = pageElement.ownerDocument.createElement('input');
+					checkbox.setAttribute('type', 'checkbox');
+					if (isChecked) {
+						// Use setAttribute so the attribute is present in the
+						// serialised HTML and turndown can read node.checked.
+						checkbox.setAttribute('checked', '');
+					}
+					closestLi.insertBefore(checkbox, closestLi.firstChild);
+					// Remove data-tag so a <li> with multiple tagged
+					// descendants is not processed more than once.
+					element.removeAttribute('data-tag');
+				}
+				else {
+					// Top-level to-do paragraph: replace with a task-list item
+					// so turndown emits unescaped "- [ ] " / "- [x] ".
+					// The OneNote API does not encode visual indentation for
+					// these elements — they appear flat regardless of how they
+					// look in the UI.
+					const ul = pageElement.ownerDocument.createElement('ul');
+					const li = pageElement.ownerDocument.createElement('li');
+					const checkbox = pageElement.ownerDocument.createElement('input');
+					checkbox.setAttribute('type', 'checkbox');
+					if (isChecked) {
+						checkbox.setAttribute('checked', '');
+					}
+					li.appendChild(checkbox);
+					// We need to move children in case an image was marked as TO-DO
+					while (element.firstChild) {
+						li.appendChild(element.firstChild);
+					}
+					ul.appendChild(li);
+					element.replaceWith(ul);
+				}
 			}
 			// All other OneNote tags are already in the Obsidian tag format ;)
 			else {
@@ -1055,8 +1093,10 @@ export class OneNoteImporter extends FormatImporter {
 	//
 	// https://github.com/obsidianmd/obsidian-importer/issues/363
 	removeExtraListItemParagraphs(element: HTMLElement): void {
-		// if the first list item child is a paragraph
-		element.querySelectorAll('li > p:first-child').forEach((p) => {
+		// Match `li > p:first-child` (normal case) and also
+		// `li > input:first-child + p` for when convertTags has inserted a
+		// checkbox as the first child before the wrapping paragraph.
+		element.querySelectorAll('li > p:first-child, li > input:first-child + p').forEach((p) => {
 			if (
 				isHTMLElement(p)
 				// and it has 0 margin (this is really just to sanity check that this isn't meant to create newlines, visually)

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -4,9 +4,16 @@ import { genUid, extractErrorMessage, parseHTML } from '../util';
 import { FormatImporter } from '../format-importer';
 import { ATTACHMENT_EXTS, AUTH_REDIRECT_URI, ImportContext } from '../main';
 import { AccessTokenResponse } from './onenote/models';
-import { getSiblingsInSameCodeBlock, isFenceCodeBlock, isInlineCodeSpan, isBRElement, isParagraphWrappingOnlyCode } from './onenote/code';
 import { inkmlToSvg } from './onenote/inkml';
-import { MathMLToLaTeX } from 'mathml-to-latex';
+import {
+	convertTags as _convertTags,
+	combineCodeBlocksAsNecessary as _combineCodeBlocksAsNecessary,
+	styledElementToHTML as _styledElementToHTML,
+	convertMathML as _convertMathML,
+	escapeTextNodes as _escapeTextNodes,
+	removeExtraListItemParagraphs as _removeExtraListItemParagraphs,
+	convertInternalLinks as _convertInternalLinks,
+} from './onenote/onenote-converter';
 
 const LOCAL_STORAGE_KEY = 'onenote-importer-refresh-token';
 const GRAPH_CLIENT_ID: string = '66553851-08fa-44f2-8bb1-1436f121a73d';
@@ -54,10 +61,6 @@ function assertJSONWrappedResponse<T>(res: unknown): asserts res is JSONWrappedR
 	if (!Array.isArray((res as Record<string, unknown>).value)) {
 		throw new Error(`Expected response to have an error in 'value' property`);
 	}
-}
-
-function isHTMLElement(node: Node): node is HTMLElement {
-	return node instanceof HTMLElement;
 }
 
 export class OneNoteImporter extends FormatImporter {
@@ -604,36 +607,7 @@ export class OneNoteImporter extends FormatImporter {
 
 	/** Convert MathML elements to LaTeX format for Obsidian */
 	convertMathML(pageElement: HTMLElement): void {
-		const mathElements = Array.from(pageElement.querySelectorAll('math'));
-
-		for (const mathElement of mathElements) {
-			try {
-				// Get the MathML as a string
-				const mathMLString = mathElement.outerHTML;
-
-				// Convert MathML to LaTeX using mathml2latex
-				const latexString = MathMLToLaTeX.convert(mathMLString);
-
-				// Create the appropriate LaTeX syntax for Obsidian.
-				//
-				// MathML exported from OneNote all include the attribute display="block",
-				// but we can safely convert them to inline form, as the block form would
-				// be wrapped in <br /> line breaks.
-				let obsidianMath = `$${latexString}$`;
-
-				// Create a text node with the LaTeX
-				const textNode = document.createTextNode(obsidianMath);
-
-				// Replace the MathML element with the LaTeX text node
-				mathElement.parentNode?.replaceChild(textNode, mathElement);
-			}
-			catch (error) {
-				console.warn('Failed to convert MathML to LaTeX:', error);
-				// If conversion fails, keep the original MathML or replace with a placeholder
-				const fallbackText = document.createTextNode('[Math equation - conversion failed]');
-				mathElement.parentNode?.replaceChild(fallbackText, mathElement);
-			}
-		}
+		_convertMathML(pageElement);
 	}
 
 	isLatexMath(text: string): boolean {
@@ -643,20 +617,7 @@ export class OneNoteImporter extends FormatImporter {
 
 	/** Escape characters which will cause problems after converting to markdown. */
 	escapeTextNodes(node: ChildNode): void {
-		if (node.nodeType === Node.TEXT_NODE && node.textContent) {
-			// Don't escape text that contains LaTeX math expressions
-			if (this.isLatexMath(node.textContent)) {
-				return;
-			}
-
-			node.textContent = node.textContent
-				.replace(/([<>])/g, '\\$1');
-		}
-		else {
-			for (let i = 0; i < node.childNodes.length; i++) {
-				this.escapeTextNodes(node.childNodes[i]);
-			}
-		}
+		_escapeTextNodes(node);
 	}
 
 	// OneNote returns page data and inking data in one file, so we need to split them
@@ -693,74 +654,12 @@ export class OneNoteImporter extends FormatImporter {
 	}
 
 	convertTags(pageElement: HTMLElement): string {
-		const tagElements = Array.from(pageElement.querySelectorAll('[data-tag]'));
-
-		for (const element of tagElements) {
-			// If a to-do tag, then convert it into a Markdown task list
-			if (element.getAttribute('data-tag')?.contains('to-do')) {
-				const isChecked = element.getAttribute('data-tag') === 'to-do:completed';
-
-				// When the tagged element is inside a <li>, insert an
-				// <input type="checkbox"> as the first child of the <li> so
-				// that the GFM turndown rule emits "- [ ] " / "- [x] ".
-				// Injecting literal "- [ ] " text would be escaped by turndown.
-				// See https://learn.microsoft.com/en-us/graph/onenote-input-output-html
-				const closestLi = element.closest('li');
-				if (closestLi) {
-					const checkbox = pageElement.ownerDocument.createElement('input');
-					checkbox.setAttribute('type', 'checkbox');
-					if (isChecked) {
-						// Use setAttribute so the attribute is present in the
-						// serialised HTML and turndown can read node.checked.
-						checkbox.setAttribute('checked', '');
-					}
-					closestLi.insertBefore(checkbox, closestLi.firstChild);
-					// Remove data-tag so a <li> with multiple tagged
-					// descendants is not processed more than once.
-					element.removeAttribute('data-tag');
-				}
-				else {
-					// Top-level to-do paragraph: replace with a task-list item
-					// so turndown emits unescaped "- [ ] " / "- [x] ".
-					// The OneNote API does not encode visual indentation for
-					// these elements — they appear flat regardless of how they
-					// look in the UI.
-					const ul = pageElement.ownerDocument.createElement('ul');
-					const li = pageElement.ownerDocument.createElement('li');
-					const checkbox = pageElement.ownerDocument.createElement('input');
-					checkbox.setAttribute('type', 'checkbox');
-					if (isChecked) {
-						checkbox.setAttribute('checked', '');
-					}
-					li.appendChild(checkbox);
-					// We need to move children in case an image was marked as TO-DO
-					while (element.firstChild) {
-						li.appendChild(element.firstChild);
-					}
-					ul.appendChild(li);
-					element.replaceWith(ul);
-				}
-			}
-			// All other OneNote tags are already in the Obsidian tag format ;)
-			else {
-				const tags = element.getAttribute('data-tag')?.split(',');
-				tags?.forEach((tag) => {
-					element.innerHTML = element.innerHTML + ` #${tag.replace(':', '-')} `;
-				});
-			}
-		}
+		_convertTags(pageElement);
 		return pageElement.outerHTML;
 	}
 
 	convertInternalLinks(pageElement: HTMLElement): void {
-		const links: HTMLAnchorElement[] = pageElement.findAll('a') as HTMLAnchorElement[];
-		for (const link of links) {
-			if (link.href.startsWith('onenote:')) {
-				const startIdx = link.href.indexOf('#') + 1;
-				const endIdx = link.href.indexOf('&', startIdx);
-				link.href = link.href.slice(startIdx, endIdx);
-			}
-		}
+		_convertInternalLinks(pageElement);
 	}
 
 	getEntityPathNoParent(entityID: string, currentPath: string): string | null {
@@ -976,95 +875,12 @@ export class OneNoteImporter extends FormatImporter {
 	 * single newline (br), combine them.
 	 */
 	combineCodeBlocksAsNecessary(pageElement: HTMLElement): void {
-		const paragraphs = pageElement.querySelectorAll('p:has(+ br + p)');
-		// querySelectorAll must return results in document order, so we should combine nodes in reverse order
-		Array.from(paragraphs).reverse().forEach((p) => {
-			const firstParagraph = p;
-			const lineBreak = p.nextElementSibling;
-			if (!isBRElement(lineBreak)) {
-				throw new Error(`Expected a <br> element after the paragraph, but found: ${lineBreak?.nodeName}`);
-			}
-			const secondParagraph = lineBreak.nextElementSibling;
-			if (isParagraphWrappingOnlyCode(firstParagraph)
-				&& isParagraphWrappingOnlyCode(secondParagraph)) {
-				// move the line break ...
-				firstParagraph.appendChild(lineBreak);
-				// .. and add another line break to capture the newline between
-				// the two paragraphs
-				firstParagraph.appendChild(lineBreak.cloneNode());
-				// ... and clone second paragraph's children into the first paragraph
-				firstParagraph.insertAdjacentHTML('beforeend', secondParagraph.innerHTML);
-				// clean-up the DOM (linebreak was moved, second paragraph wasn't)
-				secondParagraph.remove();
-			}
-		});
+		_combineCodeBlocksAsNecessary(pageElement);
 	}
 
 	// Convert OneNote styled elements to valid HTML for proper htmlToMarkdown conversion
 	styledElementToHTML(pageElement: HTMLElement): void {
-		// Map styles to their elements
-		const styleMap: { [key: string]: string } = {
-			'font-weight:bold': 'b',
-			'font-style:italic': 'i',
-			'text-decoration:underline': 'u',
-			'text-decoration:line-through': 's',
-			'background-color': 'mark',
-		};
-		// Cites/quotes are not converted into Markdown (possible htmlToMarkdown bug?), so we do it ourselves temporarily
-		const cites = pageElement.findAll('cite');
-		cites.forEach((cite) => cite.innerHTML = '> ' + cite.innerHTML + '<br>');
-
-		const elements = pageElement.querySelectorAll('*');
-		elements.forEach(element => {
-			if (!pageElement.contains(element)) {
-				// already processed and removed, can skip
-				return;
-			}
-
-			if (isInlineCodeSpan(element)) {
-				// Convert preformatted text into an inline code span
-				const codeElement = document.createElement('code');
-				codeElement.innerHTML = element.innerHTML;
-				element.replaceWith(codeElement);
-			}
-			else if (isFenceCodeBlock(element)) {
-				// Convert preformatted text into a code fence
-				const codeBlockItems: string[] = [element.innerHTML];
-				getSiblingsInSameCodeBlock(element).forEach(sibling => {
-					codeBlockItems.push(
-						isBRElement(sibling) ? '\n' : sibling.innerHTML
-					);
-					sibling.remove();
-				});
-
-				// wrap the code in a pre element
-				const codeElement = document.createElement('pre');
-				codeElement.innerHTML =
-					'```\n' +
-					codeBlockItems.join('') +
-					'\n```';
-
-				// replace the original node with the pre element
-				element.replaceWith(codeElement);
-			}
-			else {
-				if (element.nodeName === 'TD') {
-					// Do not replace table cells if they are styled.
-					element.removeAttribute('style');
-					return;
-				}
-				else {
-					const style = element.getAttribute('style') || '';
-					const matchingStyle = Object.keys(styleMap).find(key => style.includes(key));
-					if (matchingStyle) {
-						const newElementTag = styleMap[matchingStyle];
-						const newElement = document.createElement(newElementTag);
-						newElement.innerHTML = element.innerHTML;
-						element.replaceWith(newElement);
-					}
-				}
-			}
-		});
+		_styledElementToHTML(pageElement);
 	}
 
 	// OneNote wraps list items in an extra, marginless paragraph. Remove these
@@ -1093,19 +909,7 @@ export class OneNoteImporter extends FormatImporter {
 	//
 	// https://github.com/obsidianmd/obsidian-importer/issues/363
 	removeExtraListItemParagraphs(element: HTMLElement): void {
-		// Match `li > p:first-child` (normal case) and also
-		// `li > input:first-child + p` for when convertTags has inserted a
-		// checkbox as the first child before the wrapping paragraph.
-		element.querySelectorAll('li > p:first-child, li > input:first-child + p').forEach((p) => {
-			if (
-				isHTMLElement(p)
-				// and it has 0 margin (this is really just to sanity check that this isn't meant to create newlines, visually)
-				&& p.style.marginBottom === '0pt' && p.style.marginTop === '0pt'
-			) {
-				// then unwrap the paragraph (move its children up to its parent, so there is no paragraph)
-				p.replaceWith(...Array.from(p.childNodes));
-			}
-		});
+		_removeExtraListItemParagraphs(element);
 	}
 
 

--- a/src/formats/onenote/onenote-converter.ts
+++ b/src/formats/onenote/onenote-converter.ts
@@ -1,0 +1,295 @@
+/**
+ * Pure DOM-transformation functions for converting OneNote HTML to Markdown-ready HTML.
+ *
+ * These functions mutate an HTMLElement in place and can be composed in a pipeline
+ * before the final htmlToMarkdown() call.  They are extracted here so that they can
+ * be unit-tested without requiring the full Obsidian runtime.
+ *
+ * OneNote HTML is produced by the Microsoft Graph API.  Relevant spec:
+ * https://learn.microsoft.com/en-us/graph/onenote-input-output-html
+ */
+
+import { getSiblingsInSameCodeBlock, isFenceCodeBlock, isInlineCodeSpan, isBRElement, isParagraphWrappingOnlyCode } from './code';
+import { MathMLToLaTeX } from 'mathml-to-latex';
+
+function isHTMLElement(node: Node): node is HTMLElement {
+	return node instanceof HTMLElement;
+}
+
+/**
+ * Convert OneNote data-tag attributes to Markdown equivalents.
+ *
+ * The Microsoft Graph API encodes OneNote tags as `data-tag` attributes on
+ * the containing element.  Two cases are handled:
+ *
+ *  • To-do tags (`data-tag="to-do"` / `data-tag="to-do:completed"`) on
+ *    **top-level <p> elements** — the element is replaced with a
+ *    `<ul><li><input type="checkbox">…</li></ul>` so that the GFM turndown
+ *    rule emits `- [ ] ` (or `- [x] ` when completed) rather than injecting
+ *    literal Markdown text that would be escaped.  These elements are flat
+ *    in the API output regardless of visual indentation in the OneNote UI.
+ *
+ *  • To-do tags on elements **inside a <li>** — the <li> itself is rewritten
+ *    as a task-list item by inserting an `<input type="checkbox">` node so
+ *    that the GFM turndown rule can pick it up.  This preserves the nesting
+ *    depth already encoded by the surrounding <ol>/<ul> structure.
+ *
+ *  • All other tags (e.g. `important`, `question`) are converted to Obsidian
+ *    hashtag syntax and appended to the element content.
+ */
+export function convertTags(pageElement: HTMLElement): void {
+	const tagElements = Array.from(pageElement.querySelectorAll('[data-tag]'));
+
+	for (const element of tagElements) {
+		const tag = element.getAttribute('data-tag') ?? '';
+
+		if (tag.includes('to-do')) {
+			const isChecked = tag === 'to-do:completed';
+
+			// When the tagged element is inside a <li> (directly or via a <p>/<span>),
+			// we rewrite the ancestor <li> as a task-list item instead of injecting
+			// raw Markdown text into the element content.  The GFM turndown plugin
+			// recognises <li> children that are <input type="checkbox"> elements and
+			// emits "- [ ] " / "- [x] " accordingly.
+			const closestLi = element.closest('li');
+			if (closestLi) {
+				const checkbox = pageElement.ownerDocument.createElement('input');
+				checkbox.setAttribute('type', 'checkbox');
+				if (isChecked) {
+					// setAttribute ensures the 'checked' attribute is present in
+					// the serialised HTML so that turndown's GFM taskListItems
+					// rule can read node.checked correctly.
+					checkbox.setAttribute('checked', '');
+				}
+				// Insert the checkbox as the very first child of the <li> so
+				// that turndown's taskListItems rule finds it.
+				closestLi.insertBefore(checkbox, closestLi.firstChild);
+				// Remove the data-tag so we don't process this <li> twice
+				// if it contains multiple tagged descendants.
+				element.removeAttribute('data-tag');
+			}
+			else {
+				// Top-level to-do paragraph: replace with a task-list item so
+				// that the GFM turndown rule produces "- [ ] " / "- [x] "
+				// instead of injecting literal Markdown text that would be
+				// escaped by turndown.
+				//
+				// The OneNote API does not encode visual indentation for these
+				// elements — they appear as flat <p> tags regardless of how
+				// they look in the UI — so they are always emitted at the top
+				// level.
+				const ul = pageElement.ownerDocument.createElement('ul');
+				const li = pageElement.ownerDocument.createElement('li');
+				const checkbox = pageElement.ownerDocument.createElement('input');
+				checkbox.setAttribute('type', 'checkbox');
+				if (isChecked) {
+					checkbox.setAttribute('checked', '');
+				}
+				li.appendChild(checkbox);
+				// Preserve any inline children (images, formatted text, etc.)
+				while (element.firstChild) {
+					li.appendChild(element.firstChild);
+				}
+				ul.appendChild(li);
+				element.replaceWith(ul);
+			}
+		}
+		else {
+			// All other OneNote tags map directly to Obsidian tag syntax.
+			const tags = tag.split(',');
+			tags.forEach((t) => {
+				element.innerHTML = element.innerHTML + ` #${t.replace(':', '-')} `;
+			});
+		}
+	}
+}
+
+/**
+ * Given code blocks in separate paragraphs that are only separated by a
+ * single newline (<br>), combine them into one block.
+ */
+export function combineCodeBlocksAsNecessary(pageElement: HTMLElement): void {
+	const paragraphs = pageElement.querySelectorAll('p:has(+ br + p)');
+	// querySelectorAll returns results in document order; combine in reverse
+	// order so earlier nodes are still valid when we process them.
+	Array.from(paragraphs).reverse().forEach((p) => {
+		const firstParagraph = p;
+		const lineBreak = p.nextElementSibling;
+		if (!isBRElement(lineBreak)) {
+			throw new Error(`Expected a <br> element after the paragraph, but found: ${lineBreak?.nodeName}`);
+		}
+		const secondParagraph = lineBreak.nextElementSibling;
+		if (isParagraphWrappingOnlyCode(firstParagraph)
+			&& isParagraphWrappingOnlyCode(secondParagraph)) {
+			firstParagraph.appendChild(lineBreak);
+			firstParagraph.appendChild(lineBreak.cloneNode());
+			firstParagraph.insertAdjacentHTML('beforeend', secondParagraph.innerHTML);
+			secondParagraph.remove();
+		}
+	});
+}
+
+/**
+ * Convert OneNote styled elements to valid semantic HTML so that
+ * htmlToMarkdown can handle them correctly.
+ *
+ * Inline styles such as `font-weight:bold` are replaced with the
+ * corresponding semantic element (`<b>`, `<i>`, `<u>`, `<s>`, `<mark>`).
+ * Preformatted Consolas spans are converted to `<code>` or fenced
+ * ``` ``` ``` blocks.
+ */
+export function styledElementToHTML(pageElement: HTMLElement): void {
+	const styleMap: { [key: string]: string } = {
+		'font-weight:bold': 'b',
+		'font-style:italic': 'i',
+		'text-decoration:underline': 'u',
+		'text-decoration:line-through': 's',
+		'background-color': 'mark',
+	};
+	// Cites/quotes are not converted into Markdown by htmlToMarkdown, so we
+	// do it ourselves here.
+	const cites = Array.from(pageElement.querySelectorAll('cite'));
+	cites.forEach((cite) => (cite as HTMLElement).innerHTML = '> ' + (cite as HTMLElement).innerHTML + '<br>');
+
+	const elements = pageElement.querySelectorAll('*');
+	elements.forEach(element => {
+		if (!pageElement.contains(element)) {
+			return;
+		}
+
+		if (isInlineCodeSpan(element)) {
+			const codeElement = element.ownerDocument.createElement('code');
+			codeElement.innerHTML = element.innerHTML;
+			element.replaceWith(codeElement);
+		}
+		else if (isFenceCodeBlock(element)) {
+			const codeBlockItems: string[] = [element.innerHTML];
+			getSiblingsInSameCodeBlock(element).forEach(sibling => {
+				codeBlockItems.push(
+					isBRElement(sibling) ? '\n' : sibling.innerHTML
+				);
+				sibling.remove();
+			});
+
+			const codeElement = element.ownerDocument.createElement('pre');
+			codeElement.innerHTML =
+				'```\n' +
+				codeBlockItems.join('') +
+				'\n```';
+
+			element.replaceWith(codeElement);
+		}
+		else {
+			if (element.nodeName === 'TD') {
+				element.removeAttribute('style');
+				return;
+			}
+			else {
+				const style = element.getAttribute('style') || '';
+				const matchingStyle = Object.keys(styleMap).find(key => style.includes(key));
+				if (matchingStyle) {
+					const newElementTag = styleMap[matchingStyle];
+					const newElement = element.ownerDocument.createElement(newElementTag);
+					newElement.innerHTML = element.innerHTML;
+					element.replaceWith(newElement);
+				}
+			}
+		}
+	});
+}
+
+/** Convert MathML elements to LaTeX format for Obsidian. */
+export function convertMathML(pageElement: HTMLElement): void {
+	const mathElements = Array.from(pageElement.querySelectorAll('math'));
+
+	for (const mathElement of mathElements) {
+		try {
+			const mathMLString = mathElement.outerHTML;
+			const latexString = MathMLToLaTeX.convert(mathMLString);
+			// MathML exported from OneNote all include display="block", but
+			// we convert to inline form ($…$) because the block form would
+			// be wrapped in <br /> line breaks.
+			const obsidianMath = `$${latexString}$`;
+			const textNode = mathElement.ownerDocument.createTextNode(obsidianMath);
+			mathElement.parentNode?.replaceChild(textNode, mathElement);
+		}
+		catch (error) {
+			console.warn('Failed to convert MathML to LaTeX:', error);
+			const fallbackText = mathElement.ownerDocument.createTextNode('[Math equation - conversion failed]');
+			mathElement.parentNode?.replaceChild(fallbackText, mathElement);
+		}
+	}
+}
+
+/** Escape characters which will cause problems after converting to markdown. */
+export function escapeTextNodes(node: ChildNode): void {
+	if (node.nodeType === Node.TEXT_NODE && node.textContent) {
+		if (isLatexMath(node.textContent)) {
+			return;
+		}
+		node.textContent = node.textContent.replace(/([<>])/g, '\\$1');
+	}
+	else {
+		for (let i = 0; i < node.childNodes.length; i++) {
+			escapeTextNodes(node.childNodes[i]);
+		}
+	}
+}
+
+function isLatexMath(text: string): boolean {
+	const trimmed = text.trim();
+	return (trimmed.startsWith('$') && trimmed.endsWith('$')) || (trimmed.startsWith('$$') && trimmed.endsWith('$$'));
+}
+
+/**
+ * Remove the extra, marginless paragraph that OneNote wraps around list item
+ * text.  Without this, turndown adds extra blank lines inside list items,
+ * which breaks nested list rendering.
+ *
+ * BEFORE:
+ *   <ul>
+ *     <li>
+ *       <p style="margin-top:0pt;margin-bottom:0pt">Item text</p>
+ *       <ul>
+ *         <li style="list-style-type:circle">Nested item</li>
+ *       </ul>
+ *     </li>
+ *   </ul>
+ *
+ * AFTER:
+ *   <ul>
+ *     <li>
+ *       Item text
+ *       <ul>
+ *         <li style="list-style-type:circle">Nested item</li>
+ *       </ul>
+ *     </li>
+ *   </ul>
+ *
+ * See https://github.com/obsidianmd/obsidian-importer/issues/363
+ */
+export function removeExtraListItemParagraphs(element: HTMLElement): void {
+	// Match both `li > p:first-child` (normal case) and
+	// `li > input:first-child + p` (when convertTags has inserted a checkbox
+	// as the first child before the wrapping paragraph).
+	element.querySelectorAll('li > p:first-child, li > input:first-child + p').forEach((p) => {
+		if (
+			isHTMLElement(p)
+			&& p.style.marginBottom === '0pt' && p.style.marginTop === '0pt'
+		) {
+			p.replaceWith(...Array.from(p.childNodes));
+		}
+	});
+}
+
+/** Convert onenote: internal links to their page-id fragment form. */
+export function convertInternalLinks(pageElement: HTMLElement): void {
+	const links = Array.from(pageElement.querySelectorAll('a')) as HTMLAnchorElement[];
+	for (const link of links) {
+		if (link.href.startsWith('onenote:')) {
+			const startIdx = link.href.indexOf('#') + 1;
+			const endIdx = link.href.indexOf('&', startIdx);
+			link.href = link.href.slice(startIdx, endIdx);
+		}
+	}
+}

--- a/tests/onenote/helpers.ts
+++ b/tests/onenote/helpers.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared test helpers for OneNote converter tests.
+ */
+
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import TurndownService from 'turndown';
+// @ts-expect-error – no bundled types in the package
+import { gfm } from '@joplin/turndown-plugin-gfm';
+
+import {
+	convertTags,
+	combineCodeBlocksAsNecessary,
+	styledElementToHTML,
+	convertInternalLinks,
+	removeExtraListItemParagraphs,
+	escapeTextNodes,
+} from '../../src/formats/onenote/onenote-converter';
+
+export const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Build a turndown instance that matches the Obsidian htmlToMarkdown configuration. */
+export function makeTurndown(): TurndownService {
+	const td = new TurndownService({ bulletListMarker: '-' });
+	td.use(gfm);
+	// Obsidian's htmlToMarkdown passes <pre> content through verbatim rather
+	// than escaping it, because styledElementToHTML already wrote the fenced
+	// code markers (``` … ```) as raw text into the <pre> innerHTML.  Without
+	// this rule, turndown escapes the backticks.
+	td.addRule('pre-verbatim', {
+		filter: 'pre',
+		replacement(_content, node) {
+			return '\n\n' + (node as HTMLElement).textContent + '\n\n';
+		},
+	});
+	return td;
+}
+
+/**
+ * Load a fixture file, run the full conversion pipeline, and return the
+ * resulting Markdown string.  Simulates what OneNoteImporter.processFile
+ * does, minus attachment downloading and the format-splitting step.
+ *
+ * Uses the global document provided by vitest's jsdom environment so that
+ * instanceof HTMLElement checks inside the converter work correctly.
+ */
+export function convertFixture(filename: string): string {
+	const fixtureHtml = readFileSync(resolve(__dirname, filename), 'utf8');
+
+	// Use the vitest jsdom global document so that instanceof checks in the
+	// converter functions resolve against the same HTMLElement class.
+	// Extract just the <body> content to avoid loading <head> metadata.
+	const bodyMatch = fixtureHtml.match(/<body[^>]*>([\s\S]*)<\/body>/i);
+	document.body.innerHTML = bodyMatch ? bodyMatch[1] : fixtureHtml;
+	const body = document.body as HTMLElement;
+
+	// Run the conversion pipeline in the same order as processFile
+	convertTags(body);
+	combineCodeBlocksAsNecessary(body);
+	styledElementToHTML(body);
+	convertInternalLinks(body);
+	removeExtraListItemParagraphs(body);
+	escapeTextNodes(body);
+
+	return makeTurndown().turndown(body.innerHTML);
+}

--- a/tests/onenote/onenote-baseline.test.ts
+++ b/tests/onenote/onenote-baseline.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Regression baseline tests for onenote.html.
+ *
+ * Covers every element type present in the fixture to guard against
+ * regressions in the existing conversion behaviour.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { convertFixture } from './helpers';
+
+describe('onenote.html – baseline conversion', () => {
+	let md: string;
+
+	beforeEach(() => {
+		md = convertFixture('onenote.html');
+	});
+
+	it('converts plain paragraph text', () => {
+		expect(md).toContain('This is a plain paragraph with no formatting.');
+	});
+
+	it('converts bold span to **strong**', () => {
+		expect(md).toContain('**bold words**');
+	});
+
+	it('converts italic span to _em_', () => {
+		expect(md).toContain('_italic words_');
+	});
+
+	it('converts strikethrough span to ~~text~~', () => {
+		expect(md).toContain('~~strikethrough words~~');
+	});
+
+	it('converts underlined span (no markdown equivalent — text preserved)', () => {
+		expect(md).toContain('underlined words');
+	});
+
+	it('converts highlighted span text (mark → plain text fallback)', () => {
+		expect(md).toContain('These words are highlighted');
+	});
+
+	it('converts unchecked flat to-do to a "- [ ]" task-list item', () => {
+		expect(md).toContain('-   [ ] Unchecked task');
+	});
+
+	it('converts checked flat to-do to a "- [x]" task-list item', () => {
+		expect(md).toContain('-   [x] Checked task');
+	});
+
+	it('converts unordered list', () => {
+		expect(md).toContain('-   Unordered list');
+	});
+
+	it('converts ordered list', () => {
+		expect(md).toContain('1.  Ordered list');
+	});
+
+	it('combines adjacent Consolas paragraphs into one fenced code block', () => {
+		expect(md).toContain('```\nconst x = 1;\nconst y = 2;\n```');
+	});
+
+	it('converts inline Consolas span to backtick code', () => {
+		expect(md).toContain('Call the function `myFunction()` to start.');
+	});
+
+	it('converts cite element to blockquote prefix', () => {
+		// styledElementToHTML prepends "> " inside the cite innerHTML, then
+		// turndown renders the cite as plain text — so the output is a literal
+		// \> rather than a true blockquote block.
+		expect(md).toContain('\\> This is a citation.');
+	});
+
+	it('converts italic quote paragraph', () => {
+		expect(md).toContain('_This is a quoted block of text._');
+	});
+
+	it('converts H1 heading using setext underline', () => {
+		expect(md).toContain('Heading 1\n=========');
+	});
+
+	it('converts H2 heading using setext underline', () => {
+		expect(md).toContain('Heading 2\n---------');
+	});
+
+	it('converts H3 heading using ATX prefix', () => {
+		expect(md).toContain('### Heading 3');
+	});
+
+	it('converts H4 heading to italic span (no H4 in setext/ATX output)', () => {
+		// turndown has no H4 setext/ATX rule beyond H3; the italic style on the
+		// OneNote H4 element causes styledElementToHTML to wrap it in <i>.
+		expect(md).toContain('\n_Heading 4_\n');
+	});
+
+	it('converts H5 heading using ATX prefix', () => {
+		expect(md).toContain('##### Heading 5');
+	});
+
+	it('converts internal onenote: links to page-id fragment', () => {
+		expect(md).toContain('[Test page](Test)');
+	});
+
+	it('preserves external https links', () => {
+		expect(md).toContain('[https://obsidian.md](https://obsidian.md)');
+	});
+
+	it('converts table to GFM table format', () => {
+		expect(md).toContain('| Header A | Header B |');
+		expect(md).toContain('| **BOLD TEXT** | Normal |');
+	});
+
+	it('converts important note tag to Obsidian hashtag', () => {
+		expect(md).toContain('#important');
+	});
+
+	it('converts question note tag to Obsidian hashtag', () => {
+		expect(md).toContain('#question');
+	});
+
+	it('converts bold paragraph text', () => {
+		expect(md).toContain('**Paragraph with combined indentation and bold.**');
+	});
+});

--- a/tests/onenote/onenote-indented-example.html
+++ b/tests/onenote/onenote-indented-example.html
@@ -1,0 +1,75 @@
+<!-- Generated from the author's personal OneNote on 2026-04-18 -->
+<html lang="en-GB">
+	<head>
+		<title>Test</title>
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+		<meta name="created" content="2026-04-18T22:18:00.0000000" />
+	</head>
+	<body data-absolute-enabled="true" style="font-family:Calibri;font-size:11pt">
+		<div style="position:absolute;left:48px;top:115px;width:720px">
+			<p style="margin-top:0pt;margin-bottom:0pt">Indented Numbered List</p>
+			<ol>
+				<li><p style="margin-top:0pt;margin-bottom:0pt">Outer</p>
+				<ol>
+					<li style="list-style-type:lower-alpha"><p style="margin-top:0pt;margin-bottom:0pt">Inner l1</p>
+					<ol>
+						<li style="list-style-type:lower-roman">Inner l2</li>
+					</ol>
+					</li>
+				</ol>
+				</li>
+				<li>Outer</li>
+				<li>Outer</li>
+				<br />
+			</ol>
+			<br />
+			<p style="margin-top:0pt;margin-bottom:0pt">Indented Unordered List</p>
+			<ul>
+				<li><p style="margin-top:0pt;margin-bottom:0pt">Outer</p>
+				<ul>
+					<li style="list-style-type:circle"><p style="margin-top:0pt;margin-bottom:0pt">Inner 1</p>
+					<ul>
+						<li>Inner 2</li>
+					</ul>
+					</li>
+				</ul>
+				</li>
+				<li>Outer</li>
+			</ul>
+			<br />
+			<p style="margin-top:0pt;margin-bottom:0pt">Indented Numbered Todos</p>
+			<ol>
+				<li><p data-tag="to-do" style="margin-top:0pt;margin-bottom:0pt">Outer</p>
+				<ol>
+					<li style="list-style-type:lower-alpha"><p data-tag="to-do" style="margin-top:0pt;margin-bottom:0pt">Inner l1</p>
+					<ol>
+						<li style="list-style-type:lower-roman"><span data-tag="to-do">Inner l2</span></li>
+					</ol>
+					</li>
+				</ol>
+				</li>
+				<li><span data-tag="to-do">Outer</span></li>
+			</ol>
+			<br />
+			<p style="margin-top:0pt;margin-bottom:0pt">Indented Unordered Todos</p>
+			<ul>
+				<li><p data-tag="to-do" style="margin-top:0pt;margin-bottom:0pt">Outer</p>
+				<ul>
+					<li style="list-style-type:circle"><p data-tag="to-do" style="margin-top:0pt;margin-bottom:0pt">Inner l1</p>
+					<ul>
+						<li><span data-tag="to-do">Inner l2</span></li>
+					</ul>
+					</li>
+				</ul>
+				</li>
+				<li><span data-tag="to-do">Outer</span></li>
+			</ul>
+			<br />
+			<p style="margin-top:0pt;margin-bottom:0pt">Indented Todos</p>
+			<p data-tag="to-do" style="margin-top:0pt;margin-bottom:0pt">Outer</p>
+			<p data-tag="to-do" style="margin-top:0pt;margin-bottom:0pt">Inner l1</p>
+			<p data-tag="to-do" style="margin-top:0pt;margin-bottom:0pt">Inner l2</p>
+			<p data-tag="to-do" style="margin-top:0pt;margin-bottom:0pt">Outer</p>
+		</div>
+	</body>
+</html>

--- a/tests/onenote/onenote-indented.test.ts
+++ b/tests/onenote/onenote-indented.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for the five nested-list and to-do cases in
+ * onenote-indented-example.html, covering the bug where inner list items
+ * and to-do items inside lists were silently dropped or escaped.
+ *
+ * Fixture structure:
+ *   1. Indented Numbered List  – ol > li > p + ol > li > p + ol > li
+ *   2. Indented Unordered List – ul > li > p + ul > li > p + ul > li
+ *   3. Indented Numbered Todos – same structure with data-tag="to-do" on p/span
+ *   4. Indented Unordered Todos – same structure with data-tag="to-do" on p/span
+ *   5. Indented Todos – flat <p data-tag="to-do"> elements (no nesting in API output)
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { convertFixture } from './helpers';
+
+describe('onenote-indented-example.html – nested lists and todos', () => {
+	let md: string;
+
+	beforeEach(() => {
+		md = convertFixture('onenote-indented-example.html');
+	});
+
+	// -----------------------------------------------------------------------
+	// Case 1 – Indented Numbered List
+	// -----------------------------------------------------------------------
+
+	it('indented numbered list: outer items use "1." marker', () => {
+		expect(md).toMatch(/1\.\s+Outer/);
+	});
+
+	it('indented numbered list: inner level-1 items are indented', () => {
+		const outerIdx = md.indexOf('1.  Outer');
+		const innerIdx = md.indexOf('Inner l1');
+		expect(outerIdx).toBeGreaterThanOrEqual(0);
+		expect(innerIdx).toBeGreaterThan(outerIdx);
+		const innerLine = md.split('\n').find(line => line.includes('Inner l1'));
+		expect(innerLine).toBeDefined();
+		expect(innerLine!.match(/^\s+/)).not.toBeNull();
+	});
+
+	it('indented numbered list: inner level-2 items are more deeply indented', () => {
+		const l1Line = md.split('\n').find(line => line.includes('Inner l1'));
+		const l2Line = md.split('\n').find(line => line.includes('Inner l2'));
+		expect(l1Line).toBeDefined();
+		expect(l2Line).toBeDefined();
+		const l1Indent = (l1Line!.match(/^\s+/) ?? [''])[0].length;
+		const l2Indent = (l2Line!.match(/^\s+/) ?? [''])[0].length;
+		expect(l2Indent).toBeGreaterThan(l1Indent);
+	});
+
+	// -----------------------------------------------------------------------
+	// Case 2 – Indented Unordered List
+	// -----------------------------------------------------------------------
+
+	it('indented unordered list: outer items use "-" marker', () => {
+		expect(md).toMatch(/-\s+Outer/);
+	});
+
+	it('indented unordered list: inner items are indented with "-"', () => {
+		const innerLine = md.split('\n').find(line => line.includes('Inner 1'));
+		expect(innerLine).toBeDefined();
+		expect(innerLine!.match(/^\s+/)).not.toBeNull();
+	});
+
+	it('indented unordered list: deepest items are more deeply indented', () => {
+		const l1Line = md.split('\n').find(line => line.includes('Inner 1'));
+		const l2Line = md.split('\n').find(line => line.includes('Inner 2'));
+		expect(l1Line).toBeDefined();
+		expect(l2Line).toBeDefined();
+		const l1Indent = (l1Line!.match(/^\s+/) ?? [''])[0].length;
+		const l2Indent = (l2Line!.match(/^\s+/) ?? [''])[0].length;
+		expect(l2Indent).toBeGreaterThan(l1Indent);
+	});
+
+	// -----------------------------------------------------------------------
+	// Case 3 – Indented Numbered Todos
+	// -----------------------------------------------------------------------
+
+	it('indented numbered todos: outer items carry "[ ]" checkbox', () => {
+		const numberedTodosStart = md.indexOf('Indented Numbered Todos');
+		expect(numberedTodosStart).toBeGreaterThanOrEqual(0);
+		const afterHeader = md.slice(numberedTodosStart);
+		expect(afterHeader).toMatch(/\[ \]\s*Outer/);
+	});
+
+	it('indented numbered todos: nested items carry "[ ]" and are indented', () => {
+		const afterHeader = md.slice(md.indexOf('Indented Numbered Todos'));
+		const innerL1Line = afterHeader.split('\n').find(
+			line => line.includes('[ ]') && line.includes('Inner l1')
+		);
+		expect(innerL1Line).toBeDefined();
+		expect(innerL1Line!.match(/^\s+/)).not.toBeNull();
+	});
+
+	it('indented numbered todos: level-2 items have "[ ]" and deeper indentation', () => {
+		const afterHeader = md.slice(md.indexOf('Indented Numbered Todos'));
+		const innerL1Line = afterHeader.split('\n').find(
+			line => line.includes('[ ]') && line.includes('Inner l1')
+		);
+		const innerL2Line = afterHeader.split('\n').find(
+			line => line.includes('[ ]') && line.includes('Inner l2')
+		);
+		expect(innerL1Line).toBeDefined();
+		expect(innerL2Line).toBeDefined();
+		const l1Indent = (innerL1Line!.match(/^\s+/) ?? [''])[0].length;
+		const l2Indent = (innerL2Line!.match(/^\s+/) ?? [''])[0].length;
+		expect(l2Indent).toBeGreaterThan(l1Indent);
+	});
+
+	// -----------------------------------------------------------------------
+	// Case 4 – Indented Unordered Todos
+	// -----------------------------------------------------------------------
+
+	it('indented unordered todos: outer items carry "[ ]" checkbox', () => {
+		const unorderedTodosStart = md.indexOf('Indented Unordered Todos');
+		expect(unorderedTodosStart).toBeGreaterThanOrEqual(0);
+		const afterHeader = md.slice(unorderedTodosStart);
+		expect(afterHeader).toMatch(/\[ \]\s*Outer/);
+	});
+
+	it('indented unordered todos: nested items carry "[ ]" and are indented', () => {
+		const afterHeader = md.slice(md.indexOf('Indented Unordered Todos'));
+		const innerL1Line = afterHeader.split('\n').find(
+			line => line.includes('[ ]') && line.includes('Inner l1')
+		);
+		expect(innerL1Line).toBeDefined();
+		expect(innerL1Line!.match(/^\s+/)).not.toBeNull();
+	});
+
+	it('indented unordered todos: level-2 items have "[ ]" and deeper indentation', () => {
+		const afterHeader = md.slice(md.indexOf('Indented Unordered Todos'));
+		const innerL1Line = afterHeader.split('\n').find(
+			line => line.includes('[ ]') && line.includes('Inner l1')
+		);
+		const innerL2Line = afterHeader.split('\n').find(
+			line => line.includes('[ ]') && line.includes('Inner l2')
+		);
+		expect(innerL1Line).toBeDefined();
+		expect(innerL2Line).toBeDefined();
+		const l1Indent = (innerL1Line!.match(/^\s+/) ?? [''])[0].length;
+		const l2Indent = (innerL2Line!.match(/^\s+/) ?? [''])[0].length;
+		expect(l2Indent).toBeGreaterThan(l1Indent);
+	});
+
+	// -----------------------------------------------------------------------
+	// Case 5 – Flat "Indented" Todos
+	// The OneNote API does not encode visual indentation for plain
+	// <p data-tag="to-do"> elements — they are always flat in the HTML
+	// regardless of how they appear in the UI.  All four items must become
+	// top-level "- [ ]" task-list entries with no indentation.
+	// -----------------------------------------------------------------------
+
+	it('flat todos: each <p data-tag="to-do"> becomes a "- [ ]" task-list item', () => {
+		const flatTodosStart = md.indexOf('Indented Todos');
+		expect(flatTodosStart).toBeGreaterThanOrEqual(0);
+		const afterHeader = md.slice(flatTodosStart);
+		const taskLines = afterHeader.split('\n').filter(line => line.includes('[ ]'));
+		// Four flat todo items in the fixture
+		expect(taskLines.length).toBeGreaterThanOrEqual(4);
+		// None should be escaped (no backslash before the brackets)
+		for (const line of taskLines) {
+			expect(line).not.toMatch(/\\\[/);
+		}
+	});
+
+	it('flat todos: items appear at the top level (no leading indentation)', () => {
+		const afterHeader = md.slice(md.indexOf('Indented Todos'));
+		const taskLines = afterHeader
+			.split('\n')
+			.filter(line => line.includes('[ ]') && line.trim() !== '');
+		for (const line of taskLines) {
+			expect(line.startsWith(' ')).toBe(false);
+		}
+	});
+});

--- a/tests/onenote/onenote.html
+++ b/tests/onenote/onenote.html
@@ -1,0 +1,110 @@
+<!-- Generated from the author's personal OneNote on 2026-04-18 -->
+<html lang="en-GB">
+	<head>
+		<title>Test Page</title>
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+		<meta name="created" content="2026-04-18T22:31:00.0000000" />
+	</head>
+	<body data-absolute-enabled="true" style="font-family:Calibri;font-size:11pt">
+		<div style="position:absolute;left:48px;top:115px;width:720px">
+			<p style="margin-top:0pt;margin-bottom:0pt">This is a plain paragraph with no formatting.￼</p>
+			<p style="margin-top:0pt;margin-bottom:0pt"><span style="font-weight:bold">bold words</span></p>
+			<p style="margin-top:0pt;margin-bottom:0pt"><span style="font-style:italic">italic words</span>                                                        ￼<span style="text-decoration:underline">underlined words</span>                                                     ￼<span style="text-decoration:line-through">strikethrough words</span> </p>
+			<br />
+			<p style="margin-top:0pt;margin-bottom:0pt"><span style="background-color:yellow">These words are highlighted</span>￼</p>
+			<p data-tag="to-do" style="margin-top:0pt;margin-bottom:0pt">Unchecked task  </p>
+			<p data-tag="to-do:completed" style="margin-top:0pt;margin-bottom:0pt">Checked task</p>
+			<p style="margin-top:0pt;margin-bottom:0pt">                                                                   ￼This is a top level sentence.</p>
+			<p style="margin-top:0pt;margin-bottom:0pt">This sentence is indented one level.</p>
+			<p style="margin-top:0pt;margin-bottom:0pt">This sentence is indented twice.</p>
+			<br />
+			<p style="margin-top:0pt;margin-bottom:0pt">Top-level paragraph</p>
+			<p style="margin-top:0pt;margin-bottom:0pt">One indented child</p>
+			<p style="margin-top:0pt;margin-bottom:0pt">Second indented child</p>
+			<p style="margin-top:0pt;margin-bottom:0pt">Intended child of second indented child</p>
+			<br />
+			<ul>
+				<li>Unordered list</li>
+				<li>Unordered list</li>
+			</ul>
+			<br />
+			<ol>
+				<li>Ordered list</li>
+				<li>Ordered list</li>
+			</ol>
+			<br />
+			<p style="font-family:Consolas;margin-top:0pt;margin-bottom:0pt">const x = 1;</p><br /><p style="font-family:Consolas;margin-top:0pt;margin-bottom:0pt">const y = 2;</p>
+			<br />
+			<p style="margin-top:0pt;margin-bottom:0pt">Inline code: Call the function <span style="font-family:Consolas">myFunction()</span> to start.</p>
+			<br />
+			<cite style="font-size:9pt;color:#595959;margin-top:0pt;margin-bottom:0pt">This is a citation.</cite>
+			<br />
+			<p style="color:#595959;font-style:italic;margin-top:0pt;margin-bottom:0pt">This is a quoted block of text.</p>
+			<br />
+			<p style="font-family:Calibri Light;font-size:20pt;margin-top:0pt;margin-bottom:0pt">This is a title.</p>
+			<br />
+			<h1 style="font-size:16pt;color:#1e4e79;margin-top:0pt;margin-bottom:0pt">Heading 1</h1>
+			<h2 style="font-size:14pt;color:#2e75b5;margin-top:0pt;margin-bottom:0pt">Heading 2</h2>
+			<h3 style="font-size:12pt;color:#1f3763;margin-top:0pt;margin-bottom:0pt">Heading 3</h3>
+			<h4 style="font-size:12pt;color:#2f5496;font-style:italic;margin-top:0pt;margin-bottom:0pt">Heading 4</h4>
+			<h5 style="color:#2e75b5;margin-top:0pt;margin-bottom:0pt">Heading 5</h5>
+			<h6 style="color:#2e75b5;font-style:italic;margin-top:0pt;margin-bottom:0pt">Heading 6</h6>
+			<br />
+			<p style="margin-top:0pt;margin-bottom:0pt">Internal Link: Visit <a href="onenote:#Test&amp;section-id={mytestid}&amp;page-id={myTestPageId}&amp;end">Test page</a> for more information.                                               ￼</p>
+			<p style="margin-top:0pt;margin-bottom:0pt">External link: Visit <a href="https://obsidian.md">https://obsidian.md</a> for more information.                                           ￼ </p>
+			<img width="480" height="319.5" src="https://graph.microsoft.com/v1.0/users('myuserId')/onenote/resources/anotherid/$value" data-src-type="image/jpeg" data-fullres-src="https://graph.microsoft.com/v1.0/users('myuserId')/onenote/resources/anotherid/$value" data-fullres-src-type="image/jpeg" />
+			<br />
+			<p style="margin-top:0pt;margin-bottom:0pt">     </p>
+			<table style="border:1px solid;border-collapse:collapse">
+				<tr>
+					<td style="border:1px solid">Header A</td>
+					<td style="border:1px solid">Header B</td>
+				</tr>
+				<tr>
+					<td style="border:1px solid"><span style="font-weight:bold">BOLD TEXT</span></td>
+					<td style="border:1px solid">Normal</td>
+				</tr>
+			</table>
+			<p style="margin-top:0pt;margin-bottom:0pt">                                        </p>
+			<p style="margin-top:0pt;margin-bottom:0pt">Equation:                                  ￼   ￼  			<math display="block" xmlns="http://www.w3.org/1998/Math/MathML">
+				<mi>x</mi>
+				<mo>&#160;</mo>
+				<mo>=</mo>
+				<mfrac>
+					<mrow>
+						<mfenced>
+							<mrow>
+								<mo>−</mo>
+								<mi>b</mi>
+								<mo>&#160;</mo>
+								<mo>&#177;</mo>
+								<mo>&#160;</mo>
+								<msqrt>
+									<mrow>
+										<msup>
+											<mi>b</mi>
+											<mn>2</mn>
+										</msup>
+										<mo>−</mo>
+										<mn>4</mn>
+										<mi>a</mi>
+										<mi>c</mi>
+									</mrow>
+								</msqrt>
+							</mrow>
+						</mfenced>
+					</mrow>
+					<mrow />
+				</mfrac>
+				<mn>2</mn>
+				<mi>a</mi>
+			</math>
+                                                                        ￼                                                                                                   ￼			</p>
+			<p data-tag="important" style="margin-top:0pt;margin-bottom:0pt">Important tag </p>
+			<p data-tag="question" style="margin-top:0pt;margin-bottom:0pt">Question tag</p>
+			<br />
+			<p style="margin-top:0pt;margin-bottom:0pt">Normal paragraph.</p>
+			<p style="margin-top:0pt;margin-bottom:0pt"><span style="font-weight:bold">Paragraph with combined indentation and bold.</span></p>
+		</div>
+	</body>
+</html>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		environment: 'jsdom',
+		include: ['tests/**/*.test.ts'],
+	},
+});


### PR DESCRIPTION
Fixes two related bugs causing nested list to-do items to be corrupted on import.

## My issue

I used the importer to import my notebook containing multiple nested ordered lists of tasks. Rather than being flattened out (as I know OneNote can have issues with this data not being present in the html output), they were not present in the output at all.

From my test file:
<img width="200" height="109" alt="Screenshot 2026-04-21 at 22 00 58" src="https://github.com/user-attachments/assets/f25641d6-5d50-47e4-bf9e-6221c2957d90" />

The imported obsidian file looked like:
<img width="239" height="99" alt="Screenshot 2026-04-21 at 22 02 20" src="https://github.com/user-attachments/assets/093ba325-ec68-49cb-9763-218b75d49455" />

This PR fixes this issue in the first commit, adds tests for the commit in the second commit and adds regression testing against a comprehensive test file in the third commit. 

Please consider merging the first commit and fixing my problem. I am more than happy to refactor as necessary. 

I couldn't see any testing and wrote the tests to confirm my own problem was solved and didn't impact the existing functionality. They are not essential for this PR though and can be ignored if you do not want to add testing to this repo.

## Problems

`convertTags` handled `data-tag="to-do"` by injecting literal `- [ ] ` into
the element's `innerHTML`. Turndown then escaped those characters, producing
`\- \[ \] Task text` instead of a task-list item. This affected flat
`<p data-tag="to-do">` paragraphs and to-do items inside nested `<ol>`/`<ul>`
lists, where the result was `1.  \- \[ \] Outer` instead of `- [ ]`.

A secondary bug: the injection broke `removeExtraListItemParagraphs`
(introduced in #363), which relies on `li > p:first-child` — after injection
the paragraph was no longer the first child, causing extra blank lines between
nested list levels.

## Fix

**`convertTags`:** for to-do elements inside a `<li>`, insert
`<input type="checkbox">` as the first child of the `<li>` so the GFM
turndown rule produces `- [ ]` / `- [x]` natively. For top-level
`<p data-tag="to-do">` elements (which the OneNote Graph API always emits
flat regardless of visual indentation), replace the paragraph with
`<ul><li><input type="checkbox">…</li></ul>`.

**`removeExtraListItemParagraphs`:** selector extended from `li > p:first-child`
to also match `li > input:first-child + p`.

## Testing

Commits 2 and 3 add vitest + jsdom. DOM-transformation functions are extracted
into `onenote-converter.ts` for testability; `onenote.ts` is refactored to
delegate its five pipeline methods to `onenote-converter.ts` so that the
tested code and production code stay in sync.

- **Commit 2:** 14 tests against `onenote-indented-example.html` (fixture from
  the author's personal OneNote, 2026-04-18), covering all five affected cases:
  indented numbered lists, indented unordered lists, numbered to-do lists,
  unordered to-do lists, and flat to-do paragraphs. All pass.
- **Commit 3:** 25 regression tests against `onenote.html`, covering all
  element types handled before this change. All pass. Not covered: `convertMathML`, `escapeTextNodes`, and the MathML error-fallback path. Statement coverage: 87%.


Source OneNote page for **onenote-indented-example.html** as it renders in OneNote.
<img width="342" height="694" alt="Screenshot 2026-04-21 at 22 06 45" src="https://github.com/user-attachments/assets/a3e356b9-30be-44a2-8ca7-db7a8c651f69" />

Source OneNote page for **onenote.html** as it renders in OneNote. NB, I don't want to leak my OneNote userId so I'd prefer to avoid sharing a PDF.
<img width="545" height="1209" alt="Screenshot 2026-04-21 at 22 09 22" src="https://github.com/user-attachments/assets/5bc0982a-79a6-44f5-85f7-de53c260604c" />

