### PR TITLE
fix(bear): preserve Unicode tags

### DIFF
--- a/src/formats/bear-bear2bk.ts
+++ b/src/formats/bear-bear2bk.ts
@@ -3,6 +3,7 @@ import { path, parseFilePath } from '../filesystem';
 import { FormatImporter } from '../format-importer';
 import { ImportContext } from '../main';
 import { readZip, ZipEntryFile } from '../zip';
+import { extractBearTagsFromContent, normalizeBearTagsInMarkdown } from './bear-tags';
 
 type Metadata = {
 	id: string;
@@ -49,31 +50,7 @@ export class Bear2bkImporter extends FormatImporter {
 	}
 
 	private extractTagsFromContent(content: string): string[] {
-		const tags = new Set<string>();
-
-		// Extract simple #tags (alphanumeric, underscore, hyphen, and slash, no spaces)
-		//    Ensures it's not part of a URL or an already processed enclosed tag.
-		//    Allows / in the middle of the tag, but not at the start or end of the simple tag.
-		//    Diacritics regex range from https://stackoverflow.com/questions/30225552/regex-for-diacritics
-		const simpleTagRegex = /(?<!\S)#([A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ0-9_][A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ0-9_/\-]*[A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ0-9_]|[A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ0-9_]+)(?![#\w/])/g;
-		let matchSimple;
-		while ((matchSimple = simpleTagRegex.exec(content)) !== null) {
-			const rawSimpleTag = matchSimple[1].trim();
-			if (rawSimpleTag !== '') {
-				if (this.flattenTags && rawSimpleTag.includes('/')) {
-					const parts = rawSimpleTag.split('/');
-					for (const part of parts) {
-						tags.add(part);
-					}
-				}
-				else {
-					tags.add(rawSimpleTag);
-				}
-			}
-		}
-
-		const finalTags = Array.from(tags);
-		return finalTags;
+		return extractBearTagsFromContent(content, this.flattenTags);
 	}
 
 	async import(ctx: ImportContext): Promise<void> {
@@ -138,17 +115,7 @@ export class Bear2bkImporter extends FormatImporter {
 								}
 							}
 
-							// Replace spaces in enclosed tags with underscores and make them classic tags
-							mdContent = mdContent.replace(/#([^\n#]+?[^\s])#/g, (_match, tag) => { // require non-space before closing to avoid using next tag's opening #
-								return '#' + tag.replace(/\s+/g, '_');
-							});
-
-							// Remove special characters in simple tags
-							mdContent = mdContent.replace(/#([^0-9\s#]+)/g, (_match, tag) => {
-								let cleanTag = tag.replace(/[^A-Za-zÀ-ÖØ-öø-įĴ-őŔ-žǍ-ǰǴ-ǵǸ-țȞ-ȟȤ-ȳɃɆ-ɏḀ-ẞƀ-ƓƗ-ƚƝ-ơƤ-ƥƫ-ưƲ-ƶẠ-ỿ0-9_/\-]/g, '_');
-								cleanTag = cleanTag.replace(/_+/g, '_'); // collapse multiple underscores
-								return '#' + cleanTag;
-							});
+							mdContent = normalizeBearTagsInMarkdown(mdContent);
 
 							// Extract tags from content
 							const tags = this.extractTagsFromContent(mdContent);

