### PR TITLE
Evernote: Preserve intra-word underscores

### DIFF
--- a/src/formats/yarle/convert-html-to-md.ts
+++ b/src/formats/yarle/convert-html-to-md.ts
@@ -2,6 +2,7 @@ import { NoteData } from './models/NoteData';
 import { YarleOptions } from './options';
 
 import { getTurndownService } from './utils/turndown-service';
+import { restoreIntraWordEscapedUnderscores } from './utils/markdown-escaping';
 
 const unwrapElement = (node: Element) => {
 	node.replaceWith(...Array.from(node.children));
@@ -93,6 +94,7 @@ export const convertHtml2Md = (yarleOptions: YarleOptions, { htmlContent }: Note
 
 	const newLinePlaceholder = new RegExp('<YARLE_NEWLINE_PLACEHOLDER>', 'g');
 	contentInMd = contentInMd.replace(newLinePlaceholder, '');
+	contentInMd = restoreIntraWordEscapedUnderscores(contentInMd);
 
 	return contentInMd && contentInMd !== 'undefined' ? { content: contentInMd } : { content: '' };
 };

--- a/src/formats/yarle/utils/markdown-escaping.ts
+++ b/src/formats/yarle/utils/markdown-escaping.ts
@@ -1,0 +1,5 @@
+const intraWordEscapedUnderscore = /([\p{L}\p{N}])\\_(?=[\p{L}\p{N}])/gu;
+
+export const restoreIntraWordEscapedUnderscores = (content: string): string => {
+	return content.replace(intraWordEscapedUnderscore, '$1_');
+};

--- a/tests/evernote/markdown-escaping.test.ts
+++ b/tests/evernote/markdown-escaping.test.ts
@@ -1,0 +1,39 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { restoreIntraWordEscapedUnderscores } from '../../src/formats/yarle/utils/markdown-escaping';
+
+test('restores escaped underscores inside words', () => {
+	assert.equal(
+		restoreIntraWordEscapedUnderscores('A file named foo\\_bar.txt was imported.'),
+		'A file named foo_bar.txt was imported.'
+	);
+});
+
+test('restores repeated intra-word underscores', () => {
+	assert.equal(
+		restoreIntraWordEscapedUnderscores('one\\_two\\_three'),
+		'one_two_three'
+	);
+});
+
+test('restores intra-word underscores between Unicode letters', () => {
+	assert.equal(
+		restoreIntraWordEscapedUnderscores('cafe\\_moka and café\\_moka'),
+		'cafe_moka and café_moka'
+	);
+});
+
+test('preserves escapes used for Markdown emphasis delimiters', () => {
+	assert.equal(
+		restoreIntraWordEscapedUnderscores('\\_emphasis\\_ and word \\_ word'),
+		'\\_emphasis\\_ and word \\_ word'
+	);
+});
+
+test('preserves underscores outside word boundaries', () => {
+	assert.equal(
+		restoreIntraWordEscapedUnderscores('\\_leading trailing\\_ foo\\__bar'),
+		'\\_leading trailing\\_ foo\\__bar'
+	);
+});


### PR DESCRIPTION
## Summary

Fixes #189.

- restore Turndown-escaped underscores when they are inside words, such as `foo\_bar.txt`
- keep escapes around Markdown emphasis delimiters and non-word-boundary underscores unchanged
- add a focused regression test for repeated, Unicode, and delimiter cases

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm exec tsx --test tests/evernote/markdown-escaping.test.ts`
- `pnpm run test`
- `pnpm run build`
- `pnpm exec eslint src/formats/yarle/convert-html-to-md.ts src/formats/yarle/utils/markdown-escaping.ts tests/evernote/markdown-escaping.test.ts`
- `git diff --check`