### PR TITLE
Notion: merge display contents wrapped lists

### DIFF
--- a/src/formats/notion/convert-to-md.ts
+++ b/src/formats/notion/convert-to-md.ts
@@ -18,6 +18,7 @@ import {
 	stripNotionId,
 	stripParentDirectories,
 } from './notion-utils';
+import { fixNotionLists } from './lists';
 
 export async function readToMarkdown(info: NotionResolverInfo, file: ZipEntryFile): Promise<string> {
 	const text = await file.readText();
@@ -625,34 +626,6 @@ function fixMermaidCodeblock(body: HTMLElement) {
 	for (const codeblock of body.findAll('.language-Mermaid')) {
 		codeblock.removeClass('language-Mermaid');
 		codeblock.addClass('language-mermaid');
-	}
-}
-
-function fixNotionLists(body: HTMLElement, tagName: 'ul' | 'ol') {
-	// Notion creates each list item within its own <ol> or <ul>, messing up newlines in the converted Markdown.
-	// Iterate all adjacent <ul>s or <ol>s and replace each string of adjacent lists with a single <ul> or <ol>.
-	for (const htmlList of body.findAll(tagName)) {
-		const htmlLists: HTMLElement[] = [];
-		const listItems: HTMLElement[] = [];
-		let nextAdjacentList: HTMLElement = htmlList;
-
-		while (nextAdjacentList.tagName === tagName.toUpperCase()) {
-			htmlLists.push(nextAdjacentList);
-			for (let i = 0; i < nextAdjacentList.children.length; i++) {
-				listItems.push(nextAdjacentList.children[i] as HTMLElement);
-			}
-			// classes are always "to-do-list, bulleted-list, or numbered-list"
-			if (!nextAdjacentList.nextElementSibling || nextAdjacentList.getAttribute('class') !== nextAdjacentList.nextElementSibling.getAttribute('class')) break;
-			nextAdjacentList = nextAdjacentList.nextElementSibling as HTMLElement;
-		}
-
-		const joinedList = body.createEl(tagName);
-		for (const li of listItems) {
-			joinedList.appendChild(li);
-		}
-
-		htmlLists[0].replaceWith(joinedList);
-		htmlLists.slice(1).forEach(htmlList => htmlList.remove());
 	}
 }
 

--- a/src/formats/notion/lists.ts
+++ b/src/formats/notion/lists.ts
@@ -1,0 +1,71 @@
+type NotionListContainer = {
+	list: HTMLElement;
+	container: HTMLElement;
+};
+
+function getDisplayContentsListContainer(element: Element | null, tagName: 'ul' | 'ol'): NotionListContainer | null {
+	if (!element) return null;
+
+	const htmlElement = element as HTMLElement;
+	const style = htmlElement.getAttribute('style') ?? '';
+	const isDisplayContentsWrapper = htmlElement.tagName === 'DIV' && /\bdisplay\s*:\s*contents\b/i.test(style);
+	if (!isDisplayContentsWrapper || htmlElement.children.length !== 1) {
+		return null;
+	}
+
+	const child = htmlElement.firstElementChild as HTMLElement | null;
+	if (child?.tagName !== tagName.toUpperCase()) {
+		return null;
+	}
+
+	return {
+		list: child,
+		container: htmlElement,
+	};
+}
+
+function getNotionListContainer(element: Element | null, tagName: 'ul' | 'ol'): NotionListContainer | null {
+	const wrappedList = getDisplayContentsListContainer(element, tagName);
+	if (wrappedList) return wrappedList;
+
+	if (!element) return null;
+
+	const htmlElement = element as HTMLElement;
+	if (htmlElement.tagName !== tagName.toUpperCase()) {
+		return null;
+	}
+
+	return getDisplayContentsListContainer(htmlElement.parentElement, tagName) ?? {
+		list: htmlElement,
+		container: htmlElement,
+	};
+}
+
+export function fixNotionLists(body: HTMLElement, tagName: 'ul' | 'ol') {
+	// Notion creates each list item within its own <ol> or <ul>, messing up newlines in the converted Markdown.
+	// Iterate all adjacent <ul>s or <ol>s and replace each string of adjacent lists with a single <ul> or <ol>.
+	for (const htmlList of Array.from(body.querySelectorAll(tagName)) as HTMLElement[]) {
+		const htmlLists: NotionListContainer[] = [];
+		const listItems: HTMLElement[] = [];
+		let nextAdjacentList = getNotionListContainer(htmlList, tagName);
+
+		while (nextAdjacentList) {
+			htmlLists.push(nextAdjacentList);
+			for (let i = 0; i < nextAdjacentList.list.children.length; i++) {
+				listItems.push(nextAdjacentList.list.children[i] as HTMLElement);
+			}
+			// classes are always "to-do-list, bulleted-list, or numbered-list"
+			const nextContainer = getNotionListContainer(nextAdjacentList.container.nextElementSibling, tagName);
+			if (!nextContainer || nextAdjacentList.list.getAttribute('class') !== nextContainer.list.getAttribute('class')) break;
+			nextAdjacentList = nextContainer;
+		}
+
+		const joinedList = body.ownerDocument.createElement(tagName);
+		for (const li of listItems) {
+			joinedList.appendChild(li);
+		}
+
+		htmlLists[0].container.replaceWith(joinedList);
+		htmlLists.slice(1).forEach(htmlList => htmlList.container.remove());
+	}
+}

--- a/tests/notion/lists.test.ts
+++ b/tests/notion/lists.test.ts
@@ -1,0 +1,138 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { fixNotionLists } from '../../src/formats/notion/lists';
+
+class TestElement {
+	tagName: string;
+	children: TestElement[] = [];
+	parentElement: TestElement | null = null;
+	private attrs = new Map<string, string>();
+
+	constructor(tagName: string, attrs: Record<string, string> = {}) {
+		this.tagName = tagName.toUpperCase();
+		for (const [key, value] of Object.entries(attrs)) {
+			this.attrs.set(key, value);
+		}
+	}
+
+	get ownerDocument() {
+		return {
+			createElement: (tagName: string) => new TestElement(tagName),
+		};
+	}
+
+	get firstElementChild() {
+		return this.children[0] ?? null;
+	}
+
+	get nextElementSibling() {
+		if (!this.parentElement) return null;
+		const index = this.parentElement.children.indexOf(this);
+		return this.parentElement.children[index + 1] ?? null;
+	}
+
+	getAttribute(name: string) {
+		return this.attrs.get(name) ?? null;
+	}
+
+	appendChild(child: TestElement) {
+		child.remove();
+		child.parentElement = this;
+		this.children.push(child);
+		return child;
+	}
+
+	replaceWith(replacement: TestElement) {
+		if (!this.parentElement) return;
+		const index = this.parentElement.children.indexOf(this);
+		if (index === -1) return;
+		replacement.parentElement = this.parentElement;
+		this.parentElement.children[index] = replacement;
+		this.parentElement = null;
+	}
+
+	remove() {
+		if (!this.parentElement) return;
+		const index = this.parentElement.children.indexOf(this);
+		if (index !== -1) {
+			this.parentElement.children.splice(index, 1);
+		}
+		this.parentElement = null;
+	}
+
+	querySelectorAll(tagName: string) {
+		const matches: TestElement[] = [];
+		const upperTagName = tagName.toUpperCase();
+		const visit = (element: TestElement) => {
+			for (const child of element.children) {
+				if (child.tagName === upperTagName) {
+					matches.push(child);
+				}
+				visit(child);
+			}
+		};
+		visit(this);
+		return matches;
+	}
+}
+
+function el(tagName: string, attrs: Record<string, string> = {}, children: TestElement[] = []) {
+	const element = new TestElement(tagName, attrs);
+	for (const child of children) {
+		element.appendChild(child);
+	}
+	return element;
+}
+
+function list(tagName: 'ul' | 'ol', listClass: string, items: string[]) {
+	return el(tagName, { class: listClass }, items.map(item => el('li', { text: item })));
+}
+
+function displayContentsList(tagName: 'ul' | 'ol', listClass: string, items: string[]) {
+	return el('div', { style: 'display:contents' }, [list(tagName, listClass, items)]);
+}
+
+function itemTexts(listElement: TestElement) {
+	return listElement.children.map(child => child.getAttribute('text'));
+}
+
+test('merges Notion ordered lists wrapped in display contents divs', () => {
+	const body = el('div', {}, [
+		displayContentsList('ol', 'numbered-list', ['Item A']),
+		displayContentsList('ol', 'numbered-list', ['Item B']),
+		displayContentsList('ol', 'numbered-list', ['Item C']),
+	]);
+
+	fixNotionLists(body as unknown as HTMLElement, 'ol');
+
+	assert.equal(body.children.length, 1);
+	assert.equal(body.children[0].tagName, 'OL');
+	assert.deepEqual(itemTexts(body.children[0]), ['Item A', 'Item B', 'Item C']);
+});
+
+test('keeps separate Notion list groups when classes differ across wrappers', () => {
+	const body = el('div', {}, [
+		displayContentsList('ol', 'numbered-list', ['Item A']),
+		displayContentsList('ol', 'other-list', ['Item B']),
+	]);
+
+	fixNotionLists(body as unknown as HTMLElement, 'ol');
+
+	assert.equal(body.children.length, 2);
+	assert.deepEqual(itemTexts(body.children[0]), ['Item A']);
+	assert.deepEqual(itemTexts(body.children[1]), ['Item B']);
+});
+
+test('still merges adjacent unwrapped Notion lists', () => {
+	const body = el('div', {}, [
+		list('ul', 'bulleted-list', ['Item A']),
+		list('ul', 'bulleted-list', ['Item B']),
+	]);
+
+	fixNotionLists(body as unknown as HTMLElement, 'ul');
+
+	assert.equal(body.children.length, 1);
+	assert.equal(body.children[0].tagName, 'UL');
+	assert.deepEqual(itemTexts(body.children[0]), ['Item A', 'Item B']);
+});


### PR DESCRIPTION
## Summary

Fixes #566.

Notion HTML exports can wrap each numbered list item in a `div` with `display:contents`, with every item stored in its own single-item `<ol start="N">`. The existing Notion list normalization only merged adjacent list elements, so these wrapper divs prevented the items from being joined before Markdown conversion.

This moves the Notion list normalization into a small tested helper and teaches it to treat those display-contents wrappers as merge containers while preserving the existing adjacent unwrapped list behavior.

## Validation

- `pnpm exec tsx --test tests/notion/lists.test.ts`
- `pnpm run test`
- `pnpm run build`
- `pnpm exec eslint src/formats/notion/convert-to-md.ts src/formats/notion/lists.ts tests/notion/lists.test.ts`
- `git diff --check HEAD^..HEAD`