### PR TITLE
fix(csv): sanitize import path segments

### DIFF
--- a/src/format-importer.ts
+++ b/src/format-importer.ts
@@ -1,7 +1,7 @@
 import { App, normalizePath, Platform, Setting, TFile, TFolder, Vault } from 'obsidian';
 import { getAllFiles, NodePickedFile, NodePickedFolder, path, parseFilePath, PickedFile, WebPickedFile } from './filesystem';
 import { ImporterModal, ImportContext, AuthCallback } from './main';
-import { sanitizeFileName } from './util';
+import { sanitizeFileName, sanitizeFilePath as sanitizeFilePathValue } from './util';
 
 const MAX_PATH_DESCRIPTION_LENGTH = 300;
 
@@ -249,7 +249,7 @@ export abstract class FormatImporter {
 
 	/** Remove any characters that would be illegal on any platform. */
 	sanitizeFilePath(path: string): string {
-		return path.replace(/[:|?<>*\\]/g, '');
+		return sanitizeFilePathValue(path);
 	}
 
 	/**

--- a/src/sanitize.ts
+++ b/src/sanitize.ts
@@ -1,0 +1,32 @@
+let slashesRe = /[/\\]/g;
+let illegalRe = /[\?<>:\*\|"]/g;
+let controlRe = /[\x00-\x1f\x80-\x9f]/g;
+let reservedRe = /^\.+$/;
+let windowsReservedRe = /^(con|prn|aux|nul|com[0-9]|lpt[0-9])(\..*)?$/i;
+let windowsTrailingRe = /[\. ]+$/;
+let startsWithDotRe = /^\./;
+let badLinkRe = /[\[\]#|^]/g;
+
+export function sanitizeFileName(name: string) {
+	const sanitized = name
+		.replace(slashesRe, '-')
+		.replace(illegalRe, '')
+		.replace(controlRe, '')
+		.replace(reservedRe, '')
+		.replace(windowsTrailingRe, '')
+		.replace(windowsReservedRe, '')
+		.replace(startsWithDotRe, '')
+		.replace(badLinkRe, '');
+
+	const trimmed = sanitized.trim();
+	return trimmed || 'Untitled';
+}
+
+export function sanitizeFilePath(filePath: string) {
+	return filePath
+		.split(slashesRe)
+		.map(segment => segment.trim())
+		.filter(segment => segment.length > 0)
+		.map(sanitizeFileName)
+		.join('/');
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,31 +1,5 @@
 import { FrontMatterCache, stringifyYaml } from 'obsidian';
-
-let slashesRe = /[/\\]/g;
-let illegalRe = /[\?<>:\*\|"]/g;
-let controlRe = /[\x00-\x1f\x80-\x9f]/g;
-let reservedRe = /^\.+$/;
-let windowsReservedRe = /^(con|prn|aux|nul|com[0-9]|lpt[0-9])(\..*)?$/i;
-let windowsTrailingRe = /[\. ]+$/;
-let startsWithDotRe = /^\./; // Regular expression to match filenames starting with "."
-let badLinkRe = /[\[\]#|^]/g; // Regular expression to match characters that interferes with links: [ ] # | ^
-
-// First remove illegal characters such as spaces and periods, then check for Windows reserved words.
-export function sanitizeFileName(name: string) {
-	const sanitized = name
-		.replace(slashesRe, '-') // Replace slashes with dash
-		.replace(illegalRe, '')
-		.replace(controlRe, '')
-		.replace(reservedRe, '')
-		.replace(windowsTrailingRe, '')
-		.replace(windowsReservedRe, '')
-		.replace(startsWithDotRe, '')
-		.replace(badLinkRe, '');
-
-	// If the result is empty or only whitespace after sanitization, return a default name
-	// This prevents creating files like ".md" (no name) or folders with only spaces
-	const trimmed = sanitized.trim();
-	return trimmed || 'Untitled';
-}
+export { sanitizeFileName, sanitizeFilePath } from './sanitize';
 
 export function genUid(length: number): string {
 	let array: string[] = [];

--- a/tests/util/sanitize-file-path.test.ts
+++ b/tests/util/sanitize-file-path.test.ts
@@ -1,0 +1,19 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { sanitizeFileName, sanitizeFilePath } from '../../src/sanitize';
+
+test('sanitizeFileName trims leading spaces and trailing periods', () => {
+	assert.equal(sanitizeFileName(' Alice Smith. '), 'Alice Smith');
+});
+
+test('sanitizeFilePath preserves folders while sanitizing each segment', () => {
+	assert.equal(
+		sanitizeFilePath(' Contacts / Friends. / Alice Smith. '),
+		'Contacts/Friends/Alice Smith'
+	);
+});
+
+test('sanitizeFilePath removes empty path segments', () => {
+	assert.equal(sanitizeFilePath('/ Contacts // Friends /'), 'Contacts/Friends');
+});


### PR DESCRIPTION
## What does this PR do?

Normalizes importer output path segments with the same filename sanitizer already used for imported note names.

This addresses CSV import paths generated from templates such as `{{Category}}/{{Name}}` when a CSV value starts with spaces or ends with a period. Instead of passing those folder segment names through and letting Obsidian warn about invalid names, the importer now trims and sanitizes each path segment before creating folders.

## Related Issue

Fixes #501

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Moved the filename sanitizer into `src/sanitize.ts` so it can be tested without importing Obsidian's type-only runtime package.
- Added `sanitizeFilePath()` to preserve nested paths while sanitizing each path segment.
- Updated `FormatImporter.sanitizeFilePath()` to use the segment-aware sanitizer.
- Added tests for leading spaces, trailing periods, nested path preservation, and empty path segment removal.

## How to Test

1. `pnpm install --frozen-lockfile`
2. `pnpm exec tsx --test tests/util/sanitize-file-path.test.ts`
3. `pnpm run test`
4. `pnpm run build`
5. `pnpm exec eslint src/format-importer.ts src/util.ts src/sanitize.ts`

Observed locally:

- Focused sanitizer test passed with 3 tests.
- Full `pnpm run test` passed with 35 tests.
- `pnpm run build` passed.
- ESLint passed on touched source files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/obsidianmd/obsidian-importer/blob/master/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS with pnpm 10.20.0 and Node 26.3.0

### Documentation & Housekeeping

- [x] Documentation update — N/A
- [x] Config update — N/A

## Screenshots / Logs

```text
✔ sanitizeFileName trims leading spaces and trailing periods
✔ sanitizeFilePath preserves folders while sanitizing each segment
✔ sanitizeFilePath removes empty path segments

ℹ tests 35
ℹ pass 35
```
