### PR TITLE
fix(notion): merge list items split by display:contents wrappers

### DIFF
--- a/src/formats/notion/convert-to-md.ts
+++ b/src/formats/notion/convert-to-md.ts
@@ -72,6 +72,7 @@ export async function readToMarkdown(info: NotionResolverInfo, file: ZipEntryFil
 	replaceElementsWithChildren(body, 'div.indented');
 	replaceElementsWithChildren(body, 'details');
 	fixToggleHeadings(body);
+	unwrapNotionListWrappers(body);
 	fixNotionLists(body, 'ul');
 	fixNotionLists(body, 'ol');
 	fixMermaidCodeblock(body);
@@ -628,6 +629,19 @@ function fixMermaidCodeblock(body: HTMLElement) {
 	}
 }
 
+function unwrapNotionListWrappers(body: HTMLElement) {
+	// Notion wraps each list item in <div style="display:contents"><ol/ul><li>...</li></ol/ul></div>.
+	// These wrappers prevent fixNotionLists from seeing adjacent <ol>/<ul> as siblings.
+	for (const div of body.findAll('div[style]')) {
+		const style = div.getAttribute('style') ?? '';
+		if (!style.includes('display:contents') && !style.includes('display: contents')) continue;
+		const children = Array.from(div.children);
+		if (children.length === 1 && (children[0].tagName === 'OL' || children[0].tagName === 'UL')) {
+			hoistChildren(div);
+		}
+	}
+}
+
 function fixNotionLists(body: HTMLElement, tagName: 'ul' | 'ol') {
 	// Notion creates each list item within its own <ol> or <ul>, messing up newlines in the converted Markdown.
 	// Iterate all adjacent <ul>s or <ol>s and replace each string of adjacent lists with a single <ul> or <ol>.
@@ -647,6 +661,8 @@ function fixNotionLists(body: HTMLElement, tagName: 'ul' | 'ol') {
 		}
 
 		const joinedList = body.createEl(tagName);
+		const startAttr = htmlLists[0].getAttribute('start');
+		if (startAttr) joinedList.setAttribute('start', startAttr);
 		for (const li of listItems) {
 			joinedList.appendChild(li);
 		}


### PR DESCRIPTION
Fixes #566 

Notion HTML exports wrap each list item in its own `<div style="display:contents"><ol start="N"><li>…</li></ol></div>`. The existing fixNotionLists() merges adjacent `<ol>/<ul>` siblings, but the wrapper divs break sibling detection — leaving every item as its own isolated list, so Markdown renders as repeated "1." instead of "1. 2. 3.".

Add unwrapNotionListWrappers(), called before fixNotionLists(), which removes only those display:contents divs whose sole child is an `<ol>` or `<ul>` (other wrappers are left untouched). Also preserve the start attribute of the first list when joining, so non-1-based numbering is kept.