### PR TITLE
Notion: preserve bare URL links

### DIFF
--- a/src/formats/notion/convert-to-md.ts
+++ b/src/formats/notion/convert-to-md.ts
@@ -18,6 +18,7 @@ import {
 	stripNotionId,
 	stripParentDirectories,
 } from './notion-utils';
+import { preserveBareUrlLinks } from './markdown-links';
 
 export async function readToMarkdown(info: NotionResolverInfo, file: ZipEntryFile): Promise<string> {
 	const text = await file.readText();
@@ -88,6 +89,7 @@ export async function readToMarkdown(info: NotionResolverInfo, file: ZipEntryFil
 
 	markdownBody = escapeHashtags(markdownBody);
 	markdownBody = fixDoubleBackslash(markdownBody);
+	markdownBody = preserveBareUrlLinks(markdownBody);
 
 	const description = dom.find('p[class*=page-description]')?.textContent;
 	if (description) markdownBody = description + '\n\n' + markdownBody;

--- a/src/formats/notion/markdown-links.ts
+++ b/src/formats/notion/markdown-links.ts
@@ -1,0 +1,16 @@
+const sameTextUrlLink = /(^|[^!])\[([^\]\n]+)\]\(((?:https?:\/\/|www\.)[^\s)]+)\)/g;
+const escapedMarkdownPunctuation = /\\([\\`*_[\]{}()#+.!-])/g;
+
+function normalizeUrlText(value: string) {
+	return value.trim().replace(escapedMarkdownPunctuation, '$1');
+}
+
+export function preserveBareUrlLinks(markdownBody: string) {
+	return markdownBody.replace(sameTextUrlLink, (match, prefix: string, text: string, url: string) => {
+		if (normalizeUrlText(text) !== normalizeUrlText(url)) {
+			return match;
+		}
+
+		return `${prefix}${url}`;
+	});
+}

--- a/tests/notion/markdown-links.test.ts
+++ b/tests/notion/markdown-links.test.ts
@@ -1,0 +1,37 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { preserveBareUrlLinks } from '../../src/formats/notion/markdown-links';
+
+test('preserves bare URL links emitted by Notion HTML export', () => {
+	const markdown = [
+		'Links:',
+		'[https://example.com](https://example.com)',
+		'[http://example.com/path?x=1#top](http://example.com/path?x=1#top)',
+		'[www.example.com](www.example.com)',
+	].join('\n');
+
+	assert.equal(preserveBareUrlLinks(markdown), [
+		'Links:',
+		'https://example.com',
+		'http://example.com/path?x=1#top',
+		'www.example.com',
+	].join('\n'));
+});
+
+test('keeps descriptive, mismatched, and image links unchanged', () => {
+	const markdown = [
+		'[Example](https://example.com)',
+		'[https://example.com](https://example.org)',
+		'![https://example.com](https://example.com)',
+	].join('\n');
+
+	assert.equal(preserveBareUrlLinks(markdown), markdown);
+});
+
+test('matches URLs whose display text was markdown-escaped', () => {
+	assert.equal(
+		preserveBareUrlLinks('[https://example.com/a\\_b](https://example.com/a_b)'),
+		'https://example.com/a_b'
+	);
+});


### PR DESCRIPTION
## Summary

Fixes #376.

Notion HTML exports can represent a bare URL as an anchor whose text is the same URL. Obsidian's HTML-to-Markdown conversion turns that into verbose Markdown like `[https://example.com](https://example.com)`. This keeps those same-text HTTP/WWW links as bare URLs while leaving descriptive links, mismatched links, and image links unchanged.

## Validation

- `pnpm exec tsx --test tests/notion/markdown-links.test.ts`
- `pnpm run test`
- `pnpm run build`
- `pnpm exec eslint src/formats/notion/markdown-links.ts src/formats/notion/convert-to-md.ts tests/notion/markdown-links.test.ts`
- `git diff --check`
