### PR TITLE
Apple Notes: Import same-title notes as copies

### DIFF
--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -34,6 +34,7 @@ export class AppleNotesImporter extends FormatImporter {
 	resolvedAccounts: Record<number, ANAccount> = {};
 	resolvedFiles: Record<number, TFile> = {};
 	resolvedFolders: Record<number, TFolder> = {};
+	claimedNotePaths = new Set<string>();
 
 	multiAccount = false;
 	noteCount = 0;
@@ -301,10 +302,14 @@ export class AppleNotesImporter extends FormatImporter {
 			title = `${datePrefix} ${title}`;
 		}
 
-		const fullPath = path.join(folder.path, `${title}.md`);
+		const fileName = `${title}.md`;
+		const fullPath = this.getNotePath(folder, fileName);
+		const currentImportCollision = this.claimedNotePaths.has(fullPath);
 
 		// Check for duplicate notes based on the selected handling option
-		const existingFile = this.vault.getAbstractFileByPath(fullPath);
+		const existingFile = currentImportCollision
+			? null
+			: this.vault.getAbstractFileByPath(fullPath);
 
 		if (existingFile && existingFile instanceof TFile) {
 			if (this.duplicateHandling === DuplicateHandling.Skip) {
@@ -318,6 +323,7 @@ export class AppleNotesImporter extends FormatImporter {
 
 				// Only skip if the Apple Note hasn't been modified since the existing file
 				if (appleNoteModTime <= existingFileModTime) {
+					this.claimedNotePaths.add(fullPath);
 					this.ctx.reportSkipped(row.ZTITLE1, 'note unchanged since last import');
 					return existingFile;
 				}
@@ -326,7 +332,8 @@ export class AppleNotesImporter extends FormatImporter {
 			// For CreateCopy option, we continue without skipping (will create numbered copy)
 		}
 
-		const file = await this.saveAsMarkdownFile(folder, `${title}.md`, '');
+		const file = await this.saveAsMarkdownFile(folder, fileName, '', currentImportCollision);
+		this.claimedNotePaths.add(file.path);
 
 		this.ctx.status(`Importing note ${title}`);
 		this.resolvedFiles[id] = file;
@@ -487,6 +494,10 @@ export class AppleNotesImporter extends FormatImporter {
 		return new converterType(this, decoded);
 	}
 
+	getNotePath(folder: TFolder, fileName: string): string {
+		return path.join(folder.path, sanitizeFileName(fileName));
+	}
+
 	decodeTime(timestamp: number): number {
 		if (!timestamp || timestamp < 1) return new Date().getTime();
 		return Math.floor((timestamp + CORETIME_OFFSET) * 1000);
@@ -501,8 +512,8 @@ export class AppleNotesImporter extends FormatImporter {
 		}
 	}
 
-	async saveAsMarkdownFile(folder: TFolder, title: string, content: string): Promise<TFile> {
-		if (this.duplicateHandling === DuplicateHandling.Skip || this.duplicateHandling === DuplicateHandling.ImportUpdated) {
+	async saveAsMarkdownFile(folder: TFolder, title: string, content: string, createCopy = false): Promise<TFile> {
+		if (!createCopy && (this.duplicateHandling === DuplicateHandling.Skip || this.duplicateHandling === DuplicateHandling.ImportUpdated)) {
 			// For Skip and ImportUpdated, create the file directly without numeric suffix
 			const sanitizedName = sanitizeFileName(title);
 			const fullPath = path.join(folder.path, sanitizedName);

--- a/tests/apple-notes/duplicate-titles.test.ts
+++ b/tests/apple-notes/duplicate-titles.test.ts
@@ -1,0 +1,175 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import Module from 'node:module';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import url from 'node:url';
+import zlib from 'node:zlib';
+import crypto from 'node:crypto';
+import childProcess from 'node:child_process';
+
+(globalThis as typeof globalThis & { window: { require: (request: string) => unknown } }).window = {
+	require: ((request: string) => {
+		switch (request) {
+			case 'node:original-fs':
+				return fs;
+			case 'node:os':
+				return os;
+			case 'node:path':
+				return path;
+			case 'node:url':
+				return url;
+			case 'node:zlib':
+				return zlib;
+			case 'node:crypto':
+				return crypto;
+			case 'node:child_process':
+				return childProcess;
+			default:
+				throw new Error(`Unexpected window.require(${request})`);
+		}
+	}),
+};
+
+class TFile {
+	path: string;
+	content: string;
+	stat: { mtime: number };
+
+	constructor(path: string, content = '') {
+		this.path = path;
+		this.content = content;
+		this.stat = { mtime: 0 };
+	}
+}
+
+class TFolder {
+	path: string;
+
+	constructor(path: string) {
+		this.path = path;
+	}
+}
+
+const load = Module._load;
+Module._load = function (request: string, parent: NodeModule | null, isMain: boolean) {
+	if (request === 'obsidian') {
+		return {
+			Notice: class {},
+			Platform: { isDesktop: true, isDesktopApp: true, isMacOS: true },
+			Setting: class {},
+			TFile,
+			TFolder,
+			moment: () => ({ format: () => '2026-06-20' }),
+		};
+	}
+
+	return load.apply(this, [request, parent, isMain]);
+};
+
+type FakeFile = {
+	path: string;
+	content: string;
+	stat: {
+		mtime: number;
+	};
+};
+
+async function makeImporter(rows: Record<number, Record<string, unknown>>) {
+	const { AppleNotesImporter } = await import('../../src/formats/apple-notes');
+	const folder = new TFolder('Apple Notes');
+	const files = new Map<string, FakeFile>();
+
+	const importer = Object.create(AppleNotesImporter.prototype);
+	Object.assign(importer, {
+		app: {
+			fileManager: {
+				async createNewMarkdownFile(targetFolder: typeof folder, title: string, content: string) {
+					const ext = title.endsWith('.md') ? '.md' : '';
+					const base = ext ? title.slice(0, -ext.length) : title;
+					let path = `${targetFolder.path}/${title}`;
+					let i = 1;
+					while (files.has(path)) {
+						path = `${targetFolder.path}/${base} ${i}${ext}`;
+						i++;
+					}
+
+					const file = new TFile(path, content);
+					files.set(path, file);
+					return file;
+				},
+			},
+		},
+		ctx: {
+			status() {},
+			reportFailed() {},
+			reportNoteSuccess() {},
+			reportProgress() {},
+			reportSkipped() {},
+		},
+		vault: {
+			getAbstractFileByPath(targetPath: string) {
+				return files.get(targetPath);
+			},
+			modify(file: FakeFile, content: string, options: { mtime?: number } = {}) {
+				file.content = content;
+				if (options.mtime) file.stat.mtime = options.mtime;
+			},
+		},
+		database: {
+			async get(_strings: TemplateStringsArray, ...values: unknown[]) {
+				const id = values.at(-1) as number;
+				return rows[id];
+			},
+		},
+		resolvedFiles: {},
+		resolvedFolders: { 1: folder },
+		rootFolder: folder,
+		owners: { 1: 1 },
+		filePrefixFormat: '',
+		duplicateHandling: 'import-updated',
+		claimedNotePaths: new Set<string>(),
+		noteCount: Object.keys(rows).length,
+		parsedNotes: 0,
+	});
+
+	importer.decodeData = (hexdata: string) => ({
+		format: async () => `Body for ${hexdata}`,
+	}) as never;
+
+	return { importer, files };
+}
+
+test('Apple Notes same-title source notes import as separate files', async () => {
+	const { importer, files } = await makeImporter({
+		1: {
+			zhexdata: 'first',
+			ZTITLE1: 'Shared title',
+			ZFOLDER: 1,
+			ZCREATIONDATE1: 1,
+			ZCREATIONDATE2: null,
+			ZCREATIONDATE3: null,
+			ZMODIFICATIONDATE1: 2,
+			ZISPASSWORDPROTECTED: false,
+		},
+		2: {
+			zhexdata: 'second',
+			ZTITLE1: 'Shared title',
+			ZFOLDER: 1,
+			ZCREATIONDATE1: 3,
+			ZCREATIONDATE2: null,
+			ZCREATIONDATE3: null,
+			ZMODIFICATIONDATE1: 4,
+			ZISPASSWORDPROTECTED: false,
+		},
+	});
+
+	const first = await importer.resolveNote(1);
+	const second = await importer.resolveNote(2);
+
+	assert.equal(first?.path, 'Apple Notes/Shared title.md');
+	assert.equal(second?.path, 'Apple Notes/Shared title 1.md');
+	assert.equal(files.get('Apple Notes/Shared title.md')?.content, 'Body for first');
+	assert.equal(files.get('Apple Notes/Shared title 1.md')?.content, 'Body for second');
+});


### PR DESCRIPTION
## Summary

Fixes #554.

Apple Notes can contain multiple notes with the same title. During one import, the first note created `Title.md`, then later same-title source notes resolved the same output path and reused that existing file under the default duplicate handling mode. The later notes were effectively collapsed into the first output file.

This keeps track of note paths already claimed during the current Apple Notes import. If a later source note would use the same path, it falls through to Obsidian's normal copy creation path so the notes are imported as `Title.md`, `Title 1.md`, etc. Existing vault files still use the existing duplicate-handling behavior for repeat imports.

## Validation

- `pnpm exec tsx --test tests/apple-notes/duplicate-titles.test.ts`
- `pnpm run test`
- `pnpm run build`
- `pnpm exec eslint src/formats/apple-notes.ts tests/apple-notes/duplicate-titles.test.ts`
- `git diff --check origin/master...HEAD`
