### PR TITLE
Apple Notes: Preserve soft returns

### DIFF
--- a/src/formats/apple-notes/convert-note.ts
+++ b/src/formats/apple-notes/convert-note.ts
@@ -54,12 +54,13 @@ export class NoteConverter extends ANConverter {
 			do {
 				attr = this.note.attributeRun[i];
 				offsetEnd = offsetEnd + attr.length;
-				attrText += this.note.noteText.substring(offsetStart, offsetEnd);
+				const attrRunText = this.note.noteText.substring(offsetStart, offsetEnd);
+				attrText += attrRunText;
 
 				offsetStart = offsetEnd;
 				nextIsSame = (i == this.note.attributeRun.length - 1)
 					? false
-					: attrEquals(attr, this.note.attributeRun[i + 1]);
+					: attrEquals(attr, this.note.attributeRun[i + 1]) && !attrRunText.endsWith('\n');
 
 				i++;
 			}
@@ -67,9 +68,16 @@ export class NoteConverter extends ANConverter {
 
 			/* Then, since Obsidian doesn't like formatting crossing new lines or 
 			starting/ending at spaces, divide tokens based on that */
-			for (let fragment of attrText.split(FRAGMENT_SPLIT)) {
+			const splitFragments = attrText.split(FRAGMENT_SPLIT);
+			for (let j = 0; j < splitFragments.length; j++) {
+				const fragment = splitFragments[j];
 				if (!fragment) continue;
-				tokens.push({ attr, fragment });
+				const hasLaterText = splitFragments.slice(j + 1).some(f => /\S/.test(f));
+				tokens.push({
+					attr,
+					fragment,
+					softLineBreak: fragment.includes('\n') && hasLaterText
+				});
 			}
 		}
 
@@ -78,14 +86,14 @@ export class NoteConverter extends ANConverter {
 
 	async format(table = false, parentNotePath = ''): Promise<string> {
 		let fragments = this.parseTokens();
-		let firstLineSkip = !table && this.importer.omitFirstLine && this.note.noteText.contains('\n');
+		let firstLineSkip = !table && this.importer.omitFirstLine && this.note.noteText.includes('\n');
 		let converted = '';
 
 		for (let j = 0; j < fragments.length; j++) {
-			let { attr, fragment } = fragments[j];
+			let { attr, fragment, softLineBreak } = fragments[j];
 
 			if (firstLineSkip) {
-				if (fragment.contains('\n') || attr.attachmentInfo) {
+				if (fragment.includes('\n') || attr.attachmentInfo) {
 					firstLineSkip = false;
 				}
 				else {
@@ -94,11 +102,15 @@ export class NoteConverter extends ANConverter {
 			}
 
 			attr.fragment = fragment;
-			attr.atLineStart = j == 0 ? true : fragments[j - 1]?.fragment.contains('\n');
+			const previousFragment = fragments[j - 1];
+			attr.atLineStart = j == 0 ? true : previousFragment?.fragment.includes('\n') && !previousFragment.softLineBreak;
 
 			converted += this.formatMultiRun(attr);
 
-			if (!/\S/.test(attr.fragment) || this.multiRun == ANMultiRun.Monospaced) {
+			if (softLineBreak && attr.fragment.includes('\n') && this.multiRun != ANMultiRun.Monospaced) {
+				converted += attr.fragment.replace(/[ \t]*\n[ \t]*/g, '<br>');
+			}
+			else if (!/\S/.test(attr.fragment) || this.multiRun == ANMultiRun.Monospaced) {
 				converted += attr.fragment;
 			}
 			else if (attr.attachmentInfo) {

--- a/src/formats/apple-notes/models.ts
+++ b/src/formats/apple-notes/models.ts
@@ -46,6 +46,7 @@ export type ANAccount = {
 export type ANFragmentPair = {
 	attr: ANAttributeRun;
 	fragment: string;
+	softLineBreak?: boolean;
 };
 
 export enum ANMultiRun {

--- a/tests/apple-notes/soft-returns.test.ts
+++ b/tests/apple-notes/soft-returns.test.ts
@@ -1,0 +1,64 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { NoteConverter } from '../../src/formats/apple-notes/convert-note';
+import { ANDocument, ANAttributeRun, ANStyleType } from '../../src/formats/apple-notes/models';
+import { AppleNotesImporter } from '../../src/formats/apple-notes';
+
+const attrType = { fieldsArray: [] };
+
+function run(text: string, styleType: ANStyleType = ANStyleType.Default): ANAttributeRun {
+	return {
+		$type: attrType,
+		length: text.length,
+		paragraphStyle: { styleType, indentAmount: 0 }
+	} as ANAttributeRun;
+}
+
+async function convert(parts: string[], runs: ANAttributeRun[]): Promise<string> {
+	const importer = {
+		omitFirstLine: false,
+		app: { fileManager: {} }
+	} as unknown as AppleNotesImporter;
+
+	const document = {
+		note: {
+			noteText: parts.join(''),
+			attributeRun: runs,
+			version: 1
+		}
+	} as ANDocument;
+
+	return new NoteConverter(importer, document).format();
+}
+
+test('preserves Apple Notes soft returns inside a bullet item', async () => {
+	const text = 'First line\nSecond line';
+
+	assert.equal(
+		await convert([text], [run(text, ANStyleType.DottedList)]),
+		'- First line<br>Second line'
+	);
+});
+
+test('keeps separate Apple Notes bullet paragraphs as separate list items', async () => {
+	const first = 'First item\n';
+	const second = 'Second item';
+
+	assert.equal(
+		await convert([first, second], [
+			run(first, ANStyleType.DottedList),
+			run(second, ANStyleType.DottedList)
+		]),
+		'- First item\n- Second item'
+	);
+});
+
+test('preserves Apple Notes soft returns in normal paragraphs', async () => {
+	const text = 'First line\nSecond line';
+
+	assert.equal(
+		await convert([text], [run(text)]),
+		'First line<br>Second line'
+	);
+});


### PR DESCRIPTION
## Summary

- preserve Apple Notes soft returns as Markdown `<br>` breaks instead of treating them as new paragraphs/list items
- keep separate Apple Notes paragraph/list runs as separate Markdown paragraphs/list items
- add focused Apple Notes converter coverage for bullet and paragraph soft returns

Fixes #328.

## Validation

- `pnpm exec tsx --test tests/apple-notes/soft-returns.test.ts`
- `pnpm run test`
- `pnpm run build`
- `pnpm exec eslint src/formats/apple-notes/convert-note.ts src/formats/apple-notes/models.ts tests/apple-notes/soft-returns.test.ts`
- `git diff --check origin/master...HEAD`
