### PR TITLE
Notion API: Handle nested paragraphs

### DIFF
--- a/src/formats/notion-api/block-converter.ts
+++ b/src/formats/notion-api/block-converter.ts
@@ -299,7 +299,7 @@ export async function convertBlockToMarkdown(
 	
 	switch (type) {
 		case 'paragraph':
-			markdown = convertParagraph(block, context);
+			markdown = await convertParagraph(block, context);
 			break;
 		
 		case 'heading_1':
@@ -491,9 +491,25 @@ export async function convertBlockToMarkdown(
 /**
  * Convert paragraph block to Markdown
  */
-export function convertParagraph(block: BlockObjectResponse, context?: BlockConversionContext): string {
+export async function convertParagraph(block: BlockObjectResponse, context?: BlockConversionContext): Promise<string> {
 	if (block.type !== 'paragraph') return '';
-	return convertRichText(block.paragraph.rich_text, context);
+
+	const rawText = convertRichText(block.paragraph.rich_text, context);
+	const indentLevel = context?.indentLevel || 0;
+	const line = rawText ? '    '.repeat(indentLevel) + rawText : '';
+
+	if (!context) return line;
+
+	const childrenMarkdown = await processChildrenToMarkdown(
+		block,
+		context,
+		indentLevel + 1,
+		'paragraph'
+	);
+
+	if (!childrenMarkdown) return line;
+	if (!line) return childrenMarkdown;
+	return line + '\n' + childrenMarkdown;
 }
 
 /**


### PR DESCRIPTION
Nested paragraphs were silently discarded on import. A paragraph indented under another paragraph in Notion (Tab in the editor — the child arrives in the API as a block in the parent's `.children` with `has_children: true`) would simply vanish from the output.

## Fix

`convertParagraph` now recursively converts its children and emits them below the parent, prefixing each nested level with 4 spaces per depth so the hierarchy is preserved in the Markdown.

## Example

<img width="451" height="185" alt="Screenshot 2026-04-23 at 12 00 36" src="https://github.com/user-attachments/assets/74807047-8a80-4161-9cb2-40e3cec7b588" />


Before: only "A paragraph with children" made it into the note — both nested paragraphs were dropped.

After: All paragraphs included.
