### PR TITLE
Onenote import options to skip attachments, images, and handwritten notes

### DIFF
--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -64,6 +64,7 @@ export class OneNoteImporter extends FormatImporter {
 	// Settings
 	importPreviouslyImported: boolean = false;
 	importIncompatibleAttachments: boolean = false;
+	importHandwrittenNotes: boolean = true;
 	// UI
 	microsoftAccountSetting: Setting;
 	switchUserSetting: Setting;
@@ -90,6 +91,14 @@ export class OneNoteImporter extends FormatImporter {
 			.addToggle((toggle) => toggle
 				.setValue(false)
 				.onChange((value) => (this.importIncompatibleAttachments = value))
+			);
+
+		new Setting(this.modal.contentEl)
+			.setName('Import handwritten notes')
+			.setDesc('Handwritten notes are saved as SVG vector images.')
+			.addToggle((toggle) => toggle
+				.setValue(true)
+				.onChange((value) => (this.importHandwrittenNotes = value))
 			);
 
 		new Setting(this.modal.contentEl)
@@ -551,20 +560,19 @@ export class OneNoteImporter extends FormatImporter {
 
 			// Process InkML content if present and convert to SVG
 			let inkEmbedMarkdown = '';
-			try {
-				const svgContent = inkmlToSvg(splitContent.inkml);
-				if (svgContent) {
-					// Save the SVG as an attachment
-					const svgFilename = `${page.title} - Ink.svg`;
-					await this.vault.create(`${pageFolder.path}/${svgFilename}`, svgContent);
-
-					// Create markdown embed for the SVG
-					inkEmbedMarkdown = `\n\n![[${svgFilename}]]\n`;
-					progress.reportAttachmentSuccess(svgFilename);
+			if (this.importHandwrittenNotes) {
+				try {
+					const svgContent = inkmlToSvg(splitContent.inkml);
+					if (svgContent) {
+						const svgFilename = `${page.title} - Ink.svg`;
+						await this.vault.create(`${pageFolder.path}/${svgFilename}`, svgContent);
+						inkEmbedMarkdown = `\n\n![[${svgFilename}]]\n`;
+						progress.reportAttachmentSuccess(svgFilename);
+					}
 				}
-			}
-			catch (e) {
-				console.error('Failed to convert InkML to SVG in page:', page.title, e);
+				catch (e) {
+					console.error('Failed to convert InkML to SVG in page:', page.title, e);
+				}
 			}
 
 			let taggedPage = this.convertTags(parseHTML(splitContent.html));

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -66,6 +66,7 @@ export class OneNoteImporter extends FormatImporter {
 	importPreviouslyImported: boolean = false;
 	attachmentWhitelist: string = '';
 	importHandwrittenNotes: boolean = true;
+	importEmbeddedImages: boolean = true;
 	// UI
 	microsoftAccountSetting: Setting;
 	switchUserSetting: Setting;
@@ -122,6 +123,14 @@ export class OneNoteImporter extends FormatImporter {
 			.addToggle((toggle) => toggle
 				.setValue(true)
 				.onChange((value) => (this.importHandwrittenNotes = value))
+			);
+
+		new Setting(this.modal.contentEl)
+			.setName('Import embedded images')
+			.setDesc('Images embedded in notes are downloaded and saved as attachments.')
+			.addToggle((toggle) => toggle
+				.setValue(true)
+				.onChange((value) => (this.importEmbeddedImages = value))
 			);
 
 		new Setting(this.modal.contentEl)
@@ -896,22 +905,24 @@ export class OneNoteImporter extends FormatImporter {
 			}
 		}
 
-		for (let i = 0; i < images.length; i++) {
-			const image = images[i];
-			let split: string[] = image.getAttribute('data-fullres-src-type')!.split('/');
-			const extension: string = split[1];
-			const currentDate = moment().format('YYYYMMDDHHmmss');
-			const fileName: string = `Exported image ${currentDate}-${i}.${extension}`;
-			const contentLocation = image.getAttribute('data-fullres-src')!;
-			const outputPath = await this.fetchAttachment(progress, fileName, contentLocation);
-			if (outputPath) {
-				image.src = encodeURI(outputPath);
-				if (!image.alt || BASE64_REGEX.test(image.alt)) {
-					image.alt = 'Exported image';
-				}
-				else {
-					// Sanitize OCR text to ensure valid markdown
-					image.alt = this.sanitizeOCRText(image.alt) || 'Exported image';
+		if (this.importEmbeddedImages) {
+			for (let i = 0; i < images.length; i++) {
+				const image = images[i];
+				let split: string[] = image.getAttribute('data-fullres-src-type')!.split('/');
+				const extension: string = split[1];
+				const currentDate = moment().format('YYYYMMDDHHmmss');
+				const fileName: string = `Exported image ${currentDate}-${i}.${extension}`;
+				const contentLocation = image.getAttribute('data-fullres-src')!;
+				const outputPath = await this.fetchAttachment(progress, fileName, contentLocation);
+				if (outputPath) {
+					image.src = encodeURI(outputPath);
+					if (!image.alt || BASE64_REGEX.test(image.alt)) {
+						image.alt = 'Exported image';
+					}
+					else {
+						// Sanitize OCR text to ensure valid markdown
+						image.alt = this.sanitizeOCRText(image.alt) || 'Exported image';
+					}
 				}
 			}
 		}

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -6,6 +6,7 @@ import { ATTACHMENT_EXTS, AUTH_REDIRECT_URI, ImportContext } from '../main';
 import { AccessTokenResponse } from './onenote/models';
 import { getSiblingsInSameCodeBlock, isFenceCodeBlock, isInlineCodeSpan, isBRElement, isParagraphWrappingOnlyCode } from './onenote/code';
 import { inkmlToSvg } from './onenote/inkml';
+import { toWhitelist, findUnsupportedWhitelistPatterns, matchesAttachmentWhitelist } from './onenote/attachment-whitelist';
 import { MathMLToLaTeX } from 'mathml-to-latex';
 
 const LOCAL_STORAGE_KEY = 'onenote-importer-refresh-token';
@@ -63,7 +64,7 @@ function isHTMLElement(node: Node): node is HTMLElement {
 export class OneNoteImporter extends FormatImporter {
 	// Settings
 	importPreviouslyImported: boolean = false;
-	importIncompatibleAttachments: boolean = false;
+	attachmentWhitelist: string = '';
 	importHandwrittenNotes: boolean = true;
 	// UI
 	microsoftAccountSetting: Setting;
@@ -83,15 +84,37 @@ export class OneNoteImporter extends FormatImporter {
 	lastSuccessfulFetchTime: number = performance.now();
 
 	async init() {
+		this.attachmentWhitelist = toWhitelist(ATTACHMENT_EXTS);
+
 		this.addOutputLocationSetting('OneNote');
 
-		new Setting(this.modal.contentEl)
-			.setName('Import incompatible attachments')
-			.setDesc('Imports incompatible attachments which cannot be embedded in Obsidian, such as .exe files.')
-			.addToggle((toggle) => toggle
-				.setValue(false)
-				.onChange((value) => (this.importIncompatibleAttachments = value))
-			);
+		let whitelistWarning: HTMLElement;
+
+		const whitelistSetting = new Setting(this.modal.contentEl)
+			.setName('Import attachments')
+			.setDesc('Glob patterns for attachment types to import, comma-separated (e.g. *.pdf, *.png). Use * to import everything. The default list contains all Obsidian-compatible types.')
+			.addText((text) => {
+				text.inputEl.style.width = '100%';
+				text.setValue(this.attachmentWhitelist)
+					.onChange((value) => {
+						this.attachmentWhitelist = value;
+						const unsupported = findUnsupportedWhitelistPatterns(value);
+						if (unsupported.length > 0) {
+							whitelistWarning.setText(`Unsupported patterns (will be ignored): ${unsupported.join(', ')}`);
+							whitelistWarning.show();
+						}
+						else {
+							whitelistWarning.hide();
+						}
+					});
+			});
+		whitelistSetting.settingEl.style.flexWrap = 'wrap';
+		whitelistSetting.controlEl.style.width = '100%';
+
+		whitelistWarning = this.modal.contentEl.createEl('p', {
+			attr: { style: 'font-size: smaller; font-style: italic; color: var(--color-red);' },
+		});
+		whitelistWarning.hide();
 
 		new Setting(this.modal.contentEl)
 			.setName('Import handwritten notes')
@@ -856,15 +879,11 @@ export class OneNoteImporter extends FormatImporter {
 				object.parentNode?.insertBefore(object.firstChild, object.nextSibling);
 			}
 
-			let split: string[] = object.getAttribute('data-attachment')!.split('.');
-			const extension: string = split[split.length - 1];
-
-			// If the page contains an incompatible file and user doesn't want to import them, skip
-			if (!ATTACHMENT_EXTS.contains(extension) && !this.importIncompatibleAttachments) {
+			const originalName = object.getAttribute('data-attachment')!;
+			if (!matchesAttachmentWhitelist(originalName, this.attachmentWhitelist)) {
 				continue;
 			}
 			else {
-				const originalName = object.getAttribute('data-attachment')!;
 				const contentLocation = object.getAttribute('data')!;
 				const filename = await this.fetchAttachment(progress, originalName, contentLocation);
 

--- a/src/formats/onenote/attachment-whitelist.ts
+++ b/src/formats/onenote/attachment-whitelist.ts
@@ -1,0 +1,32 @@
+export function toWhitelist(extensions: string[]): string {
+	return extensions.map(e => `*.${e}`).join(', ');
+}
+
+function parseWhitelistPatterns(whitelist: string): string[] {
+	return whitelist.split(',').map(p => p.trim()).filter(p => p.length > 0);
+}
+
+function isValidPattern(pattern: string): boolean {
+	if (pattern === '*') return true;
+	if (/^\*\.[^*?]+$/.test(pattern)) return true;
+	if (/^[^*?]+$/.test(pattern)) return true;
+	return false;
+}
+
+function findUnsupportedPatterns(patterns: string[]): string[] {
+	return patterns.filter(p => !isValidPattern(p));
+}
+
+function matchesPattern(filename: string, pattern: string): boolean {
+	if (pattern === '*') return true;
+	if (pattern.startsWith('*.')) return filename.toLowerCase().endsWith(pattern.slice(1).toLowerCase());
+	return filename.toLowerCase() === pattern.toLowerCase();
+}
+
+export function findUnsupportedWhitelistPatterns(whitelist: string): string[] {
+	return findUnsupportedPatterns(parseWhitelistPatterns(whitelist));
+}
+
+export function matchesAttachmentWhitelist(filename: string, whitelist: string): boolean {
+	return parseWhitelistPatterns(whitelist).some(pattern => matchesPattern(filename, pattern));
+}

--- a/tests/onenote/attachment-whitelist.test.ts
+++ b/tests/onenote/attachment-whitelist.test.ts
@@ -1,0 +1,118 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+	toWhitelist,
+	findUnsupportedWhitelistPatterns,
+	matchesAttachmentWhitelist,
+} from '../../src/formats/onenote/attachment-whitelist';
+
+// toWhitelist
+
+test('toWhitelist converts extensions to *.ext glob patterns joined by commas', () => {
+	assert.equal(toWhitelist(['png', 'jpg', 'pdf']), '*.png, *.jpg, *.pdf');
+});
+
+test('toWhitelist returns empty string for empty array', () => {
+	assert.equal(toWhitelist([]), '');
+});
+
+test('toWhitelist handles a single extension', () => {
+	assert.equal(toWhitelist(['pdf']), '*.pdf');
+});
+
+// findUnsupportedWhitelistPatterns
+
+test('findUnsupportedWhitelistPatterns returns empty array for blank whitelist', () => {
+	assert.deepEqual(findUnsupportedWhitelistPatterns(''), []);
+});
+
+test('findUnsupportedWhitelistPatterns returns empty array when all patterns are valid', () => {
+	assert.deepEqual(findUnsupportedWhitelistPatterns('*, *.png, report.pdf, file'), []);
+});
+
+test('findUnsupportedWhitelistPatterns accepts * wildcard', () => {
+	assert.deepEqual(findUnsupportedWhitelistPatterns('*'), []);
+});
+
+test('findUnsupportedWhitelistPatterns accepts *.ext patterns', () => {
+	assert.deepEqual(findUnsupportedWhitelistPatterns('*.png, *.tar.gz'), []);
+});
+
+test('findUnsupportedWhitelistPatterns accepts plain filenames', () => {
+	assert.deepEqual(findUnsupportedWhitelistPatterns('report.pdf, file'), []);
+});
+
+test('findUnsupportedWhitelistPatterns flags ** glob patterns', () => {
+	assert.deepEqual(findUnsupportedWhitelistPatterns('**/*.png'), ['**/*.png']);
+});
+
+test('findUnsupportedWhitelistPatterns flags ? wildcard patterns', () => {
+	assert.deepEqual(findUnsupportedWhitelistPatterns('file?.txt'), ['file?.txt']);
+});
+
+test('findUnsupportedWhitelistPatterns flags *. with no extension', () => {
+	assert.deepEqual(findUnsupportedWhitelistPatterns('*.'), ['*.']);
+});
+
+test('findUnsupportedWhitelistPatterns returns only unsupported patterns from a mixed whitelist', () => {
+	assert.deepEqual(
+		findUnsupportedWhitelistPatterns('*.png, **/*.jpg, file?.txt, *'),
+		['**/*.jpg', 'file?.txt']
+	);
+});
+
+test('findUnsupportedWhitelistPatterns ignores empty entries from extra commas', () => {
+	assert.deepEqual(findUnsupportedWhitelistPatterns('*.png,,  ,**/*.jpg'), ['**/*.jpg']);
+});
+
+// matchesAttachmentWhitelist
+
+test('matchesAttachmentWhitelist returns false for empty whitelist', () => {
+	assert.equal(matchesAttachmentWhitelist('file.pdf', ''), false);
+});
+
+test('matchesAttachmentWhitelist returns false for whitespace-only whitelist', () => {
+	assert.equal(matchesAttachmentWhitelist('file.pdf', '   '), false);
+});
+
+test('matchesAttachmentWhitelist * matches any filename', () => {
+	assert.equal(matchesAttachmentWhitelist('file.exe', '*'), true);
+	assert.equal(matchesAttachmentWhitelist('anything.123', '*'), true);
+});
+
+test('matchesAttachmentWhitelist *.ext matches filename with that extension', () => {
+	assert.equal(matchesAttachmentWhitelist('photo.jpg', '*.jpg'), true);
+	assert.equal(matchesAttachmentWhitelist('document.pdf', '*.pdf'), true);
+});
+
+test('matchesAttachmentWhitelist *.ext does not match a different extension', () => {
+	assert.equal(matchesAttachmentWhitelist('photo.png', '*.jpg'), false);
+});
+
+test('matchesAttachmentWhitelist *.ext matching is case-insensitive', () => {
+	assert.equal(matchesAttachmentWhitelist('Photo.JPG', '*.jpg'), true);
+	assert.equal(matchesAttachmentWhitelist('photo.jpg', '*.JPG'), true);
+});
+
+test('matchesAttachmentWhitelist matches exact filename', () => {
+	assert.equal(matchesAttachmentWhitelist('report.pdf', 'report.pdf'), true);
+	assert.equal(matchesAttachmentWhitelist('other.pdf', 'report.pdf'), false);
+});
+
+test('matchesAttachmentWhitelist exact filename match is case-insensitive', () => {
+	assert.equal(matchesAttachmentWhitelist('Report.PDF', 'report.pdf'), true);
+});
+
+test('matchesAttachmentWhitelist returns true when any pattern in the list matches', () => {
+	assert.equal(matchesAttachmentWhitelist('file.pdf', '*.png, *.pdf, *.jpg'), true);
+	assert.equal(matchesAttachmentWhitelist('file.exe', '*.png, *.pdf, *.jpg'), false);
+});
+
+test('matchesAttachmentWhitelist handles extra whitespace around patterns', () => {
+	assert.equal(matchesAttachmentWhitelist('file.pdf', '  *.pdf  ,  *.png  '), true);
+});
+
+test('matchesAttachmentWhitelist ignores empty entries from extra commas', () => {
+	assert.equal(matchesAttachmentWhitelist('file.pdf', '*.png,,*.pdf'), true);
+});


### PR DESCRIPTION
- **Import handwritten notes**: opt out of converting InkML ink strokes to SVG attachments
- **Import embedded images**: opt out of downloading and saving inline images as attachments
- **Import attachments**: a glob-pattern whitelist (e.g. `*.pdf, *.png`) replacing the "import incompatible attachments" toggle. Defaults to all Obsidian-compatible types. Shows an inline warning for unsupported patterns

All defaults preserve the current behavior