### PR TITLE
HTML: Use Zoho note titles

### DIFF
--- a/src/formats/html-title.ts
+++ b/src/formats/html-title.ts
@@ -1,0 +1,29 @@
+export function extractZohoNotecardName(dataNotecard: string | null | undefined): string | null {
+	if (!dataNotecard) {
+		return null;
+	}
+
+	let metadata: unknown;
+	try {
+		metadata = JSON.parse(dataNotecard);
+	}
+	catch {
+		return null;
+	}
+
+	if (!metadata || typeof metadata !== 'object') {
+		return null;
+	}
+
+	const name = (metadata as { name?: unknown }).name;
+	if (typeof name !== 'string') {
+		return null;
+	}
+
+	return name.trim() || null;
+}
+
+export function extractHtmlImportTitle(dom: HTMLElement, fallbackTitle: string): string {
+	const body = dom.querySelector('body');
+	return extractZohoNotecardName(body?.getAttribute('data-notecard')) ?? fallbackTitle;
+}

--- a/src/formats/html.ts
+++ b/src/formats/html.ts
@@ -11,6 +11,7 @@ import { FormatImporter } from '../format-importer';
 import { ImportContext } from '../main';
 import { extensionForMime } from '../mime';
 import { parseHTML, stringToUtf8 } from '../util';
+import { extractHtmlImportTitle } from './html-title';
 
 export class HtmlImporter extends FormatImporter {
 	attachmentSizeLimit: number;
@@ -223,7 +224,7 @@ export class HtmlImporter extends FormatImporter {
 			}
 
 			let mdContent = htmlToMarkdown(dom);
-			let mdFile = await this.saveAsMarkdownFile(folder, file.basename, mdContent);
+			let mdFile = await this.saveAsMarkdownFile(folder, extractHtmlImportTitle(dom, file.basename), mdContent);
 
 			// Because `htmlToMarkdown` always gets us markdown links, we'll want to convert them into wikilinks, or relative links depending on the user's preference.
 			if (!Object.isEmpty(attachments)) {

--- a/tests/html/title.test.ts
+++ b/tests/html/title.test.ts
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractHtmlImportTitle, extractZohoNotecardName } from '../../src/formats/html-title';
+
+function htmlWithNotecard(dataNotecard: string | null): HTMLElement {
+	return {
+		querySelector(selector: string) {
+			assert.equal(selector, 'body');
+			return {
+				getAttribute(name: string) {
+					assert.equal(name, 'data-notecard');
+					return dataNotecard;
+				},
+			};
+		},
+	} as unknown as HTMLElement;
+}
+
+test('uses the Zoho notecard name as the HTML import title', () => {
+	const title = extractHtmlImportTitle(htmlWithNotecard('{"name":"Vietnam"}'), '9j1oe6413f84cc35f');
+
+	assert.equal(title, 'Vietnam');
+});
+
+test('trims Zoho notecard names before using them', () => {
+	assert.equal(extractZohoNotecardName('{"name":"  Travel Notes  "}'), 'Travel Notes');
+});
+
+test('falls back to the source filename when Zoho metadata is unavailable', () => {
+	assert.equal(extractHtmlImportTitle(htmlWithNotecard(null), '9j1oe6413f84cc35f'), '9j1oe6413f84cc35f');
+});
+
+test('falls back to the source filename when Zoho metadata is malformed', () => {
+	assert.equal(extractHtmlImportTitle(htmlWithNotecard('{bad json'), '9j1oe6413f84cc35f'), '9j1oe6413f84cc35f');
+});
+
+test('falls back to the source filename when the Zoho name is blank', () => {
+	assert.equal(extractHtmlImportTitle(htmlWithNotecard('{"name":"   "}'), '9j1oe6413f84cc35f'), '9j1oe6413f84cc35f');
+});
+
+test('falls back to the source filename when the Zoho name is not a string', () => {
+	assert.equal(extractHtmlImportTitle(htmlWithNotecard('{"name":42}'), '9j1oe6413f84cc35f'), '9j1oe6413f84cc35f');
+});


### PR DESCRIPTION
## Summary

- use Zoho Notebook's `data-notecard.name` metadata as the imported HTML note title
- keep the exported filename as the fallback when the metadata is missing, malformed, blank, or not a string
- add tests for the title extraction fallback behavior

Fixes #514.

## Validation

- `git diff --check HEAD^..HEAD`
- `pnpm exec eslint src/formats/html.ts src/formats/html-title.ts tests/html/title.test.ts`
- `pnpm exec tsx --test tests/html/title.test.ts`
- `pnpm run test`
- `pnpm run build`
