### PR TITLE
fix(evernote): dedupe filenames case-insensitively

### DIFF
--- a/src/formats/yarle/utils/filename-dedupe.ts
+++ b/src/formats/yarle/utils/filename-dedupe.ts
@@ -1,0 +1,34 @@
+import { escapeStringRegexp } from './escape-string-regexp';
+
+export const getFilenamePrefix = (filename: string): string => {
+	return filename.split('.').slice(0, -1).join('.');
+};
+
+export const getFilenameIndexForPrefix = (filePrefix: string, fileNamePrefix: string): number | null => {
+	const normalizedFilePrefix = filePrefix.toLowerCase();
+	const normalizedNamePrefix = fileNamePrefix.toLowerCase();
+	const indexedNameRegex = new RegExp(`^${escapeStringRegexp(normalizedNamePrefix)}\\.(\\d+)(?:$|\\s)`);
+
+	if (normalizedFilePrefix === normalizedNamePrefix) {
+		return 0;
+	}
+
+	const indexedMatch = normalizedFilePrefix.match(indexedNameRegex);
+	return indexedMatch ? Number(indexedMatch[1]) : null;
+};
+
+export const getNextFilenameIndex = (files: string[], fileNamePrefix: string): number => {
+	const usedIndexes = new Set<number>();
+	for (const file of files) {
+		const index = getFilenameIndexForPrefix(getFilenamePrefix(file), fileNamePrefix);
+		if (index !== null) {
+			usedIndexes.add(index);
+		}
+	}
+
+	let nextIndex = 0;
+	while (usedIndexes.has(nextIndex)) {
+		nextIndex++;
+	}
+	return nextIndex;
+};

--- a/src/formats/yarle/utils/filename-utils.ts
+++ b/src/formats/yarle/utils/filename-utils.ts
@@ -5,8 +5,8 @@ import { sanitizeFileName } from '../../../util';
 import { yarleOptions } from '../yarle';
 
 import { ResourceFileProperties } from '../models/ResourceFileProperties';
-import { escapeStringRegexp } from './escape-string-regexp';
 import { extensionForMime } from '../../../mime';
+import { getNextFilenameIndex } from './filename-dedupe';
 
 // Filename length constants
 const MAX_NOTE_NAME_LENGTH = 100; // Limit note name length to prevent path issues
@@ -17,20 +17,9 @@ export const normalizeTitle = (title: string) => {
 };
 
 export const getFileIndex = (dstPath: string, fileNamePrefix: string): number => {
-	const index = fs
-		.readdirSync(dstPath)
-		.filter(file => {
-			// make sure we get the first copy with no count suffix or the copies whose filename changed
-			// drop the extension to compare with filename prefix
-			const filePrefix = file.split('.').slice(0, -1).join('.');
-			const escapedFilePrefix = escapeStringRegexp(fileNamePrefix);
-			const fileWithSameName = filePrefix.match(new RegExp(`${escapedFilePrefix}\\.\\d+`));
-
-			return filePrefix === fileNamePrefix || fileWithSameName;
-		})
-		.length;
-
-	return index;
+	// Pick an unused index case-insensitively so default macOS/Windows
+	// filesystems do not overwrite title variants.
+	return getNextFilenameIndex(fs.readdirSync(dstPath), fileNamePrefix);
 
 };
 export const getResourceFileProperties = (workDir: string, resource: any): ResourceFileProperties => {

--- a/tests/evernote/filename-dedupe.test.ts
+++ b/tests/evernote/filename-dedupe.test.ts
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+	getFilenameIndexForPrefix,
+	getFilenamePrefix,
+	getNextFilenameIndex,
+} from '../../src/formats/yarle/utils/filename-dedupe';
+
+test('chooses the next filename index case-insensitively', () => {
+	assert.equal(getNextFilenameIndex([
+		'Sales.md',
+		'Sales.1.md',
+		'salesforce.md',
+	], 'sales'), 2);
+});
+
+test('fills gaps instead of reusing an existing case-variant suffix', () => {
+	assert.equal(getNextFilenameIndex([
+		'Sales.md',
+		'sales.2.md',
+	], 'sales'), 1);
+});
+
+test('detects zettelkasten numbered copies before the note title suffix', () => {
+	assert.equal(getNextFilenameIndex([
+		'202601011230.md',
+		'202601011230.1 Project.md',
+	], '202601011230'), 2);
+});
+
+test('detects numbered copies case-insensitively', () => {
+	assert.equal(getFilenameIndexForPrefix('Project.12', 'project'), 12);
+	assert.equal(getFilenameIndexForPrefix('PROJECT.12', 'project'), 12);
+});
+
+test('escapes regex characters in note titles before matching numbered copies', () => {
+	assert.equal(getFilenameIndexForPrefix('Q1.2026 Plan.1', 'q1.2026 plan'), 1);
+	assert.equal(getFilenameIndexForPrefix('Q1x2026 Plan.1', 'q1.2026 plan'), null);
+});
+
+test('extracts filename prefixes using the existing final-extension rule', () => {
+	assert.equal(getFilenamePrefix('archive.tar.gz'), 'archive.tar');
+	assert.equal(getFilenamePrefix('Untitled Note.md'), 'Untitled Note');
+});


### PR DESCRIPTION
## Summary

- choose Evernote/Yarle filename suffixes case-insensitively so case-only title variants do not overwrite each other on default macOS and Windows filesystems
- select the first unused numeric suffix instead of counting matches, which avoids reuse when existing suffixes are non-contiguous
- cover note names, resource names, regex-sensitive titles, and zettelkasten filename suffixes

Fixes #384
Addresses the case-insensitive filename collision described in #547.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm exec tsx --test tests/evernote/filename-dedupe.test.ts`
- `pnpm run test`
- `pnpm run build`
- `pnpm exec eslint src/formats/yarle/utils/filename-utils.ts src/formats/yarle/utils/filename-dedupe.ts tests/evernote/filename-dedupe.test.ts`
- `git diff --check`
- `codex review --base origin/master`

Internal review notes: early review passes found a non-contiguous suffix collision and a zettelkasten suffix collision; both are covered by the final tests in this PR.