### PR TITLE
Fix OneNote progress for skipped pages

### DIFF
--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -458,6 +458,7 @@ export class OneNoteImporter extends FormatImporter {
 
 				if (!this.importPreviouslyImported && page.id && previouslyImported.has(page.id)) {
 					progress.reportSkipped(page.title, 'it was previously imported');
+					progress.reportProgress(++progressCurrent, progressTotal);
 					continue;
 				}
 


### PR DESCRIPTION
## Summary

When the OneNote importer skips a previously imported page, it currently reports the skip and then continues without updating the progress counter. This can leave the remaining count and progress bar behind the actual number of processed pages.

This change updates progress before continuing when a previously imported page is skipped.

## Validation

- `npx -y pnpm@10.20.0 run build`
- `npx -y pnpm@10.20.0 test`
