### PR TITLE
Notion: Preserve formatted number properties

### DIFF
--- a/src/formats/notion/convert-to-md.ts
+++ b/src/formats/notion/convert-to-md.ts
@@ -18,6 +18,7 @@ import {
 	stripNotionId,
 	stripParentDirectories,
 } from './notion-utils';
+import { parseNotionNumberPropertyValue } from './property-values';
 
 export async function readToMarkdown(info: NotionResolverInfo, file: ZipEntryFile): Promise<string> {
 	const text = await file.readText();
@@ -146,8 +147,7 @@ function parseProperty(property: HTMLTableRowElement): YamlProperty | undefined 
 			content = body.innerHTML.includes('checkbox-on');
 			break;
 		case 'number':
-			content = Number(body.textContent);
-			if (isNaN(content)) return;
+			content = parseNotionNumberPropertyValue(body.textContent);
 			break;
 		case 'date':
 			fixNotionDates(body);

--- a/src/formats/notion/property-values.ts
+++ b/src/formats/notion/property-values.ts
@@ -1,0 +1,6 @@
+export function parseNotionNumberPropertyValue(text: string | null): number | string {
+	const rawValue = text ?? '';
+	const value = Number(rawValue);
+
+	return Number.isNaN(value) ? rawValue.trim() : value;
+}

--- a/tests/notion/properties.test.ts
+++ b/tests/notion/properties.test.ts
@@ -1,0 +1,14 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseNotionNumberPropertyValue } from '../../src/formats/notion/property-values';
+
+test('plain Notion number properties stay numeric', () => {
+	assert.equal(parseNotionNumberPropertyValue('67.3'), 67.3);
+	assert.equal(parseNotionNumberPropertyValue(' -42 '), -42);
+});
+
+test('formatted Notion number properties are preserved as text', () => {
+	assert.equal(parseNotionNumberPropertyValue('R$67.3'), 'R$67.3');
+	assert.equal(parseNotionNumberPropertyValue('$1,234.56'), '$1,234.56');
+});


### PR DESCRIPTION
## Summary
- Preserve formatted Notion number property values that cannot be parsed as JavaScript numbers instead of dropping them.
- Keep plain numeric Notion property values serialized as numbers.

Fixes #407

## Validation
- `pnpm exec tsx --test tests/notion/properties.test.ts`
- `pnpm run test`
- `pnpm run build`
- `pnpm exec eslint src/formats/notion/convert-to-md.ts src/formats/notion/property-values.ts tests/notion/properties.test.ts`
- `git diff --check origin/master...HEAD`