--- a/src/formats/bear-tags.ts
+++ b/src/formats/bear-tags.ts
@@ -1,0 +1,44 @@
+const tagEdgeChar = String.raw`\p{L}\p{M}\p{N}_`;
+const tagBodyChar = String.raw`${tagEdgeChar}/\-`;
+const simpleTagRegex = new RegExp(
+	String.raw`(?<!\S)#([${tagEdgeChar}][${tagBodyChar}]*[${tagEdgeChar}]|[${tagEdgeChar}]+)(?![#${tagEdgeChar}/])`,
+	'gu'
+);
+const invalidSimpleTagCharRegex = new RegExp(String.raw`[^${tagBodyChar}]`, 'gu');
+
+export function normalizeBearTagsInMarkdown(mdContent: string): string {
+	// Replace spaces in enclosed tags with underscores and make them classic tags.
+	mdContent = mdContent.replace(/#([^\n#]+?[^\s])#/g, (_match, tag) => { // require non-space before closing to avoid using next tag's opening #
+		return '#' + tag.replace(/\s+/g, '_');
+	});
+
+	// Remove special characters in simple tags while preserving Unicode letters.
+	mdContent = mdContent.replace(/#([^0-9\s#]+)/gu, (_match, tag) => {
+		let cleanTag = tag.replace(invalidSimpleTagCharRegex, '_');
+		cleanTag = cleanTag.replace(/_+/g, '_'); // collapse multiple underscores
+		return '#' + cleanTag;
+	});
+
+	return mdContent;
+}
+
+export function extractBearTagsFromContent(content: string, flattenTags = false): string[] {
+	const tags = new Set<string>();
+	let matchSimple;
+	while ((matchSimple = simpleTagRegex.exec(content)) !== null) {
+		const rawSimpleTag = matchSimple[1].trim();
+		if (rawSimpleTag !== '') {
+			if (flattenTags && rawSimpleTag.includes('/')) {
+				const parts = rawSimpleTag.split('/');
+				for (const part of parts) {
+					tags.add(part);
+				}
+			}
+			else {
+				tags.add(rawSimpleTag);
+			}
+		}
+	}
+
+	return Array.from(tags);
+}

--- a/tests/bear/tags.test.ts
+++ b/tests/bear/tags.test.ts
@@ -1,0 +1,50 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+	extractBearTagsFromContent,
+	normalizeBearTagsInMarkdown,
+} from '../../src/formats/bear-tags';
+
+test('preserves CJK simple Bear tags during normalization and extraction', () => {
+	const content = normalizeBearTagsInMarkdown('#中文 #标签/子标签 #仕事 #일정');
+
+	assert.equal(content, '#中文 #标签/子标签 #仕事 #일정');
+	assert.deepEqual(extractBearTagsFromContent(content), [
+		'中文',
+		'标签/子标签',
+		'仕事',
+		'일정',
+	]);
+});
+
+test('flattens nested CJK Bear tags when requested', () => {
+	const content = normalizeBearTagsInMarkdown('#标签/子标签');
+
+	assert.deepEqual(extractBearTagsFromContent(content, true), [
+		'标签',
+		'子标签',
+	]);
+});
+
+test('keeps existing Latin and diacritic Bear tag behavior', () => {
+	const content = normalizeBearTagsInMarkdown('#project #mañana #cafe-au-lait #daily_note');
+
+	assert.deepEqual(extractBearTagsFromContent(content), [
+		'project',
+		'mañana',
+		'cafe-au-lait',
+		'daily_note',
+	]);
+});
+
+test('normalizes enclosed tags and unsupported punctuation', () => {
+	const content = normalizeBearTagsInMarkdown('#two words# #中文，标签 #bad!tag');
+
+	assert.equal(content, '#two_words #中文_标签 #bad_tag');
+	assert.deepEqual(extractBearTagsFromContent(content), [
+		'two_words',
+		'中文_标签',
+		'bad_tag',
+	]);
+});


### PR DESCRIPTION
## Summary
- preserve Unicode letters and marks when Bear simple tags are normalized
- extract CJK nested tags such as `#标签/子标签` into frontmatter instead of collapsing them to `_`
- move Bear tag normalization into a small helper with focused tests

Fixes #515

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm exec tsx --test tests/bear/tags.test.ts`
- `pnpm run test`
- `pnpm run build`
- `pnpm exec eslint src/formats/bear-bear2bk.ts src/formats/bear-tags.ts tests/bear/tags.test.ts`
- `git diff --check`