### PR TITLE
Evernote: Preserve external URI links

### DIFF
--- a/src/formats/yarle/utils/link-hrefs.ts
+++ b/src/formats/yarle/utils/link-hrefs.ts
@@ -1,0 +1,8 @@
+const markdownHrefScheme = /^[A-Za-z][A-Za-z0-9+.-]*:/;
+const unsafeMarkdownHrefScheme = /^(?:javascript|data|vbscript):/i;
+
+export function isNormalMarkdownHref(href: string): boolean {
+	// Evernote note links are resolved after import so they need the internal-link path.
+	if (href.startsWith('evernote://')) return false;
+	return href.startsWith('www.') || (markdownHrefScheme.test(href) && !unsafeMarkdownHrefScheme.test(href));
+}

--- a/src/formats/yarle/utils/turndown-rules/internal-links-rule.ts
+++ b/src/formats/yarle/utils/turndown-rules/internal-links-rule.ts
@@ -3,6 +3,7 @@ import { RuntimePropertiesSingleton } from '../../runtime-properties';
 import { yarleOptions } from '../../yarle';
 
 import { normalizeTitle } from '../filename-utils';
+import { isNormalMarkdownHref } from '../link-hrefs';
 import { getTurndownService } from '../turndown-service';
 import { isTOC } from '../is-toc';
 
@@ -39,10 +40,6 @@ export const wikiStyleLinksRule = {
 		if (type === 'file') {
 			return `![[${realValue}]]`;
 		}
-		if (value.match(/^(https?:|www\.|file:|ftp:|mailto:)/)) {
-			return prefix + getShortLinkIfPossible(text, value);
-		}
-
 		if (value.startsWith('evernote://')) {
 			const fileName = normalizeTitle(text);
 			const noteIdNameMap = RuntimePropertiesSingleton.getInstance();
@@ -55,6 +52,9 @@ export const wikiStyleLinksRule = {
 			}
 
 			return prefix + `[[${value}]]`;
+		}
+		if (isNormalMarkdownHref(value)) {
+			return prefix + getShortLinkIfPossible(text, value);
 		}
 
 		return prefix + `[[${realValue}${text === realValue ? '' : `|${text}`}]]`;

--- a/tests/evernote/link-hrefs.test.ts
+++ b/tests/evernote/link-hrefs.test.ts
@@ -1,0 +1,28 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isNormalMarkdownHref } from '../../src/formats/yarle/utils/link-hrefs';
+
+test('treats app and phone URI schemes as normal Markdown links', () => {
+	assert.equal(isNormalMarkdownHref('tel:205-555-8260'), true);
+	assert.equal(isNormalMarkdownHref('x-soulver://open?doc=abc'), true);
+	assert.equal(isNormalMarkdownHref('busycalevent://event/123'), true);
+	assert.equal(isNormalMarkdownHref('app://example/path'), true);
+});
+
+test('keeps existing normal Markdown link schemes', () => {
+	assert.equal(isNormalMarkdownHref('https://example.com'), true);
+	assert.equal(isNormalMarkdownHref('http://example.com'), true);
+	assert.equal(isNormalMarkdownHref('ftp://example.com/file.txt'), true);
+	assert.equal(isNormalMarkdownHref('file:///Users/example/file.txt'), true);
+	assert.equal(isNormalMarkdownHref('mailto:user@example.com'), true);
+	assert.equal(isNormalMarkdownHref('www.example.com'), true);
+});
+
+test('does not treat note names or unsafe schemes as normal Markdown links', () => {
+	assert.equal(isNormalMarkdownHref('Project note'), false);
+	assert.equal(isNormalMarkdownHref('evernote://view/123/abc'), false);
+	assert.equal(isNormalMarkdownHref('javascript:alert(1)'), false);
+	assert.equal(isNormalMarkdownHref('data:text/html;base64,PGgxPkhlbGxvPC9oMT4='), false);
+	assert.equal(isNormalMarkdownHref('vbscript:msgbox(1)'), false);
+});


### PR DESCRIPTION
## Summary

Fixes #214.

Evernote links with URI schemes such as `tel:`, `app:`, `x-soulver:`, or `busycalevent:` currently fall through to the wiki-link path, which turns them into non-clickable Obsidian links. This treats normal URI schemes as Markdown links while keeping `evernote://` on the existing internal Evernote note-link resolution path.

The helper also avoids creating normal Markdown links for script/data schemes.

## Validation

- `pnpm exec tsx --test tests/evernote/link-hrefs.test.ts`
- `pnpm run test`
- `pnpm run build`
- `pnpm exec eslint src/formats/yarle/utils/link-hrefs.ts src/formats/yarle/utils/turndown-rules/internal-links-rule.ts tests/evernote/link-hrefs.test.ts`
- `git diff --check HEAD^..HEAD`