### PR TITLE
Evernote: Sanitize notebook folder names

### DIFF
--- a/src/formats/yarle/utils/folder-utils.ts
+++ b/src/formats/yarle/utils/folder-utils.ts
@@ -6,6 +6,13 @@ import { yarleOptions } from '../yarle';
 import { replaceLastOccurrenceInString } from './string-utils';
 
 import { getNoteFileName, getNoteName, normalizeTitle } from './filename-utils';
+import {
+	getNotebookNameAndFolderNames,
+	getSanitizedNotebookFolderNames,
+	sanitizeNotebookFolderName,
+} from './notebook-folder-utils';
+
+export { getNotebookNameAndFolderNames, sanitizeNotebookFolderName };
 
 export interface Path {
 	mdPath: string;
@@ -156,20 +163,6 @@ export const clearResourceDir = (note: any): void => {
 	clearDistDir(resPath);
 	resourceDirClears.set(resPath, clears + 1);
 };
-export const getNotebookNameAndFolderNames = (basename: string): { notebookName: string, notebookFolderNames: string[] } => {
-	const notebookFolderNames = basename.split('@@@');
-
-	let notebookName = notebookFolderNames.pop();
-	if (!notebookName) {
-		notebookName = basename;
-	}
-	return {
-		notebookName,
-		notebookFolderNames
-	};
-};
-
-
 export const getNotebookStackedProps = (baseEnex: PickedFile): NotebookStackProps => {
 	if (!(baseEnex instanceof NodePickedFile)) throw new Error('Evernote import currently only works on desktop');
 
@@ -184,7 +177,7 @@ export const getNotebookStackedProps = (baseEnex: PickedFile): NotebookStackProp
 
 export const getNotebookStackOutputDir = (enex: PickedFile, options: YarleOptions): string => {
 
-	const { notebookFolderNames } = getNotebookNameAndFolderNames(enex.basename);
+	const notebookFolderNames = getSanitizedNotebookFolderNames(enex.basename);
 
 	fs.mkdirSync(path.join(options.outputDir, ...notebookFolderNames), { recursive: true });
 	return [options.outputDir, ...notebookFolderNames].join(options.pathSeparator);
@@ -214,10 +207,10 @@ export const setPaths = (enexFileBasename: string, yarleOptions: YarleOptions): 
 	// console.log(`Skip enex filename from output? ${yarleOptions.skipEnexFileNameFromOutputPath}`);
 	if (!yarleOptions.skipEnexFileNameFromOutputPath) {
 		// Truncate enex filename if it's too long to prevent path issues
-		let truncatedBasename = enexFileBasename;
+		let truncatedBasename = sanitizeNotebookFolderName(enexFileBasename);
 
-		if (enexFileBasename.length > MAX_ENEX_DIR_LENGTH) {
-			truncatedBasename = enexFileBasename.substring(0, MAX_ENEX_DIR_LENGTH);
+		if (truncatedBasename.length > MAX_ENEX_DIR_LENGTH) {
+			truncatedBasename = truncatedBasename.substring(0, MAX_ENEX_DIR_LENGTH);
 			console.warn(`ENEX filename too long (${enexFileBasename.length} chars), truncated to ${MAX_ENEX_DIR_LENGTH} chars: ${truncatedBasename}`);
 		}
 

--- a/src/formats/yarle/utils/notebook-folder-utils.ts
+++ b/src/formats/yarle/utils/notebook-folder-utils.ts
@@ -1,0 +1,42 @@
+const notebookStackSeparator = '@@@';
+
+let slashesRe = /[/\\]/g;
+let illegalRe = /[\?<>:\*\|"]/g;
+let controlRe = /[\x00-\x1f\x80-\x9f]/g;
+let reservedRe = /^\.+$/;
+let windowsReservedRe = /^(con|prn|aux|nul|com[0-9]|lpt[0-9])(\..*)?$/i;
+let windowsTrailingRe = /[\. ]+$/;
+let startsWithDotRe = /^\./;
+let badLinkRe = /[\[\]#|^]/g;
+
+export function sanitizeNotebookFolderName(name: string): string {
+	const sanitized = name
+		.replace(slashesRe, '-')
+		.replace(illegalRe, '')
+		.replace(controlRe, '')
+		.replace(reservedRe, '')
+		.replace(windowsTrailingRe, '')
+		.replace(windowsReservedRe, '')
+		.replace(startsWithDotRe, '')
+		.replace(badLinkRe, '');
+
+	return sanitized.trim() || 'Untitled';
+}
+
+export function getNotebookNameAndFolderNames(basename: string): { notebookName: string, notebookFolderNames: string[] } {
+	const notebookFolderNames = basename.split(notebookStackSeparator);
+
+	let notebookName = notebookFolderNames.pop();
+	if (!notebookName) {
+		notebookName = basename;
+	}
+	return {
+		notebookName,
+		notebookFolderNames
+	};
+}
+
+export function getSanitizedNotebookFolderNames(basename: string): string[] {
+	const { notebookFolderNames } = getNotebookNameAndFolderNames(basename);
+	return notebookFolderNames.map(sanitizeNotebookFolderName);
+}

--- a/tests/evernote/notebook-folder-names.test.ts
+++ b/tests/evernote/notebook-folder-names.test.ts
@@ -1,0 +1,34 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+	getNotebookNameAndFolderNames,
+	getSanitizedNotebookFolderNames,
+	sanitizeNotebookFolderName,
+} from '../../src/formats/yarle/utils/notebook-folder-utils';
+
+test('removes Windows trailing dots from Evernote notebook folder names', () => {
+	assert.equal(sanitizeNotebookFolderName('Inbox.'), 'Inbox');
+});
+
+test('removes Windows trailing spaces from Evernote notebook folder names', () => {
+	assert.equal(sanitizeNotebookFolderName('Inbox   '), 'Inbox');
+});
+
+test('falls back when an Evernote notebook folder name has no usable characters', () => {
+	assert.equal(sanitizeNotebookFolderName('...'), 'Untitled');
+});
+
+test('sanitizes Evernote notebook stack folder segments', () => {
+	assert.deepEqual(getSanitizedNotebookFolderNames('Stack.@@@Inbox.'), ['Stack']);
+});
+
+test('preserves the display notebook name when splitting Evernote notebook stacks', () => {
+	const names = getNotebookNameAndFolderNames('Stack.@@@Inbox.');
+
+	assert.equal(names.notebookName, 'Inbox.');
+	assert.deepEqual(names.notebookFolderNames, ['Stack.']);
+});
+
+test('preserves safe Evernote notebook folder names', () => {
+	assert.equal(sanitizeNotebookFolderName('Project Notes'), 'Project Notes');
+});


### PR DESCRIPTION
## Summary

- sanitize ENEX-derived Evernote notebook output folder names before creating directories
- sanitize notebook stack folder segments while preserving the original notebook display name for templates/runtime metadata
- add focused coverage for Windows trailing-dot/trailing-space folder names and fallback handling

Fixes #523.

## Validation

- `pnpm exec tsx --test tests/evernote/notebook-folder-names.test.ts`
- `pnpm run test`
- `pnpm run build`
- `pnpm exec eslint src/formats/yarle/utils/folder-utils.ts src/formats/yarle/utils/notebook-folder-utils.ts tests/evernote/notebook-folder-names.test.ts`
- `git diff --check origin/master...HEAD`
