### PR TITLE
fix(apple-notes): use full note title from body

### DIFF
--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -1,5 +1,6 @@
 import { Notice, Platform, Setting, TFile, TFolder, moment } from 'obsidian';
 import { NoteConverter } from './apple-notes/convert-note';
+import { getAppleNotesTitleFromText } from './apple-notes/title';
 import { ANAccount, ANAttachment, ANConverter, ANConverterType, ANFolderType } from './apple-notes/models';
 import { descriptor } from './apple-notes/descriptor';
 import { ImportContext } from '../main';
@@ -292,9 +293,10 @@ export class AppleNotesImporter extends FormatImporter {
 		}
 
 		const folder = this.resolvedFolders[row.ZFOLDER] || this.rootFolder;
+		const converter = this.decodeData(row.zhexdata, NoteConverter);
 
 		// Get creation date and format it according to user preference
-		let title = row.ZTITLE1;
+		let title = getAppleNotesTitleFromText(converter.note.noteText) || row.ZTITLE1;
 		if (this.filePrefixFormat) {
 			const creationTimestamp = this.decodeTime(row.ZCREATIONDATE3 || row.ZCREATIONDATE2 || row.ZCREATIONDATE1);
 			const datePrefix = moment(creationTimestamp).format(this.filePrefixFormat);
@@ -308,7 +310,7 @@ export class AppleNotesImporter extends FormatImporter {
 
 		if (existingFile && existingFile instanceof TFile) {
 			if (this.duplicateHandling === DuplicateHandling.Skip) {
-				this.ctx.reportSkipped(row.ZTITLE1, 'note is a duplicate');
+				this.ctx.reportSkipped(title, 'note is a duplicate');
 				return existingFile;
 			}
 			else if (this.duplicateHandling === DuplicateHandling.ImportUpdated) {
@@ -318,7 +320,7 @@ export class AppleNotesImporter extends FormatImporter {
 
 				// Only skip if the Apple Note hasn't been modified since the existing file
 				if (appleNoteModTime <= existingFileModTime) {
-					this.ctx.reportSkipped(row.ZTITLE1, 'note unchanged since last import');
+					this.ctx.reportSkipped(title, 'note unchanged since last import');
 					return existingFile;
 				}
 				// If Apple Note is newer, continue with import (will overwrite)
@@ -333,8 +335,6 @@ export class AppleNotesImporter extends FormatImporter {
 		this.owners[id] = this.owners[row.ZFOLDER];
 
 		// Notes may reference other notes, so we want them in resolvedFiles before we parse to avoid cycles
-		const converter = this.decodeData(row.zhexdata, NoteConverter);
-
 		this.vault.modify(file, await converter.format(false, file.path), {
 			ctime: this.decodeTime(row.ZCREATIONDATE3 || row.ZCREATIONDATE2 || row.ZCREATIONDATE1),
 			mtime: this.decodeTime(row.ZMODIFICATIONDATE1)

--- a/src/formats/apple-notes/title.ts
+++ b/src/formats/apple-notes/title.ts
@@ -1,0 +1,4 @@
+export function getAppleNotesTitleFromText(noteText: string | undefined): string | null {
+	const firstLine = noteText?.split(/\r\n|\r|\n/, 1)[0]?.trim();
+	return firstLine || null;
+}

--- a/tests/apple-notes/title.test.ts
+++ b/tests/apple-notes/title.test.ts
@@ -1,0 +1,25 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getAppleNotesTitleFromText } from '../../src/formats/apple-notes/title';
+
+test('uses the full first line as the Apple Notes title', () => {
+	const title = 'This is a long Apple Notes title that should stay intact instead of being shortened by the database title field';
+
+	assert.equal(getAppleNotesTitleFromText(`${title}\nThe rest of the note body.`), title);
+});
+
+test('supports Windows and classic Mac line endings', () => {
+	assert.equal(getAppleNotesTitleFromText('Windows line ending\r\nBody'), 'Windows line ending');
+	assert.equal(getAppleNotesTitleFromText('Classic Mac line ending\rBody'), 'Classic Mac line ending');
+});
+
+test('trims whitespace around the first line', () => {
+	assert.equal(getAppleNotesTitleFromText('  Trimmed title  \nBody'), 'Trimmed title');
+});
+
+test('returns null when the note text has no title line', () => {
+	assert.equal(getAppleNotesTitleFromText(''), null);
+	assert.equal(getAppleNotesTitleFromText('   \nBody'), null);
+	assert.equal(getAppleNotesTitleFromText(undefined), null);
+});


### PR DESCRIPTION
## Summary
- use the first line from decoded Apple Notes content as the imported note title
- fall back to the existing database title when the decoded content has no usable title line
- add unit coverage for long titles, line endings, trimming, and fallback behavior

Closes #541

## Validation
- pnpm install --frozen-lockfile
- pnpm exec tsx --test tests/apple-notes/title.test.ts
- pnpm exec eslint src/formats/apple-notes.ts src/formats/apple-notes/title.ts tests/apple-notes/title.test.ts
- pnpm run test
- pnpm run build
- git diff --check origin/master...HEAD