### PR TITLE
Keep: avoid overwriting existing note paths

### DIFF
--- a/src/formats/keep-json.ts
+++ b/src/formats/keep-json.ts
@@ -1,10 +1,11 @@
-import { FrontMatterCache, Notice, Setting, TFolder } from 'obsidian';
+import { FrontMatterCache, Notice, Setting, TFile, TFolder } from 'obsidian';
 import { PickedFile } from '../filesystem';
 import { FormatImporter } from '../format-importer';
 import { ATTACHMENT_EXTS, ImportContext } from '../main';
 import { serializeFrontMatter } from '../util';
 import { readZip, ZipEntryFile } from '../zip';
 import { KeepJson } from './keep/models';
+import { getAvailableKeepMarkdownPath } from './keep/paths';
 import { sanitizeTag, sanitizeTags, toSentenceCase } from './keep/util';
 
 
@@ -201,12 +202,22 @@ export class KeepImporter extends FormatImporter {
 			}
 		}
 
-		const file = await this.saveAsMarkdownFile(folder, filename, mdContent.join(''));
+		const file = await this.saveKeepMarkdownFile(folder, filename, mdContent.join(''));
 
 		// Modifying the creation and modified timestamps without changing file contents.
 		await this.vault.append(file, '', {
 			ctime: keepJson.createdTimestampUsec / 1000,
 			mtime: keepJson.userEditedTimestampUsec / 1000,
 		});
+	}
+
+	async saveKeepMarkdownFile(folder: TFolder, filename: string, content: string): Promise<TFile> {
+		const filePath = getAvailableKeepMarkdownPath(
+			path => this.vault.getAbstractFileByPathInsensitive(path) !== null,
+			folder.path,
+			filename,
+		);
+
+		return await this.vault.create(filePath, content);
 	}
 }

--- a/src/formats/keep/paths.ts
+++ b/src/formats/keep/paths.ts
@@ -1,0 +1,29 @@
+import { sanitizeFileName } from '../../sanitize';
+
+export function getKeepMarkdownBasePath(folderPath: string, filename: string): string {
+	const sanitizedName = sanitizeFileName(filename);
+	const parentPath = folderPath === '/' ? '' : normalizeFolderPath(folderPath);
+
+	return parentPath ? `${parentPath}/${sanitizedName}` : sanitizedName;
+}
+
+export function getAvailableKeepMarkdownPath(
+	fileExists: (path: string) => boolean,
+	folderPath: string,
+	filename: string,
+): string {
+	const basePath = getKeepMarkdownBasePath(folderPath, filename);
+	let path = `${basePath}.md`;
+	let counter = 1;
+
+	while (fileExists(path)) {
+		path = `${basePath} ${counter}.md`;
+		counter++;
+	}
+
+	return path;
+}
+
+function normalizeFolderPath(folderPath: string): string {
+	return folderPath.split('/').filter(Boolean).join('/');
+}

