### PR TITLE
fix(roam): format imported bullets with tab indents

### DIFF
--- a/src/formats/roam-json.ts
+++ b/src/formats/roam-json.ts
@@ -6,6 +6,7 @@ import { sanitizeFileName } from '../util';
 import { BlockInfo, RoamBlock, RoamPage } from './roam/models/roam-json';
 import { convertDateString, sanitizeFileNameKeepPath } from './roam/utils';
 import { blockRefRegex, extractBlockReferenceUIDs } from './roam/block-refs';
+import { formatRoamMarkdownLine, getRoamChildIndent } from './roam/list-format';
 import { moment } from 'obsidian';
 
 const roamSpecificMarkup = ['POMO', 'word-count', 'date', 'slider', 'encrypt', 'TaoOfRoam', 'orphans', 'count', 'character-count', 'comment-button', 'query', 'streak', 'attr-table', 'mentions', 'search', 'roam\/render', 'calc'];
@@ -341,12 +342,13 @@ export class RoamJSONImporter extends FormatImporter {
 		if ('string' in json && json.string) {
 			const prefix = json.heading ? '#'.repeat(json.heading) + ' ' : '';
 			const scrubbed = await this.roamMarkupScrubber(graphFolder, attachmentsFolder, json.string);
-			markdown.push(`${isChild ? indent + '* ' : indent}${prefix}${scrubbed}`);
+			markdown.push(formatRoamMarkdownLine(`${prefix}${scrubbed}`, indent, isChild));
 		}
 
 		if (json.children) {
+			const childIndent = getRoamChildIndent(indent, isChild);
 			for (const child of json.children) {
-				markdown.push(await this.jsonToMarkdown(graphFolder, attachmentsFolder, child, indent + '  ', true, '', this.oldestTimestamp, this.newestTimestamp));
+				markdown.push(await this.jsonToMarkdown(graphFolder, attachmentsFolder, child, childIndent, true, '', this.oldestTimestamp, this.newestTimestamp));
 			}
 		}
 

--- a/src/formats/roam/list-format.ts
+++ b/src/formats/roam/list-format.ts
@@ -1,0 +1,11 @@
+export function formatRoamMarkdownLine(content: string, indent: string, isChild: boolean): string {
+	if (!isChild) {
+		return `${indent}${content}`;
+	}
+
+	return `${indent}* ${content}`;
+}
+
+export function getRoamChildIndent(indent: string, isChild: boolean): string {
+	return isChild ? `${indent}\t` : indent;
+}

--- a/tests/roam/bullet-formatting.test.ts
+++ b/tests/roam/bullet-formatting.test.ts
@@ -1,0 +1,24 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { formatRoamMarkdownLine, getRoamChildIndent } from '../../src/formats/roam/list-format';
+
+test('formats first-level Roam blocks as unindented bullets', () => {
+	const indent = getRoamChildIndent('', false);
+
+	assert.equal(formatRoamMarkdownLine('Roam Bullet 1', indent, true), '* Roam Bullet 1');
+	assert.equal(formatRoamMarkdownLine('Roam Bullet 2', indent, true), '* Roam Bullet 2');
+});
+
+test('uses tab indentation for nested Roam bullets', () => {
+	const firstLevelIndent = getRoamChildIndent('', false);
+	const secondLevelIndent = getRoamChildIndent(firstLevelIndent, true);
+	const thirdLevelIndent = getRoamChildIndent(secondLevelIndent, true);
+
+	assert.equal(formatRoamMarkdownLine('Roam Bullet 2.1', secondLevelIndent, true), '\t* Roam Bullet 2.1');
+	assert.equal(formatRoamMarkdownLine('Roam Bullet 2.1.1', thirdLevelIndent, true), '\t\t* Roam Bullet 2.1.1');
+});
+
+test('keeps page-level markdown unbulleted', () => {
+	assert.equal(formatRoamMarkdownLine('# Page heading', '', false), '# Page heading');
+});


### PR DESCRIPTION
## Summary

- Format Roam JSON child blocks so first-level bullets start at the beginning of the line.
- Use tab indentation for nested Roam bullets, matching lists created in Obsidian.
- Add focused coverage for Roam bullet line formatting.

## Test

- pnpm install --frozen-lockfile
- pnpm exec tsx --test tests/roam/block-refs.test.ts tests/roam/bullet-formatting.test.ts
- pnpm exec eslint src/formats/roam-json.ts src/formats/roam/list-format.ts tests/roam/bullet-formatting.test.ts
- pnpm run test
- pnpm run build

Fixes #250