### PR TITLE
Add OneNote page date property option

### DIFF
--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -1,5 +1,5 @@
 import { OnenotePage, SectionGroup, User, PublicError, Notebook, OnenoteSection } from '@microsoft/microsoft-graph-types';
-import { DataWriteOptions, Notice, Setting, TFolder, htmlToMarkdown, ObsidianProtocolData, requestUrl, moment } from 'obsidian';
+import { DataWriteOptions, Notice, Setting, TFile, TFolder, htmlToMarkdown, ObsidianProtocolData, requestUrl, moment } from 'obsidian';
 import { genUid, extractErrorMessage, parseHTML, sanitizeFileName } from '../util';
 import { FormatImporter } from '../format-importer';
 import { ATTACHMENT_EXTS, AUTH_REDIRECT_URI, ImportContext } from '../main';
@@ -64,6 +64,7 @@ export class OneNoteImporter extends FormatImporter {
 	// Settings
 	importPreviouslyImported: boolean = false;
 	importIncompatibleAttachments: boolean = false;
+	addPageDatesAsProperties: boolean = false;
 	// UI
 	microsoftAccountSetting: Setting;
 	switchUserSetting: Setting;
@@ -98,6 +99,14 @@ export class OneNoteImporter extends FormatImporter {
 			.addToggle((toggle) => toggle
 				.setValue(true)
 				.onChange((value) => (this.importPreviouslyImported = !value))
+			);
+
+		new Setting(this.modal.contentEl)
+			.setName('Add page dates as properties')
+			.setDesc('Adds the OneNote page created and last modified timestamps to each imported note as Obsidian properties.')
+			.addToggle((toggle) => toggle
+				.setValue(false)
+				.onChange((value) => (this.addPageDatesAsProperties = value))
 			);
 
 		let authenticated = false;
@@ -594,12 +603,26 @@ export class OneNoteImporter extends FormatImporter {
 				ctime: created ?? lastModified ?? Date.now(),
 				mtime: lastModified ?? created ?? Date.now(),
 			};
+			if (this.addPageDatesAsProperties) {
+				await this.addPageDateProperties(fileRef, page);
+			}
 			await this.vault.append(fileRef, '', writeOptions);
 			progress.reportNoteSuccess(page.title!);
 		}
 		catch (e) {
 			progress.reportFailed(page.title!, e);
 		}
+	}
+
+	async addPageDateProperties(file: TFile, page: OnenotePage): Promise<void> {
+		await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
+			if (page.createdDateTime) {
+				frontmatter['created'] = moment(page.createdDateTime).toISOString();
+			}
+			if (page.lastModifiedDateTime) {
+				frontmatter['modified'] = moment(page.lastModifiedDateTime).toISOString();
+			}
+		});
 	}
 
 	/** Convert MathML elements to LaTeX format for Obsidian */


### PR DESCRIPTION
## Summary
- add an opt-in OneNote importer setting to write page dates as Obsidian properties
- when enabled, imported notes get `created` and `modified` properties from Microsoft Graph page timestamps
- keep existing filesystem `ctime`/`mtime` preservation behavior unchanged

Refs #318.

## Bounty / Payment Note
If this PR is accepted for the $150 attempt offer in #318, PayPal is available at https://www.paypal.com/paypalme/aogkft.

## Testing
- `git diff --check upstream/master...onenote-page-date-properties`
- changed-file conflict-marker scan across the branch diff
- `corepack pnpm build`
- `corepack pnpm test` (32 tests passing)