--- a/src/sanitize.ts
+++ b/src/sanitize.ts
@@ -1,0 +1,26 @@
+let slashesRe = /[/\\]/g;
+let illegalRe = /[\?<>:\*\|"]/g;
+let controlRe = /[\x00-\x1f\x80-\x9f]/g;
+let reservedRe = /^\.+$/;
+let windowsReservedRe = /^(con|prn|aux|nul|com[0-9]|lpt[0-9])(\..*)?$/i;
+let windowsTrailingRe = /[\. ]+$/;
+let startsWithDotRe = /^\./; // Regular expression to match filenames starting with "."
+let badLinkRe = /[\[\]#|^]/g; // Regular expression to match characters that interferes with links: [ ] # | ^
+
+// First remove illegal characters such as spaces and periods, then check for Windows reserved words.
+export function sanitizeFileName(name: string) {
+	const sanitized = name
+		.replace(slashesRe, '-') // Replace slashes with dash
+		.replace(illegalRe, '')
+		.replace(controlRe, '')
+		.replace(reservedRe, '')
+		.replace(windowsTrailingRe, '')
+		.replace(windowsReservedRe, '')
+		.replace(startsWithDotRe, '')
+		.replace(badLinkRe, '');
+
+	// If the result is empty or only whitespace after sanitization, return a default name
+	// This prevents creating files like ".md" (no name) or folders with only spaces
+	const trimmed = sanitized.trim();
+	return trimmed || 'Untitled';
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,31 +1,5 @@
 import { FrontMatterCache, stringifyYaml } from 'obsidian';
-
-let slashesRe = /[/\\]/g;
-let illegalRe = /[\?<>:\*\|"]/g;
-let controlRe = /[\x00-\x1f\x80-\x9f]/g;
-let reservedRe = /^\.+$/;
-let windowsReservedRe = /^(con|prn|aux|nul|com[0-9]|lpt[0-9])(\..*)?$/i;
-let windowsTrailingRe = /[\. ]+$/;
-let startsWithDotRe = /^\./; // Regular expression to match filenames starting with "."
-let badLinkRe = /[\[\]#|^]/g; // Regular expression to match characters that interferes with links: [ ] # | ^
-
-// First remove illegal characters such as spaces and periods, then check for Windows reserved words.
-export function sanitizeFileName(name: string) {
-	const sanitized = name
-		.replace(slashesRe, '-') // Replace slashes with dash
-		.replace(illegalRe, '')
-		.replace(controlRe, '')
-		.replace(reservedRe, '')
-		.replace(windowsTrailingRe, '')
-		.replace(windowsReservedRe, '')
-		.replace(startsWithDotRe, '')
-		.replace(badLinkRe, '');
-
-	// If the result is empty or only whitespace after sanitization, return a default name
-	// This prevents creating files like ".md" (no name) or folders with only spaces
-	const trimmed = sanitized.trim();
-	return trimmed || 'Untitled';
-}
+export { sanitizeFileName } from './sanitize';
 
 export function genUid(length: number): string {
 	let array: string[] = [];

--- a/tests/keep/unique-filenames.test.ts
+++ b/tests/keep/unique-filenames.test.ts
@@ -1,0 +1,40 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getAvailableKeepMarkdownPath } from '../../src/formats/keep/paths';
+
+test('resolves Google Keep note imports to a unique markdown path', () => {
+	const files = new Set<string>(['Google Keep/Shopping.md']);
+
+	const path = getAvailableKeepMarkdownPath(
+		path => files.has(path),
+		'Google Keep',
+		'Shopping',
+	);
+
+	assert.equal(path, 'Google Keep/Shopping 1.md');
+});
+
+test('scopes Google Keep note imports to the output folder', () => {
+	const files = new Set<string>(['Archive/Shopping.md']);
+
+	const path = getAvailableKeepMarkdownPath(
+		path => files.has(path),
+		'Google Keep',
+		'Shopping',
+	);
+
+	assert.equal(path, 'Google Keep/Shopping.md');
+});
+
+test('sanitizes Google Keep note filenames before resolving collisions', () => {
+	const files = new Set<string>(['Google Keep/Untitled.md']);
+
+	const path = getAvailableKeepMarkdownPath(
+		path => files.has(path),
+		'Google Keep',
+		'???',
+	);
+
+	assert.equal(path, 'Google Keep/Untitled 1.md');
+});


### PR DESCRIPTION
Fixes #583.

## Summary
- write Google Keep Markdown notes to an explicitly resolved vault path instead of the untyped FileManager helper
- preserve existing notes by suffixing collisions in the selected output folder, e.g. `Shopping 1.md`
- move filename sanitizing into a pure module so Keep path behavior can be tested without loading Obsidian runtime APIs

## Validation
- `pnpm exec tsx --test tests/keep/unique-filenames.test.ts`
- `pnpm exec eslint src/sanitize.ts src/formats/keep/paths.ts src/formats/keep-json.ts tests/keep/unique-filenames.test.ts`
- `pnpm run test`
- `pnpm run build`
- `git diff --check`