### PR TITLE
Add Logseq Markdown graph importer

### DIFF
--- a/docs/logseq-importer-assessment.md
+++ b/docs/logseq-importer-assessment.md
@@ -1,0 +1,644 @@
+# Logseq to Obsidian Importer: Assessment and Roadmap
+
+This document assesses what it would take to add a first-class **Logseq** importer to the
+official [obsidian-importer](https://github.com/obsidianmd/obsidian-importer) plugin. Today
+Logseq graphs can only be brought in via the generic "Markdown files" path, which ignores
+the many Logseq-specific conventions. The goal here is a comprehensive, low-loss migration
+of a Logseq markdown graph into an Obsidian vault.
+
+Contents:
+
+1. How an Obsidian importer works (the contract a new importer must satisfy)
+2. Prior-art inventory: what existing tools already solve, and their gaps
+3. Logseq vs Obsidian feature-mapping catalog
+4. The outline problem and the configurable structure design
+5. Handling of un-migratable / lossy features
+6. Phased implementation roadmap
+7. Declared limitations and conscious tradeoffs
+
+---
+
+## 1. How an Obsidian importer works
+
+The importer is an Obsidian plugin. Each supported source app is an **importer class** that
+extends a common base and is registered in a central map. Understanding this contract tells
+us exactly what a Logseq importer must implement and which extension points are available
+for resolving ambiguities through user options.
+
+### 1.1 The `FormatImporter` contract
+
+Every importer extends `FormatImporter` ([src/format-importer.ts](../src/format-importer.ts))
+and is registered in `ImporterPlugin.importers` ([src/main.ts](../src/main.ts)). The two
+methods that matter:
+
+- `init()` — **abstract**. Builds the importer's UI inside the modal (file/folder pickers,
+  output-folder field, and any option toggles/dropdowns). Called from the constructor.
+- `import(ctx: ImportContext)` — **abstract**. Does the actual work: read input, convert,
+  write into the vault, report progress.
+
+Optional hooks: `showTemplateConfiguration(ctx, container)` for a pre-import wizard (only the
+CSV importer uses it today), and `registerAuthCallback()` for OAuth-based importers
+(OneNote, Notion API). A `notAvailable` flag lets an importer disable itself on unsupported
+platforms (e.g. Apple Notes off macOS).
+
+### 1.2 Built-in UI helpers (how options are exposed)
+
+User-resolvable ambiguities are surfaced as Obsidian `Setting` widgets appended to
+`this.modal.contentEl` inside `init()`. The base class provides:
+
+- `addFileChooserSetting(name, extensions, allowMultiple?)` — desktop file/folder picker
+  (Electron dialog); populates `this.files: PickedFile[]`. For Logseq we pick the **graph
+  folder**.
+- `addOutputLocationSetting(defaultFolderName)` — vault-relative output folder; stored in
+  `this.outputLocation`.
+
+Concrete option pattern, from the Roam importer ([src/formats/roam-json.ts](../src/formats/roam-json.ts)):
+
+```ts
+new Setting(this.modal.contentEl)
+  .setName('Download all attachments')
+  .addToggle(toggle => toggle.setValue(this.downloadAttachments).onChange(v => this.downloadAttachments = v));
+```
+
+Dropdowns (`addDropdown`), text fields (`addText`), and toggles (`addToggle`) are all used by
+existing importers — this is how we will expose the outline mode, task-state strategy, etc.
+
+### 1.3 Progress and results: `ImportContext`
+
+`import(ctx)` receives an `ImportContext` ([src/main.ts](../src/main.ts)) used to drive the
+progress UI and the final report:
+
+- `ctx.status(message)` — current task label
+- `ctx.reportProgress(current, total)` — progress bar
+- `ctx.reportNoteSuccess(name)` / `ctx.reportAttachmentSuccess(name)`
+- `ctx.reportSkipped(name, reason)` / `ctx.reportFailed(name, reason)`
+- `ctx.isCancelled()` — checked in the import loop so the Stop button works
+
+The `skipped`/`failed` collections are how we will surface un-migratable content (queries,
+whiteboards, etc.) to the user rather than silently dropping it.
+
+### 1.4 Writing into the vault
+
+- `saveAsMarkdownFile(folder, title, content)` — sanitizes the title and creates the note.
+- `vault.create(path, content)` / `vault.modify(file, content)` — used directly when paths
+  are precomputed (Roam does this so it can build nested folders for namespaced pages).
+- `createFolders(path)` — recursive folder creation.
+- `getAvailablePathForAttachment(filename, claimedPaths)` — resolves a collision-free
+  attachment path respecting the user's attachment-folder settings.
+- `vault.createBinary(path, data)` — writes asset bytes.
+- Filename safety: `sanitizeFileName()` ([src/util.ts](../src/util.ts)) and
+  `sanitizeFileNameKeepPath()` ([src/formats/roam/utils.ts](../src/formats/roam/utils.ts),
+  preserves `/` for nested page paths).
+
+Cross-platform filesystem access is via [src/filesystem.ts](../src/filesystem.ts)
+(`PickedFile`, `getAllFiles`, `parseFilePath`) and [src/zip.ts](../src/zip.ts); importers are
+expected to use these instead of importing Node modules directly.
+
+### 1.5 The closest existing models
+
+- **Roam Research** ([src/formats/roam-json.ts](../src/formats/roam-json.ts)) is the nearest
+  analogue: an outliner with nested bullets, `((block refs))`, daily notes, and `[[wikilinks]]`.
+  Its **two-pass block-reference resolution** ([src/formats/roam/block-refs.ts](../src/formats/roam/block-refs.ts))
+  — collect a `uid -> {page, text}` index, then rewrite `((uid))` into
+  `[[page#^uid|text]]` and append `^uid` to the source line — is directly reusable for Logseq's
+  `id::` / `((uid))` model. (Roam imports a single JSON export, though; Logseq is markdown on disk.)
+- **Bear** ([src/formats/bear-bear2bk.ts](../src/formats/bear-bear2bk.ts)) and **Textbundle**
+  ([src/formats/textbundle.ts](../src/formats/textbundle.ts)) are the models for **markdown
+  files on disk plus an `assets/` folder**: copy assets via `getAvailablePathForAttachment` and
+  rewrite the links. Logseq's layout is closer to these than to Roam's.
+
+### 1.6 Tests and build
+
+Tests run with the Node test runner: `pnpm test` → `tsx --test tests/**/*.test.ts`. The one
+substantive suite is [tests/roam/block-refs.test.ts](../tests/roam/block-refs.test.ts), which
+sweeps a fixture graph. Build is esbuild (`pnpm dev` watch, `pnpm build` production). A new
+importer is a new file under `src/formats/` plus one entry in the `importers` map in
+[src/main.ts](../src/main.ts).
+
+```ts
+// src/main.ts — registration shape
+'logseq': {
+  name: 'Logseq',
+  optionText: 'Logseq',
+  importer: LogseqImporter,
+  helpPermalink: 'import/logseq',
+},
+```
+
+---
+
+## 2. Prior-art inventory
+
+Three community tools live under [prior-art/](../prior-art/). Together they cover most of the
+"easy" conversions; none does outline flattening or the harder Logseq-only features.
+
+### 2.1 `laughedelic_outbreak` (Obsidian -> Logseq; the *opposite* direction)
+
+TypeScript/Deno. Direction is reversed from ours, but it is the most valuable **specification**
+because it documents the mappings carefully and implements a clean **outline model** that we
+must *invert*.
+
+- [prior-art/laughedelic_outbreak/syntax-differences.md](../prior-art/laughedelic_outbreak/syntax-differences.md)
+  — authoritative catalog of task, date, priority, link, frontmatter, callout, embed, highlight,
+  and numbered-list mappings (the basis of section 3).
+- [prior-art/laughedelic_outbreak/structure-difference.md](../prior-art/laughedelic_outbreak/structure-difference.md)
+  — defines the flat-markdown ↔ outline transform (the basis of section 4).
+- `translate.ts` / `outline.ts` — syntax rules + a heading-stack outliner that turns flat
+  markdown into nested bullets. Our de-outline mode is the inverse of this.
+
+Useful as a reversible mapping spec; not runnable for our direction.
+
+### 2.2 `sercxanto_logseq_to_obsidian` (Logseq -> Obsidian; most mature)
+
+Python 3.9+, stdlib-only, spec-driven with good test coverage. **This is the parity bar for
+our Phase 1.** Implemented today
+([prior-art/sercxanto_logseq_to_obsidian/src/logseq_to_obsidian/transformer.py](../prior-art/sercxanto_logseq_to_obsidian/src/logseq_to_obsidian/transformer.py)):
+
+- Page properties (first block) -> YAML frontmatter; wiki-link-valued properties quoted/listified.
+- Tasks: `TODO/DOING/LATER/NOW/WAIT/WAITING/IN-PROGRESS` -> `- [ ]`, `DONE/CANCELED/CANCELLED` -> `- [x]`;
+  priority `[#A/B/C]` and `SCHEDULED:`/`DEADLINE:`/repeaters -> emoji **or** Dataview metadata.
+- Task date block-properties (`created`/`done`/`cancelled`) -> ➕/✅/❌ on the task line.
+- Block `id::` -> `^id`; `((uuid))` -> `[[path#^uuid]]`; `{{embed}}`, `{{video}}`, `{{youtube}}`,
+  `{{tweet}}` -> Obsidian equivalents.
+- `[alias]([[Page]])` -> `[[Page|alias]]`; org-mode `#+BEGIN_*` -> callouts/quotes/`%%` comments;
+  highlights `^^` -> `==`; numbered lists; LOGBOOK removal; `logseq.*` cleanup; asset images
+  `![alt](../assets/x)` -> `![[x]]` (with `{:height,:width}` -> `|WxH|`).
+- Path rules: `pages/Foo.md` -> `Foo.md`; `pages/a___b.md` -> `a/b.md`;
+  `journals/2024_08_30.md` -> `2024-08-30.md` (optionally under a Daily Notes folder).
+
+Gaps: no outline flattening; task workflow states collapsed to open/done; **wikilink text not
+rewritten** for `___` namespaces (so `[[a___b]]` can dangle); no queries/flashcards/whiteboards;
+percent-encoded filenames only warned about. CLI tool, not an Obsidian plugin.
+
+### 2.3 `NishantTharani_LogSeqToObsidian` (Logseq -> Obsidian)
+
+Single-file Python (`convert_notes.py`). Covers namespaces (`___`/`.`/`%2F`), journals,
+properties, aliases, tags, code-blocks-in-lists, asset copy + image-resize syntax, and natural
+-language date links. **Key cautionary lesson:** it *deletes* block references and embeds
+(`re.sub(r"\(\(.*?\)\)", "", line)`) — real data loss we must avoid. Also collapses task states,
+flattens assets to basename (collision risk), and leaves LOGBOOK/SCHEDULED/DEADLINE untouched.
+The bundled `bonofix-snippet.css` is cosmetic only.
+
+### 2.4 Coverage summary
+
+- Solved well by prior art (reuse the logic): properties->frontmatter, tasks + dates, links/aliases,
+  block id/refs/embeds (sercxanto), org blocks, highlights, numbered lists, asset images,
+  namespaces/journals path mapping.
+- Partially solved / inconsistent: task **state preservation**, namespace **wikilink** rewriting,
+  percent-encoded filenames, asset collision handling.
+- Not attempted by anyone: **outline flattening**, queries, flashcards, PDF highlights, whiteboards,
+  templates/macros.
+
+---
+
+## 3. Logseq vs Obsidian feature-mapping catalog
+
+Legend for **Loss**: *None* (round-trips), *Minor* (cosmetic/normalization), *Lossy* (information
+discarded by design), *Drop* (content not migratable, preserved verbatim or skipped).
+**Option** marks rows where behavior should be user-configurable.
+
+### 3.1 Document structure / outline
+
+| Logseq | Obsidian target | Loss | Proposed handling |
+|---|---|---|---|
+| Every block is a `- ` bullet; hierarchy via indentation | Preserve bullets OR flatten to paragraphs/headings | None (preserve) / Lossy (de-outline) | **Option** — see section 4 |
+| Block that is a heading (`- # Title` or `heading::` prop) | `# Title` | Minor | De-nest when de-outlining; keep `- # Title` when preserving |
+| Heading followed by tab-indented child list | `- # Heading` + list | None | Keep sercxanto's `fix_heading_child_lists` so Obsidian doesn't render children as code/quote |
+
+### 3.2 Tasks
+
+Obsidian has **no built-in task management** beyond native checkboxes (`[ ]` and `[x]` only).
+Rich tasks come from community plugins, and there are **three viable target formats** the user
+should be able to choose between. This is the single most consequential option in the importer
+because Logseq tasks carry a lot of metadata (state, priority, scheduled/deadline, repeater,
+LOGBOOK time tracking) that maps very differently into each target.
+
+#### 3.2.1 The three target formats
+
+1. **Tasks plugin — emoji format** ([publish.obsidian.md/tasks](https://publish.obsidian.md/tasks)).
+   Tasks stay inline as checkbox list items; metadata is appended as emoji + date. Most common,
+   visually compact.
+2. **Tasks plugin — Dataview/inline-field format**. Same inline checkbox, but metadata written as
+   `[key:: value]` inline fields instead of emoji. More readable/queryable, requires Dataview.
+3. **TaskNotes** ([tasknotes.dev](https://tasknotes.dev/)). Each task becomes its **own markdown
+   file** with structured metadata in **YAML frontmatter**, queried via the **Bases** core plugin
+   ([obsidian.md/help/bases](https://obsidian.md/help/bases)). Has native **time tracking**
+   (`timeEntries` array) ([time management](https://tasknotes.dev/features/time-management/)).
+
+A fourth, always-available baseline is **plain checkboxes** (no plugin): just `- [ ]` / `- [x]`,
+discarding rich metadata into text — the safe lowest-common-denominator default.
+
+#### 3.2.2 Mapping per target
+
+| Logseq | Plain | Tasks (emoji) | Tasks (Dataview) | TaskNotes (frontmatter) |
+|---|---|---|---|---|
+| `TODO` / `LATER` | `- [ ]` | `- [ ]` | `- [ ]` | `status: open` |
+| `DOING` / `NOW` | `- [ ]` | `- [/]` | `- [/]` | `status: in-progress` |
+| `DONE` | `- [x]` | `- [x] ✅ <date>` | `- [x] [completion:: date]` | `status: done` |
+| `CANCELLED` | `- [x]` | `- [-]` | `- [-]` | `status: cancelled` |
+| `WAITING` / `IN-PROGRESS` | `- [ ]` | `- [ ]` (+`#waiting`) | `- [ ]` | custom `status:` value |
+| priority `[#A/B/C]` | text | 🔺/⏫ , 🔼 , 🔽/⏬ | `[priority:: high/medium/low]` | `priority: high/normal/low` |
+| `SCHEDULED: <date>` | text | `⏳ date` | `[scheduled:: date]` | `scheduled: date` |
+| `DEADLINE: <date>` | text | `📅 date` | `[due:: date]` | `due: date` |
+| repeater `.+1d`/`++2w` | drop | `🔁 every N unit` | `[repeat:: …]` | `recurrence:` (RRULE) |
+| `created/done/cancelled` props | text | ➕ / ✅ / ❌ date | inline fields | frontmatter dates |
+| `:LOGBOOK:`/`CLOCK:` time tracking | drop | drop (no target) | drop | `timeEntries:` array |
+
+#### 3.2.3 Viability and limitations of each path
+
+- **Plain checkboxes** — trivial, fully lossless on structure, but discards almost all task
+  metadata into prose. Good default; bad for power users.
+- **Tasks plugin (emoji)** — *most straightforward*. A **line-level** transform: each Logseq task
+  block becomes one checkbox line; the outline structure is untouched. This is essentially what
+  outbreak/sercxanto already implement, so we have a proven mapping. Limits: 3->5 priority
+  remap is lossy in reverse; no place for LOGBOOK time tracking (dropped); custom states
+  (WAITING) need a tag or a custom Tasks status.
+- **Tasks plugin (Dataview)** — same line-level transform and same low risk; just a different
+  serialization of the same fields. Slightly better for querying. Same LOGBOOK gap.
+- **TaskNotes** — *most powerful but most invasive*. Each task must be **extracted into a
+  separate note file** with frontmatter, and the original block replaced by a link/embed.
+  Strong wins: rich metadata maps cleanly (status/priority/scheduled/due/recurrence), Logseq
+  **LOGBOOK `CLOCK:` entries map directly onto TaskNotes `timeEntries`** (start/end pairs), and
+  Logseq queries can be re-expressed as **Bases** views. Costs and limitations: it breaks the
+  in-outline context of a task (a task that had child blocks/notes underneath now lives in its
+  own file — those children must be moved into the task note body or left behind with a link);
+  it can explode a journal-heavy graph into thousands of tiny files; it depends on two plugins
+  (TaskNotes + Bases core plugin, Obsidian 1.10.1+). Best offered as an explicit opt-in for users
+  who are committing to the TaskNotes workflow, not the default.
+
+**Recommendation:** default to **Tasks plugin (emoji)** (proven, line-level, low risk), offer
+plain/Dataview/TaskNotes as alternatives via a dropdown. Implement emoji + Dataview + plain in
+Phase 1 (they share the same per-line pipeline); implement TaskNotes in a later phase because it
+needs the separate-file extraction machinery and is the only path that can preserve LOGBOOK time
+tracking.
+
+### 3.3 Links, references, embeds
+
+| Logseq | Obsidian target | Loss | Proposed handling |
+|---|---|---|---|
+| `[[Page]]` (canonical name) | `[[Page]]` | None | Rewrite `[[a/b]]` namespace text to match output path |
+| `[[Alias]]` (reference *by alias*) | `[[Canonical\|Alias]]` | None | See alias note below — must rewrite to canonical target |
+| `[alias]([[Page]])` | `[[Page\|alias]]` | None | Skip inside code fences |
+| `id:: <uuid>` block property | `^shortid` appended to the block line | None | Shorten UUID (see 5.2); reuse Roam approach; never delete |
+| `((uuid))` block reference | `[[Page#^shortid]]` | None if resolved | Build a vault-wide id index first; unresolved -> keep raw + warn |
+| `{{embed ((uuid))}}` | `![[Page#^shortid]]` | None if resolved | After ref pass |
+| `{{embed [[Page]]}}` | `![[Page]]` | None | |
+| `#tag` / `#[[multi word]]` | `#tag` / `#multi-word` or `[[...]]` | Minor | **Option** keep tag vs convert to link; sanitize spaces |
+| Namespace page file `a___b.md` | `a/b.md` (folders) | None | Also rewrite link text and aliases that reference it |
+| Percent-encoded filename (`Encoded%3AColon.md`) | decoded title `Encoded:Colon` -> sanitized | Minor | Decode (improve over prior art which only warns) |
+
+**Aliases are not interchangeable between the two apps.** Both have a page-level alias property,
+but they behave differently:
+
+- In **Logseq** ([alias docs](https://docs.logseq.com/#/page/term%2Falias)), an alias is a true
+  alternate name: you can write `[[Some Alias]]` anywhere and Logseq resolves it to the canonical
+  page.
+- In **Obsidian** ([alias docs](https://obsidian.md/help/aliases)), aliases only feed autocomplete
+  and search/display; a link's target in the file is always the **canonical note name**. Writing
+  `[[Some Alias]]` would point at a (possibly non-existent) note literally called "Some Alias", not
+  the canonical page.
+
+Therefore the importer must, in its link-resolution pass, build an **alias -> canonical-page map**
+from every page's `alias::`/`aliases::` property, and rewrite any reference that targets an alias
+into `[[Canonical Page|Alias]]` (keeping the alias as display text). The alias values themselves
+still go into the note's `aliases:` frontmatter so Obsidian autocomplete keeps working. (Nishant's
+tool does a basename-only version of this; we do it with full namespace paths.) Ambiguous aliases
+(same alias claimed by multiple pages) are reported via `ctx.reportSkipped` and left as-is.
+
+### 3.4 Properties
+
+| Logseq | Obsidian target | Loss | Proposed handling |
+|---|---|---|---|
+| Page properties (first block, `key:: value`) | YAML frontmatter | None | `alias`->`aliases`, `tags::`->`tags`, strip `#`, parse `[[..]]`, quote wiki-link values |
+| `title::` | drop; use as filename if differs (warn) | Minor | Logseq filename is source of truth |
+| `collapsed:: true` | removed | None | Fold state is not file-level in Obsidian |
+| `id::` | -> `^id` (see 3.3) | None | |
+| `heading:: N` | `#`×N prefix on the block | Minor | |
+| `logseq.order-list-type:: number` | numbered list (see 3.5) | None | |
+| `query-table::`, `query-sort-*::`, `filters::`, `public::` | drop or keep raw | Lossy | Logseq-internal; **Option** drop vs keep as `key:: value` |
+| Other block properties (`key:: value`, non-first block) | keep as inline text OR Dataview `[key:: value]` | Minor | **Option**; default keep as-is |
+
+### 3.5 Inline syntax and blocks
+
+| Logseq | Obsidian target | Loss | Proposed handling |
+|---|---|---|---|
+| `^^highlight^^` | `==highlight==` | None | Skip code fences |
+| `#+BEGIN_QUOTE` … `#+END_QUOTE` | `> ` blockquote | None | |
+| `#+BEGIN_NOTE/TIP/WARNING/IMPORTANT/CAUTION/EXAMPLE` | `> [!type]` callout | Minor | First `**bold**` line -> callout title |
+| `#+BEGIN_COMMENT` | `%% … %%` | None | |
+| `#+BEGIN_CENTER/VERSE/PINNED` | `> [!note]` fallback | Lossy | No native equivalent |
+| numbered list (bullet + `logseq.order-list-type:: number`) | `1.` `2.` `3.` | None | Counter per indent level |
+| code fences in bullets | code fence (indent fixed) | None | Reuse sercxanto/Nishant fix |
+| `$inline$` / `$$block$$` math | unchanged | None | Both support MathJax |
+
+### 3.6 Media / assets
+
+| Logseq | Obsidian target | Loss | Proposed handling |
+|---|---|---|---|
+| `![alt](../assets/x.png)` | `![[x.png]]` (copied via attachment settings) | Minor (alt) | **Option** keep alt as `![[x\|alt]]`; copy bytes, avoid name collisions |
+| `![alt](../assets/x.png){:height H, :width W}` | `![[x.png\|WxH]]` | None | |
+| `{{video URL}}` / `{{youtube URL}}` | `![](URL)` | None | |
+| `{{tweet URL}}` | `![](URL)` | Minor | |
+| local non-image asset link | `![[file.ext]]` or `[[file.ext]]` | None | Copy bytes |
+
+### 3.7 Journals / daily notes
+
+Journals are a first-class part of Logseq and must be migrated carefully. The migration has two
+distinct format ends, and **neither should be assumed blindly**:
+
+- **Source (Logseq):** the on-disk filename format `:journal/file-name-format` (default
+  `yyyy_MM_dd`) and the in-content date-link format `:journal/page-title-format` (default
+  `MMM do, yyyy`, e.g. `Jan 19th, 2038`). Both live in `logseq/config.edn`, so the importer should
+  **read `config.edn`** rather than hard-code defaults, and fall back to defaults only if absent.
+- **Target (Obsidian):** the daily-note filename format and folder are user-configurable in the
+  **Daily Notes** core plugin (and may be overridden by the **Periodic Notes** plugin). The Roam
+  importer already reads this via `app.internalPlugins.getPluginById('daily-notes').instance`
+  (default `YYYY-MM-DD`). We do the same, and additionally expose the format/folder as overridable
+  options so users whose target setup differs (or isn't configured yet) aren't surprised.
+
+| Logseq | Obsidian target | Loss | Proposed handling |
+|---|---|---|---|
+| `journals/2024_08_30.md` (format from `:journal/file-name-format`) | daily-note path from Daily Notes/Periodic Notes config | None | Read both configs; **Option** to override format + folder |
+| `[[Jan 19th, 2038]]` date link (`:journal/page-title-format`) | `[[2038-01-19]]` (target daily-note format) | None | Parse source format from config; reformat to target |
+
+#### Optional, more ergonomic targets
+
+Beyond the core Daily Notes plugin, two community plugins offer journal experiences closer to
+Logseq's, and the importer can optionally target them:
+
+- **Periodic Notes** ([github](https://github.com/liamcain/obsidian-periodic-notes)) — adds
+  weekly/monthly/quarterly/yearly notes. If a Logseq graph uses weekly/monthly journal pages (via
+  custom title formats), we can route them to the matching Periodic Notes folders/formats instead
+  of flattening everything into daily notes.
+- **Moments** ([community plugin](https://community.obsidian.md/plugins/moments)) — unifies dated
+  content as inline dated headings (`### [[2026-02-10]] ...`) and a timeline. A potential opt-in for
+  users who prefer dated entries embedded in topical notes rather than standalone daily files; it
+  auto-detects the Daily Notes/Periodic Notes date format, so our output stays compatible.
+
+These are **opt-in** targets (a journal-target dropdown: Daily Notes (default) / Periodic Notes /
+Moments-style). v1 implements Daily Notes; Periodic/Moments routing is a later enhancement.
+
+---
+
+## 4. The outline problem and the configurable structure design
+
+This is the central design decision. Logseq treats **every** document as an outline of nested
+blocks; indentation *is* the structure. Obsidian uses flat markdown where headings only imply
+structure visually. (See
+[structure-difference.md](../prior-art/laughedelic_outbreak/structure-difference.md).)
+
+Per the agreed decision, structure handling is a **user-selectable option**, defaulting to
+**Preserve**. Both paths apply all of the section-3 syntax conversions; they differ only in how
+the block tree is serialized.
+
+### 4.1 Preserve mode (default)
+
+Keep every block as a `- ` bullet with its original indentation. This is exactly what sercxanto
+and Nishant do, and it is **lossless** — the structure that the user built in Logseq survives
+intact. The only structural touch-up is the heading/child-list fix (3.1) so headings with
+indented children render correctly. Trade-off: notes remain "outliner-shaped" in Obsidian
+(everything is a bullet), which some users dislike.
+
+### 4.2 De-outline mode (opt-in)
+
+Produce idiomatic flat markdown by inverting outbreak's outliner (`outline.ts`). Proposed
+heuristics:
+
+- A **top-level** bullet that contains prose (not part of a real sub-list) becomes a paragraph;
+  blank line between paragraphs.
+- A bullet whose content is a heading (`# …` or `heading::`) de-nests to a real heading; its
+  children become the following content at the heading's implied level.
+- A subtree that is a **genuine list** (multiple sibling leaf items under a stem) stays a list,
+  re-indented from its outline depth.
+- Block properties and task dates that were on child lines move inline onto their block.
+- Single-child chains collapse (avoid one-item lists).
+
+```mermaid
+flowchart TD
+  block[Logseq block] --> q1{Heading content?}
+  q1 -->|yes| h[Emit heading; children become its body]
+  q1 -->|no| q2{Genuine list subtree?}
+  q2 -->|yes| l[Keep as list re-indented]
+  q2 -->|no| p[Emit as paragraph]
+```
+
+Lossy edge cases to document: a list "incidentally" nested under a paragraph loses that
+parent-child link; deeply mixed prose/list trees may not flatten cleanly; block references that
+pointed at structural bullets still resolve (we keep `^id` anchors regardless of mode). Because
+of this, de-outline is **opt-in**, never the default.
+
+### 4.3 Scope: pages vs journals
+
+De-outlining is not equally desirable everywhere. **Pages** are often long-form notes where flat
+markdown reads better, while **journals** are typically genuine bullet logs where the outline *is*
+the content and flattening would look wrong. So the de-outline choice has a **scope** sub-option:
+
+- `pages` — flatten pages only, keep journals as outlines (recommended when de-outlining)
+- `journals` — flatten journals only
+- `both` — flatten everything
+
+The default remains **Preserve everywhere**. When the user opts into de-outline, the default scope
+is **pages only**.
+
+### 4.4 Exposure
+
+Two linked settings in `init()`:
+
+```ts
+new Setting(this.modal.contentEl)
+  .setName('Document structure')
+  .setDesc('How to handle Logseq\'s outline (everything-is-a-bullet) model')
+  .addDropdown(d => d
+    .addOption('preserve', 'Preserve outline (bullets) — recommended')
+    .addOption('flatten', 'Flatten to paragraphs and headings (experimental)')
+    .setValue('preserve'));
+
+// shown only when 'flatten' is selected
+new Setting(this.modal.contentEl)
+  .setName('Flatten scope')
+  .addDropdown(d => d
+    .addOption('pages', 'Pages only — keep journals as outlines')
+    .addOption('journals', 'Journals only')
+    .addOption('both', 'Pages and journals')
+    .setValue('pages'));
+```
+
+---
+
+## 5. Handling of un-migratable / lossy features
+
+Guiding rule: **never silently delete content.** Anything we cannot faithfully convert is either
+preserved verbatim (so the text survives) or skipped with an explicit `ctx.reportSkipped` /
+`reportFailed` entry so the user knows. This is the main correctness improvement over Nishant's
+tool (which deletes block refs outright).
+
+### 5.1 Keep-or-drop is configurable per feature
+
+Every feature that is Logseq-only **and** has no good Obsidian translation — or that simply becomes
+irrelevant after migration — gets an explicit **keep / drop** choice. "Keep" preserves the original
+text verbatim (so nothing is lost and the user can revisit it); "drop" removes it **cleanly** (no
+empty bullets, dangling lines, or leftover markers). The default per feature is chosen to be the
+least surprising, but the user can flip any of them. A single grouped setting (e.g. a small list of
+toggles, or one "Logseq-only content" dropdown of `keep` / `drop`) exposes these.
+
+| Feature | On-disk syntax | Default | If kept | If dropped (clean) |
+|---|---|---|---|---|
+| Simple queries | `{{query ...}}` | keep | verbatim in a fenced code block + warn | remove block, no residue |
+| Advanced queries | `#+BEGIN_QUERY … #+END_QUERY` | keep | verbatim code block + warn | remove block |
+| Flashcards | `#card`, `{{cloze ...}}` | keep | keep block text + `#card`; drop SRS schedule | unwrap cloze to plain text |
+| PDF highlights/annotations | `logseq.property.pdf/*` | keep | keep text + warn (geometry lost) | remove annotation blocks |
+| Whiteboards | `whiteboards/*.edn` | drop | copy `.edn` as an asset + warn | skip file (reported) |
+| Templates | `template::` property | keep | keep block as a normal note + warn | skip template page |
+| Macros / dynamic vars | `{{macro ...}}`, `<% %>` | keep | verbatim + warn | remove macro call |
+| `collapsed::`, `logseq.*`, `query-*::` props | block/page props | drop | keep as `key:: value` | strip line cleanly |
+
+Alternative (future) targets — Dataview for queries, a spaced-repetition plugin for flashcards,
+PDF++/Annotator for PDF highlights, Obsidian Canvas for whiteboards — are out of scope for v1.
+
+`logseq/`, `.recycle/`, `.git/`, and the Markdown-mirror folder are ignored during the scan.
+
+### 5.2 Block references: shorten the IDs
+
+Logseq block IDs are full UUIDs (e.g. `64ab9aa4-459a-41b1-8c21-dbb38dc0c79b`). Obsidian block
+identifiers are much shorter and have a restricted charset: they may contain only **letters,
+numbers, and dashes**, and Obsidian's own UI generates short ~6-character alphanumeric IDs (e.g.
+`^a1b2c3`). Carrying the full UUID as `^64ab9aa4-...` works but is ugly and noisy in the rendered
+note and in the `[[Page#^64ab9aa4-...]]` links.
+
+Proposed handling: when converting `id:: <uuid>` to an Obsidian `^anchor`, **shorten** the UUID to
+a short, stable, collision-checked ID:
+
+- Derive a short id deterministically from the UUID (e.g. first 6–8 hex chars, or a short hash) so
+  the mapping is stable across the run.
+- Maintain a `uuid -> shortid` map; on collision **within the same note** (Obsidian only requires
+  per-note uniqueness for `^` anchors), extend by one character until unique.
+- Rewrite both the anchor (`^shortid`) and every `((uuid))` reference / `{{embed ((uuid))}}` through
+  the same map, so links stay consistent.
+- **Option** to keep the full UUID for users who prefer guaranteed-stable identifiers.
+
+This keeps the output idiomatic while preserving every reference (improving on prior art that
+either deletes refs or leaves long UUIDs inline).
+
+---
+
+## 6. Phased implementation roadmap
+
+### 6.1 Pipeline
+
+```mermaid
+flowchart LR
+  scan[Scan graph: pages/ journals/ assets/] --> parse[Parse blocks + properties]
+  parse --> index[Build id and block index]
+  index --> convert[Per-file syntax conversion]
+  convert --> outline{Outline mode?}
+  outline -->|preserve| writeP[Serialize bullets]
+  outline -->|flatten| flat[De-outline] --> writeF[Serialize flat markdown]
+  writeP --> refs[Two-pass ref/embed fixup]
+  writeF --> refs
+  refs --> assets[Copy assets + rewrite links]
+  assets --> report[Report skipped/failed]
+```
+
+A two-pass design is required because `((uuid))` references can point at blocks in other files,
+so the full id index must be built before link rewriting (same shape as the Roam importer).
+
+### 6.2 Phases
+
+**Phase 0 — Scaffold.**
+- `src/formats/logseq.ts` extending `FormatImporter`; register `'logseq'` in
+  [src/main.ts](../src/main.ts).
+- `init()`: graph-folder picker, output-folder setting, and options:
+  - **Task format**: plain / Tasks-emoji (default) / Tasks-Dataview / TaskNotes (3.2)
+  - **Document structure**: preserve (default) / flatten, plus flatten **scope** pages/journals/both (4.4)
+  - **Journal target**: Daily Notes (default) / Periodic Notes / Moments-style, with format+folder overrides (3.7)
+  - **Logseq-only content**: keep (default) / drop per feature group (5.1)
+  - **Block IDs**: shorten (default) / keep full UUID (5.2)
+  - copy-assets, properties->frontmatter, tag-vs-link toggles
+- Walk `pages/` + `journals/`; skip `logseq/`, `whiteboards/`, `.recycle/`, mirror.
+
+**Phase 1 — Core lossless conversion (reach sercxanto parity in Preserve mode).**
+- Page properties -> YAML frontmatter (alias/tags/wiki-link quoting; drop `title::`/`collapsed::`).
+- Tasks (plain + Tasks-emoji + Tasks-Dataview) + priorities + SCHEDULED/DEADLINE/repeaters + task
+  date props; LOGBOOK keep/drop.
+- Links: `[[page]]`, `[alias]([[page]])` -> `[[page|alias]]`; `#tag`/`#[[..]]`; **alias-reference
+  rewriting** to canonical (3.3).
+- Block `id::` -> shortened `^id`; `((uuid))`/`{{embed}}` two-pass resolution through the shared
+  id map (reuse [src/formats/roam/block-refs.ts](../src/formats/roam/block-refs.ts) logic).
+- Org blocks -> callouts/quote/comment; highlights; numbered lists; code-in-list fix.
+- Assets: copy via `getAvailablePathForAttachment`, rewrite `![[..]]`, handle `{:height,:width}`.
+- Namespaces (`a___b.md` -> `a/b.md`) incl. **wikilink** rewriting; journal filename/date conversion
+  reading `config.edn` and the Daily Notes plugin config.
+
+**Phase 2 — Structure + fidelity improvements.**
+- De-outline (flatten) mode (4.2) with heading fixes and the pages/journals/both scope (4.3).
+- Configurable task-state preservation (custom states / tags).
+- Percent-encoded filename decoding.
+
+**Phase 3 — Logseq-only features + richer targets.**
+- Queries / flashcards / templates / macros: keep-verbatim or clean-drop + `reportSkipped` (5.1).
+- **TaskNotes** target: extract tasks into per-task notes with YAML frontmatter, map LOGBOOK
+  `CLOCK:` -> `timeEntries`, recurrence -> `recurrence`, and optionally a Bases view (3.2).
+- **Periodic Notes / Moments** journal targets (3.7).
+- Whiteboards keep-as-asset or skip.
+
+### 6.3 TDD workflow
+
+The implementation follows test-driven development: **write the unit tests first**, then implement
+until green. End-to-end tests come later.
+
+1. For each feature row in section 3, write a focused **unit test** (input snippet -> expected
+   output) against a small pure transform function, before writing that transform. Tests start red.
+2. Implement the transform until its tests pass; refactor with tests green.
+3. Keep transforms as small, pure, independently testable functions (mirrors sercxanto's
+   `transformer.py` and outbreak's `translate.ts` rule list), so each is unit-testable without a
+   running Obsidian/vault.
+4. Only after a phase's units are green, add **end-to-end** tests that run the whole importer over a
+   fixture graph and assert the output tree.
+
+### 6.4 Test assets and harness
+
+- Unit tests: Node test runner, following [tests/roam/block-refs.test.ts](../tests/roam/block-refs.test.ts).
+  One file per transform group (tasks, links/aliases, properties, blocks, assets, journals, outline).
+- Fixtures: reuse the example vaults already in this repo as inputs —
+  [prior-art/NishantTharani_LogSeqToObsidian/example/logseq_vault](../prior-art/NishantTharani_LogSeqToObsidian/example/logseq_vault)
+  and [prior-art/sercxanto_logseq_to_obsidian/tests/fixtures/logseq/basic](../prior-art/sercxanto_logseq_to_obsidian/tests/fixtures/logseq/basic)
+  — and add small targeted fixtures for cases they miss (alias references, block-id shortening,
+  de-outline scope, TaskNotes extraction).
+- End-to-end (later): convert a fixture graph and assert the output tree, that block refs resolve,
+  and that nothing is silently dropped.
+
+---
+
+## 7. Declared limitations and conscious tradeoffs
+
+Intentionally **out of scope for v1** (text preserved, never silently lost):
+
+- Query translation to Dataview (queries preserved verbatim).
+- Flashcard/SRS scheduling, PDF area-highlight geometry, whiteboards (skipped + reported).
+- Templates/macros/dynamic-variable execution (preserved verbatim).
+- The Logseq **DB graph** format — we target the **markdown/file-based** graph only.
+
+Accepted, documented information loss:
+
+- Task **workflow** states beyond open/done are collapsed unless the preserve-state option is on.
+- Priority granularity collapses from Logseq's 3 levels to the chosen Obsidian scheme.
+- **LOGBOOK / `CLOCK:` time tracking** has no target in the Tasks-plugin or plain paths and is
+  dropped there; it is **only preserved on the TaskNotes path** (-> `timeEntries`).
+- De-outline mode is heuristic and may restructure incidental list/paragraph nesting; this is
+  why **Preserve is the default** (and pages-only when enabled).
+
+Key decisions made configurable (not assumed):
+
+- **Task format** is user-chosen among plain / Tasks-emoji (default) / Tasks-Dataview / TaskNotes.
+- Every **Logseq-only feature** can be kept (verbatim) or dropped cleanly (5.1).
+- **Journal date formats** are read from `config.edn` (source) and the Daily Notes/Periodic Notes
+  config (target), with manual overrides — never hard-coded.
+- **Block IDs** are shortened to Obsidian-style short anchors by default, with an option to keep
+  full UUIDs (5.2).
+
+Correctness guarantees we commit to:
+
+- Block references are always either resolved or kept raw — **never deleted** (unlike Nishant).
+- **Alias references** are rewritten to canonical targets so links don't break in Obsidian (3.3).
+- Assets are de-duplicated on import (no basename collisions).
+- Unconvertible content is reported to the user via `ImportContext`, not dropped silently.

--- a/docs/logseq-importer-assessment.md
+++ b/docs/logseq-importer-assessment.md
@@ -1,644 +1,296 @@
-# Logseq to Obsidian Importer: Assessment and Roadmap
-
-This document assesses what it would take to add a first-class **Logseq** importer to the
-official [obsidian-importer](https://github.com/obsidianmd/obsidian-importer) plugin. Today
-Logseq graphs can only be brought in via the generic "Markdown files" path, which ignores
-the many Logseq-specific conventions. The goal here is a comprehensive, low-loss migration
-of a Logseq markdown graph into an Obsidian vault.
-
-Contents:
-
-1. How an Obsidian importer works (the contract a new importer must satisfy)
-2. Prior-art inventory: what existing tools already solve, and their gaps
-3. Logseq vs Obsidian feature-mapping catalog
-4. The outline problem and the configurable structure design
-5. Handling of un-migratable / lossy features
-6. Phased implementation roadmap
-7. Declared limitations and conscious tradeoffs
-
----
-
-## 1. How an Obsidian importer works
-
-The importer is an Obsidian plugin. Each supported source app is an **importer class** that
-extends a common base and is registered in a central map. Understanding this contract tells
-us exactly what a Logseq importer must implement and which extension points are available
-for resolving ambiguities through user options.
-
-### 1.1 The `FormatImporter` contract
-
-Every importer extends `FormatImporter` ([src/format-importer.ts](../src/format-importer.ts))
-and is registered in `ImporterPlugin.importers` ([src/main.ts](../src/main.ts)). The two
-methods that matter:
-
-- `init()` — **abstract**. Builds the importer's UI inside the modal (file/folder pickers,
-  output-folder field, and any option toggles/dropdowns). Called from the constructor.
-- `import(ctx: ImportContext)` — **abstract**. Does the actual work: read input, convert,
-  write into the vault, report progress.
-
-Optional hooks: `showTemplateConfiguration(ctx, container)` for a pre-import wizard (only the
-CSV importer uses it today), and `registerAuthCallback()` for OAuth-based importers
-(OneNote, Notion API). A `notAvailable` flag lets an importer disable itself on unsupported
-platforms (e.g. Apple Notes off macOS).
-
-### 1.2 Built-in UI helpers (how options are exposed)
-
-User-resolvable ambiguities are surfaced as Obsidian `Setting` widgets appended to
-`this.modal.contentEl` inside `init()`. The base class provides:
-
-- `addFileChooserSetting(name, extensions, allowMultiple?)` — desktop file/folder picker
-  (Electron dialog); populates `this.files: PickedFile[]`. For Logseq we pick the **graph
-  folder**.
-- `addOutputLocationSetting(defaultFolderName)` — vault-relative output folder; stored in
-  `this.outputLocation`.
-
-Concrete option pattern, from the Roam importer ([src/formats/roam-json.ts](../src/formats/roam-json.ts)):
-
-```ts
-new Setting(this.modal.contentEl)
-  .setName('Download all attachments')
-  .addToggle(toggle => toggle.setValue(this.downloadAttachments).onChange(v => this.downloadAttachments = v));
-```
-
-Dropdowns (`addDropdown`), text fields (`addText`), and toggles (`addToggle`) are all used by
-existing importers — this is how we will expose the outline mode, task-state strategy, etc.
-
-### 1.3 Progress and results: `ImportContext`
-
-`import(ctx)` receives an `ImportContext` ([src/main.ts](../src/main.ts)) used to drive the
-progress UI and the final report:
-
-- `ctx.status(message)` — current task label
-- `ctx.reportProgress(current, total)` — progress bar
-- `ctx.reportNoteSuccess(name)` / `ctx.reportAttachmentSuccess(name)`
-- `ctx.reportSkipped(name, reason)` / `ctx.reportFailed(name, reason)`
-- `ctx.isCancelled()` — checked in the import loop so the Stop button works
-
-The `skipped`/`failed` collections are how we will surface un-migratable content (queries,
-whiteboards, etc.) to the user rather than silently dropping it.
-
-### 1.4 Writing into the vault
-
-- `saveAsMarkdownFile(folder, title, content)` — sanitizes the title and creates the note.
-- `vault.create(path, content)` / `vault.modify(file, content)` — used directly when paths
-  are precomputed (Roam does this so it can build nested folders for namespaced pages).
-- `createFolders(path)` — recursive folder creation.
-- `getAvailablePathForAttachment(filename, claimedPaths)` — resolves a collision-free
-  attachment path respecting the user's attachment-folder settings.
-- `vault.createBinary(path, data)` — writes asset bytes.
-- Filename safety: `sanitizeFileName()` ([src/util.ts](../src/util.ts)) and
-  `sanitizeFileNameKeepPath()` ([src/formats/roam/utils.ts](../src/formats/roam/utils.ts),
-  preserves `/` for nested page paths).
-
-Cross-platform filesystem access is via [src/filesystem.ts](../src/filesystem.ts)
-(`PickedFile`, `getAllFiles`, `parseFilePath`) and [src/zip.ts](../src/zip.ts); importers are
-expected to use these instead of importing Node modules directly.
-
-### 1.5 The closest existing models
-
-- **Roam Research** ([src/formats/roam-json.ts](../src/formats/roam-json.ts)) is the nearest
-  analogue: an outliner with nested bullets, `((block refs))`, daily notes, and `[[wikilinks]]`.
-  Its **two-pass block-reference resolution** ([src/formats/roam/block-refs.ts](../src/formats/roam/block-refs.ts))
-  — collect a `uid -> {page, text}` index, then rewrite `((uid))` into
-  `[[page#^uid|text]]` and append `^uid` to the source line — is directly reusable for Logseq's
-  `id::` / `((uid))` model. (Roam imports a single JSON export, though; Logseq is markdown on disk.)
-- **Bear** ([src/formats/bear-bear2bk.ts](../src/formats/bear-bear2bk.ts)) and **Textbundle**
-  ([src/formats/textbundle.ts](../src/formats/textbundle.ts)) are the models for **markdown
-  files on disk plus an `assets/` folder**: copy assets via `getAvailablePathForAttachment` and
-  rewrite the links. Logseq's layout is closer to these than to Roam's.
-
-### 1.6 Tests and build
-
-Tests run with the Node test runner: `pnpm test` → `tsx --test tests/**/*.test.ts`. The one
-substantive suite is [tests/roam/block-refs.test.ts](../tests/roam/block-refs.test.ts), which
-sweeps a fixture graph. Build is esbuild (`pnpm dev` watch, `pnpm build` production). A new
-importer is a new file under `src/formats/` plus one entry in the `importers` map in
-[src/main.ts](../src/main.ts).
-
-```ts
-// src/main.ts — registration shape
-'logseq': {
-  name: 'Logseq',
-  optionText: 'Logseq',
-  importer: LogseqImporter,
-  helpPermalink: 'import/logseq',
-},
-```
-
----
-
-## 2. Prior-art inventory
-
-Three community tools live under [prior-art/](../prior-art/). Together they cover most of the
-"easy" conversions; none does outline flattening or the harder Logseq-only features.
-
-### 2.1 `laughedelic_outbreak` (Obsidian -> Logseq; the *opposite* direction)
-
-TypeScript/Deno. Direction is reversed from ours, but it is the most valuable **specification**
-because it documents the mappings carefully and implements a clean **outline model** that we
-must *invert*.
-
-- [prior-art/laughedelic_outbreak/syntax-differences.md](../prior-art/laughedelic_outbreak/syntax-differences.md)
-  — authoritative catalog of task, date, priority, link, frontmatter, callout, embed, highlight,
-  and numbered-list mappings (the basis of section 3).
-- [prior-art/laughedelic_outbreak/structure-difference.md](../prior-art/laughedelic_outbreak/structure-difference.md)
-  — defines the flat-markdown ↔ outline transform (the basis of section 4).
-- `translate.ts` / `outline.ts` — syntax rules + a heading-stack outliner that turns flat
-  markdown into nested bullets. Our de-outline mode is the inverse of this.
-
-Useful as a reversible mapping spec; not runnable for our direction.
-
-### 2.2 `sercxanto_logseq_to_obsidian` (Logseq -> Obsidian; most mature)
-
-Python 3.9+, stdlib-only, spec-driven with good test coverage. **This is the parity bar for
-our Phase 1.** Implemented today
-([prior-art/sercxanto_logseq_to_obsidian/src/logseq_to_obsidian/transformer.py](../prior-art/sercxanto_logseq_to_obsidian/src/logseq_to_obsidian/transformer.py)):
-
-- Page properties (first block) -> YAML frontmatter; wiki-link-valued properties quoted/listified.
-- Tasks: `TODO/DOING/LATER/NOW/WAIT/WAITING/IN-PROGRESS` -> `- [ ]`, `DONE/CANCELED/CANCELLED` -> `- [x]`;
-  priority `[#A/B/C]` and `SCHEDULED:`/`DEADLINE:`/repeaters -> emoji **or** Dataview metadata.
-- Task date block-properties (`created`/`done`/`cancelled`) -> ➕/✅/❌ on the task line.
-- Block `id::` -> `^id`; `((uuid))` -> `[[path#^uuid]]`; `{{embed}}`, `{{video}}`, `{{youtube}}`,
-  `{{tweet}}` -> Obsidian equivalents.
-- `[alias]([[Page]])` -> `[[Page|alias]]`; org-mode `#+BEGIN_*` -> callouts/quotes/`%%` comments;
-  highlights `^^` -> `==`; numbered lists; LOGBOOK removal; `logseq.*` cleanup; asset images
-  `![alt](../assets/x)` -> `![[x]]` (with `{:height,:width}` -> `|WxH|`).
-- Path rules: `pages/Foo.md` -> `Foo.md`; `pages/a___b.md` -> `a/b.md`;
-  `journals/2024_08_30.md` -> `2024-08-30.md` (optionally under a Daily Notes folder).
-
-Gaps: no outline flattening; task workflow states collapsed to open/done; **wikilink text not
-rewritten** for `___` namespaces (so `[[a___b]]` can dangle); no queries/flashcards/whiteboards;
-percent-encoded filenames only warned about. CLI tool, not an Obsidian plugin.
-
-### 2.3 `NishantTharani_LogSeqToObsidian` (Logseq -> Obsidian)
-
-Single-file Python (`convert_notes.py`). Covers namespaces (`___`/`.`/`%2F`), journals,
-properties, aliases, tags, code-blocks-in-lists, asset copy + image-resize syntax, and natural
--language date links. **Key cautionary lesson:** it *deletes* block references and embeds
-(`re.sub(r"\(\(.*?\)\)", "", line)`) — real data loss we must avoid. Also collapses task states,
-flattens assets to basename (collision risk), and leaves LOGBOOK/SCHEDULED/DEADLINE untouched.
-The bundled `bonofix-snippet.css` is cosmetic only.
-
-### 2.4 Coverage summary
-
-- Solved well by prior art (reuse the logic): properties->frontmatter, tasks + dates, links/aliases,
-  block id/refs/embeds (sercxanto), org blocks, highlights, numbered lists, asset images,
-  namespaces/journals path mapping.
-- Partially solved / inconsistent: task **state preservation**, namespace **wikilink** rewriting,
-  percent-encoded filenames, asset collision handling.
-- Not attempted by anyone: **outline flattening**, queries, flashcards, PDF highlights, whiteboards,
-  templates/macros.
-
----
-
-## 3. Logseq vs Obsidian feature-mapping catalog
-
-Legend for **Loss**: *None* (round-trips), *Minor* (cosmetic/normalization), *Lossy* (information
-discarded by design), *Drop* (content not migratable, preserved verbatim or skipped).
-**Option** marks rows where behavior should be user-configurable.
-
-### 3.1 Document structure / outline
-
-| Logseq | Obsidian target | Loss | Proposed handling |
-|---|---|---|---|
-| Every block is a `- ` bullet; hierarchy via indentation | Preserve bullets OR flatten to paragraphs/headings | None (preserve) / Lossy (de-outline) | **Option** — see section 4 |
-| Block that is a heading (`- # Title` or `heading::` prop) | `# Title` | Minor | De-nest when de-outlining; keep `- # Title` when preserving |
-| Heading followed by tab-indented child list | `- # Heading` + list | None | Keep sercxanto's `fix_heading_child_lists` so Obsidian doesn't render children as code/quote |
-
-### 3.2 Tasks
-
-Obsidian has **no built-in task management** beyond native checkboxes (`[ ]` and `[x]` only).
-Rich tasks come from community plugins, and there are **three viable target formats** the user
-should be able to choose between. This is the single most consequential option in the importer
-because Logseq tasks carry a lot of metadata (state, priority, scheduled/deadline, repeater,
-LOGBOOK time tracking) that maps very differently into each target.
-
-#### 3.2.1 The three target formats
-
-1. **Tasks plugin — emoji format** ([publish.obsidian.md/tasks](https://publish.obsidian.md/tasks)).
-   Tasks stay inline as checkbox list items; metadata is appended as emoji + date. Most common,
-   visually compact.
-2. **Tasks plugin — Dataview/inline-field format**. Same inline checkbox, but metadata written as
-   `[key:: value]` inline fields instead of emoji. More readable/queryable, requires Dataview.
-3. **TaskNotes** ([tasknotes.dev](https://tasknotes.dev/)). Each task becomes its **own markdown
-   file** with structured metadata in **YAML frontmatter**, queried via the **Bases** core plugin
-   ([obsidian.md/help/bases](https://obsidian.md/help/bases)). Has native **time tracking**
-   (`timeEntries` array) ([time management](https://tasknotes.dev/features/time-management/)).
-
-A fourth, always-available baseline is **plain checkboxes** (no plugin): just `- [ ]` / `- [x]`,
-discarding rich metadata into text — the safe lowest-common-denominator default.
-
-#### 3.2.2 Mapping per target
-
-| Logseq | Plain | Tasks (emoji) | Tasks (Dataview) | TaskNotes (frontmatter) |
-|---|---|---|---|---|
-| `TODO` / `LATER` | `- [ ]` | `- [ ]` | `- [ ]` | `status: open` |
-| `DOING` / `NOW` | `- [ ]` | `- [/]` | `- [/]` | `status: in-progress` |
-| `DONE` | `- [x]` | `- [x] ✅ <date>` | `- [x] [completion:: date]` | `status: done` |
-| `CANCELLED` | `- [x]` | `- [-]` | `- [-]` | `status: cancelled` |
-| `WAITING` / `IN-PROGRESS` | `- [ ]` | `- [ ]` (+`#waiting`) | `- [ ]` | custom `status:` value |
-| priority `[#A/B/C]` | text | 🔺/⏫ , 🔼 , 🔽/⏬ | `[priority:: high/medium/low]` | `priority: high/normal/low` |
-| `SCHEDULED: <date>` | text | `⏳ date` | `[scheduled:: date]` | `scheduled: date` |
-| `DEADLINE: <date>` | text | `📅 date` | `[due:: date]` | `due: date` |
-| repeater `.+1d`/`++2w` | drop | `🔁 every N unit` | `[repeat:: …]` | `recurrence:` (RRULE) |
-| `created/done/cancelled` props | text | ➕ / ✅ / ❌ date | inline fields | frontmatter dates |
-| `:LOGBOOK:`/`CLOCK:` time tracking | drop | drop (no target) | drop | `timeEntries:` array |
-
-#### 3.2.3 Viability and limitations of each path
-
-- **Plain checkboxes** — trivial, fully lossless on structure, but discards almost all task
-  metadata into prose. Good default; bad for power users.
-- **Tasks plugin (emoji)** — *most straightforward*. A **line-level** transform: each Logseq task
-  block becomes one checkbox line; the outline structure is untouched. This is essentially what
-  outbreak/sercxanto already implement, so we have a proven mapping. Limits: 3->5 priority
-  remap is lossy in reverse; no place for LOGBOOK time tracking (dropped); custom states
-  (WAITING) need a tag or a custom Tasks status.
-- **Tasks plugin (Dataview)** — same line-level transform and same low risk; just a different
-  serialization of the same fields. Slightly better for querying. Same LOGBOOK gap.
-- **TaskNotes** — *most powerful but most invasive*. Each task must be **extracted into a
-  separate note file** with frontmatter, and the original block replaced by a link/embed.
-  Strong wins: rich metadata maps cleanly (status/priority/scheduled/due/recurrence), Logseq
-  **LOGBOOK `CLOCK:` entries map directly onto TaskNotes `timeEntries`** (start/end pairs), and
-  Logseq queries can be re-expressed as **Bases** views. Costs and limitations: it breaks the
-  in-outline context of a task (a task that had child blocks/notes underneath now lives in its
-  own file — those children must be moved into the task note body or left behind with a link);
-  it can explode a journal-heavy graph into thousands of tiny files; it depends on two plugins
-  (TaskNotes + Bases core plugin, Obsidian 1.10.1+). Best offered as an explicit opt-in for users
-  who are committing to the TaskNotes workflow, not the default.
-
-**Recommendation:** default to **Tasks plugin (emoji)** (proven, line-level, low risk), offer
-plain/Dataview/TaskNotes as alternatives via a dropdown. Implement emoji + Dataview + plain in
-Phase 1 (they share the same per-line pipeline); implement TaskNotes in a later phase because it
-needs the separate-file extraction machinery and is the only path that can preserve LOGBOOK time
-tracking.
-
-### 3.3 Links, references, embeds
-
-| Logseq | Obsidian target | Loss | Proposed handling |
-|---|---|---|---|
-| `[[Page]]` (canonical name) | `[[Page]]` | None | Rewrite `[[a/b]]` namespace text to match output path |
-| `[[Alias]]` (reference *by alias*) | `[[Canonical\|Alias]]` | None | See alias note below — must rewrite to canonical target |
-| `[alias]([[Page]])` | `[[Page\|alias]]` | None | Skip inside code fences |
-| `id:: <uuid>` block property | `^shortid` appended to the block line | None | Shorten UUID (see 5.2); reuse Roam approach; never delete |
-| `((uuid))` block reference | `[[Page#^shortid]]` | None if resolved | Build a vault-wide id index first; unresolved -> keep raw + warn |
-| `{{embed ((uuid))}}` | `![[Page#^shortid]]` | None if resolved | After ref pass |
-| `{{embed [[Page]]}}` | `![[Page]]` | None | |
-| `#tag` / `#[[multi word]]` | `#tag` / `#multi-word` or `[[...]]` | Minor | **Option** keep tag vs convert to link; sanitize spaces |
-| Namespace page file `a___b.md` | `a/b.md` (folders) | None | Also rewrite link text and aliases that reference it |
-| Percent-encoded filename (`Encoded%3AColon.md`) | decoded title `Encoded:Colon` -> sanitized | Minor | Decode (improve over prior art which only warns) |
-
-**Aliases are not interchangeable between the two apps.** Both have a page-level alias property,
-but they behave differently:
-
-- In **Logseq** ([alias docs](https://docs.logseq.com/#/page/term%2Falias)), an alias is a true
-  alternate name: you can write `[[Some Alias]]` anywhere and Logseq resolves it to the canonical
-  page.
-- In **Obsidian** ([alias docs](https://obsidian.md/help/aliases)), aliases only feed autocomplete
-  and search/display; a link's target in the file is always the **canonical note name**. Writing
-  `[[Some Alias]]` would point at a (possibly non-existent) note literally called "Some Alias", not
-  the canonical page.
-
-Therefore the importer must, in its link-resolution pass, build an **alias -> canonical-page map**
-from every page's `alias::`/`aliases::` property, and rewrite any reference that targets an alias
-into `[[Canonical Page|Alias]]` (keeping the alias as display text). The alias values themselves
-still go into the note's `aliases:` frontmatter so Obsidian autocomplete keeps working. (Nishant's
-tool does a basename-only version of this; we do it with full namespace paths.) Ambiguous aliases
-(same alias claimed by multiple pages) are reported via `ctx.reportSkipped` and left as-is.
-
-### 3.4 Properties
-
-| Logseq | Obsidian target | Loss | Proposed handling |
-|---|---|---|---|
-| Page properties (first block, `key:: value`) | YAML frontmatter | None | `alias`->`aliases`, `tags::`->`tags`, strip `#`, parse `[[..]]`, quote wiki-link values |
-| `title::` | drop; use as filename if differs (warn) | Minor | Logseq filename is source of truth |
-| `collapsed:: true` | removed | None | Fold state is not file-level in Obsidian |
-| `id::` | -> `^id` (see 3.3) | None | |
-| `heading:: N` | `#`×N prefix on the block | Minor | |
-| `logseq.order-list-type:: number` | numbered list (see 3.5) | None | |
-| `query-table::`, `query-sort-*::`, `filters::`, `public::` | drop or keep raw | Lossy | Logseq-internal; **Option** drop vs keep as `key:: value` |
-| Other block properties (`key:: value`, non-first block) | keep as inline text OR Dataview `[key:: value]` | Minor | **Option**; default keep as-is |
-
-### 3.5 Inline syntax and blocks
-
-| Logseq | Obsidian target | Loss | Proposed handling |
-|---|---|---|---|
-| `^^highlight^^` | `==highlight==` | None | Skip code fences |
-| `#+BEGIN_QUOTE` … `#+END_QUOTE` | `> ` blockquote | None | |
-| `#+BEGIN_NOTE/TIP/WARNING/IMPORTANT/CAUTION/EXAMPLE` | `> [!type]` callout | Minor | First `**bold**` line -> callout title |
-| `#+BEGIN_COMMENT` | `%% … %%` | None | |
-| `#+BEGIN_CENTER/VERSE/PINNED` | `> [!note]` fallback | Lossy | No native equivalent |
-| numbered list (bullet + `logseq.order-list-type:: number`) | `1.` `2.` `3.` | None | Counter per indent level |
-| code fences in bullets | code fence (indent fixed) | None | Reuse sercxanto/Nishant fix |
-| `$inline$` / `$$block$$` math | unchanged | None | Both support MathJax |
-
-### 3.6 Media / assets
-
-| Logseq | Obsidian target | Loss | Proposed handling |
-|---|---|---|---|
-| `![alt](../assets/x.png)` | `![[x.png]]` (copied via attachment settings) | Minor (alt) | **Option** keep alt as `![[x\|alt]]`; copy bytes, avoid name collisions |
-| `![alt](../assets/x.png){:height H, :width W}` | `![[x.png\|WxH]]` | None | |
-| `{{video URL}}` / `{{youtube URL}}` | `![](URL)` | None | |
-| `{{tweet URL}}` | `![](URL)` | Minor | |
-| local non-image asset link | `![[file.ext]]` or `[[file.ext]]` | None | Copy bytes |
-
-### 3.7 Journals / daily notes
-
-Journals are a first-class part of Logseq and must be migrated carefully. The migration has two
-distinct format ends, and **neither should be assumed blindly**:
-
-- **Source (Logseq):** the on-disk filename format `:journal/file-name-format` (default
-  `yyyy_MM_dd`) and the in-content date-link format `:journal/page-title-format` (default
-  `MMM do, yyyy`, e.g. `Jan 19th, 2038`). Both live in `logseq/config.edn`, so the importer should
-  **read `config.edn`** rather than hard-code defaults, and fall back to defaults only if absent.
-- **Target (Obsidian):** the daily-note filename format and folder are user-configurable in the
-  **Daily Notes** core plugin (and may be overridden by the **Periodic Notes** plugin). The Roam
-  importer already reads this via `app.internalPlugins.getPluginById('daily-notes').instance`
-  (default `YYYY-MM-DD`). We do the same, and additionally expose the format/folder as overridable
-  options so users whose target setup differs (or isn't configured yet) aren't surprised.
-
-| Logseq | Obsidian target | Loss | Proposed handling |
-|---|---|---|---|
-| `journals/2024_08_30.md` (format from `:journal/file-name-format`) | daily-note path from Daily Notes/Periodic Notes config | None | Read both configs; **Option** to override format + folder |
-| `[[Jan 19th, 2038]]` date link (`:journal/page-title-format`) | `[[2038-01-19]]` (target daily-note format) | None | Parse source format from config; reformat to target |
-
-#### Optional, more ergonomic targets
-
-Beyond the core Daily Notes plugin, two community plugins offer journal experiences closer to
-Logseq's, and the importer can optionally target them:
-
-- **Periodic Notes** ([github](https://github.com/liamcain/obsidian-periodic-notes)) — adds
-  weekly/monthly/quarterly/yearly notes. If a Logseq graph uses weekly/monthly journal pages (via
-  custom title formats), we can route them to the matching Periodic Notes folders/formats instead
-  of flattening everything into daily notes.
-- **Moments** ([community plugin](https://community.obsidian.md/plugins/moments)) — unifies dated
-  content as inline dated headings (`### [[2026-02-10]] ...`) and a timeline. A potential opt-in for
-  users who prefer dated entries embedded in topical notes rather than standalone daily files; it
-  auto-detects the Daily Notes/Periodic Notes date format, so our output stays compatible.
-
-These are **opt-in** targets (a journal-target dropdown: Daily Notes (default) / Periodic Notes /
-Moments-style). v1 implements Daily Notes; Periodic/Moments routing is a later enhancement.
-
----
-
-## 4. The outline problem and the configurable structure design
-
-This is the central design decision. Logseq treats **every** document as an outline of nested
-blocks; indentation *is* the structure. Obsidian uses flat markdown where headings only imply
-structure visually. (See
-[structure-difference.md](../prior-art/laughedelic_outbreak/structure-difference.md).)
-
-Per the agreed decision, structure handling is a **user-selectable option**, defaulting to
-**Preserve**. Both paths apply all of the section-3 syntax conversions; they differ only in how
-the block tree is serialized.
-
-### 4.1 Preserve mode (default)
-
-Keep every block as a `- ` bullet with its original indentation. This is exactly what sercxanto
-and Nishant do, and it is **lossless** — the structure that the user built in Logseq survives
-intact. The only structural touch-up is the heading/child-list fix (3.1) so headings with
-indented children render correctly. Trade-off: notes remain "outliner-shaped" in Obsidian
-(everything is a bullet), which some users dislike.
-
-### 4.2 De-outline mode (opt-in)
-
-Produce idiomatic flat markdown by inverting outbreak's outliner (`outline.ts`). Proposed
-heuristics:
-
-- A **top-level** bullet that contains prose (not part of a real sub-list) becomes a paragraph;
-  blank line between paragraphs.
-- A bullet whose content is a heading (`# …` or `heading::`) de-nests to a real heading; its
-  children become the following content at the heading's implied level.
-- A subtree that is a **genuine list** (multiple sibling leaf items under a stem) stays a list,
-  re-indented from its outline depth.
-- Block properties and task dates that were on child lines move inline onto their block.
-- Single-child chains collapse (avoid one-item lists).
-
-```mermaid
-flowchart TD
-  block[Logseq block] --> q1{Heading content?}
-  q1 -->|yes| h[Emit heading; children become its body]
-  q1 -->|no| q2{Genuine list subtree?}
-  q2 -->|yes| l[Keep as list re-indented]
-  q2 -->|no| p[Emit as paragraph]
-```
-
-Lossy edge cases to document: a list "incidentally" nested under a paragraph loses that
-parent-child link; deeply mixed prose/list trees may not flatten cleanly; block references that
-pointed at structural bullets still resolve (we keep `^id` anchors regardless of mode). Because
-of this, de-outline is **opt-in**, never the default.
-
-### 4.3 Scope: pages vs journals
-
-De-outlining is not equally desirable everywhere. **Pages** are often long-form notes where flat
-markdown reads better, while **journals** are typically genuine bullet logs where the outline *is*
-the content and flattening would look wrong. So the de-outline choice has a **scope** sub-option:
-
-- `pages` — flatten pages only, keep journals as outlines (recommended when de-outlining)
-- `journals` — flatten journals only
-- `both` — flatten everything
-
-The default remains **Preserve everywhere**. When the user opts into de-outline, the default scope
-is **pages only**.
-
-### 4.4 Exposure
-
-Two linked settings in `init()`:
-
-```ts
-new Setting(this.modal.contentEl)
-  .setName('Document structure')
-  .setDesc('How to handle Logseq\'s outline (everything-is-a-bullet) model')
-  .addDropdown(d => d
-    .addOption('preserve', 'Preserve outline (bullets) — recommended')
-    .addOption('flatten', 'Flatten to paragraphs and headings (experimental)')
-    .setValue('preserve'));
-
-// shown only when 'flatten' is selected
-new Setting(this.modal.contentEl)
-  .setName('Flatten scope')
-  .addDropdown(d => d
-    .addOption('pages', 'Pages only — keep journals as outlines')
-    .addOption('journals', 'Journals only')
-    .addOption('both', 'Pages and journals')
-    .setValue('pages'));
-```
-
----
-
-## 5. Handling of un-migratable / lossy features
-
-Guiding rule: **never silently delete content.** Anything we cannot faithfully convert is either
-preserved verbatim (so the text survives) or skipped with an explicit `ctx.reportSkipped` /
-`reportFailed` entry so the user knows. This is the main correctness improvement over Nishant's
-tool (which deletes block refs outright).
-
-### 5.1 Keep-or-drop is configurable per feature
-
-Every feature that is Logseq-only **and** has no good Obsidian translation — or that simply becomes
-irrelevant after migration — gets an explicit **keep / drop** choice. "Keep" preserves the original
-text verbatim (so nothing is lost and the user can revisit it); "drop" removes it **cleanly** (no
-empty bullets, dangling lines, or leftover markers). The default per feature is chosen to be the
-least surprising, but the user can flip any of them. A single grouped setting (e.g. a small list of
-toggles, or one "Logseq-only content" dropdown of `keep` / `drop`) exposes these.
-
-| Feature | On-disk syntax | Default | If kept | If dropped (clean) |
-|---|---|---|---|---|
-| Simple queries | `{{query ...}}` | keep | verbatim in a fenced code block + warn | remove block, no residue |
-| Advanced queries | `#+BEGIN_QUERY … #+END_QUERY` | keep | verbatim code block + warn | remove block |
-| Flashcards | `#card`, `{{cloze ...}}` | keep | keep block text + `#card`; drop SRS schedule | unwrap cloze to plain text |
-| PDF highlights/annotations | `logseq.property.pdf/*` | keep | keep text + warn (geometry lost) | remove annotation blocks |
-| Whiteboards | `whiteboards/*.edn` | drop | copy `.edn` as an asset + warn | skip file (reported) |
-| Templates | `template::` property | keep | keep block as a normal note + warn | skip template page |
-| Macros / dynamic vars | `{{macro ...}}`, `<% %>` | keep | verbatim + warn | remove macro call |
-| `collapsed::`, `logseq.*`, `query-*::` props | block/page props | drop | keep as `key:: value` | strip line cleanly |
-
-Alternative (future) targets — Dataview for queries, a spaced-repetition plugin for flashcards,
-PDF++/Annotator for PDF highlights, Obsidian Canvas for whiteboards — are out of scope for v1.
-
-`logseq/`, `.recycle/`, `.git/`, and the Markdown-mirror folder are ignored during the scan.
-
-### 5.2 Block references: shorten the IDs
-
-Logseq block IDs are full UUIDs (e.g. `64ab9aa4-459a-41b1-8c21-dbb38dc0c79b`). Obsidian block
-identifiers are much shorter and have a restricted charset: they may contain only **letters,
-numbers, and dashes**, and Obsidian's own UI generates short ~6-character alphanumeric IDs (e.g.
-`^a1b2c3`). Carrying the full UUID as `^64ab9aa4-...` works but is ugly and noisy in the rendered
-note and in the `[[Page#^64ab9aa4-...]]` links.
-
-Proposed handling: when converting `id:: <uuid>` to an Obsidian `^anchor`, **shorten** the UUID to
-a short, stable, collision-checked ID:
-
-- Derive a short id deterministically from the UUID (e.g. first 6–8 hex chars, or a short hash) so
-  the mapping is stable across the run.
-- Maintain a `uuid -> shortid` map; on collision **within the same note** (Obsidian only requires
-  per-note uniqueness for `^` anchors), extend by one character until unique.
-- Rewrite both the anchor (`^shortid`) and every `((uuid))` reference / `{{embed ((uuid))}}` through
-  the same map, so links stay consistent.
-- **Option** to keep the full UUID for users who prefer guaranteed-stable identifiers.
-
-This keeps the output idiomatic while preserving every reference (improving on prior art that
-either deletes refs or leaves long UUIDs inline).
-
----
-
-## 6. Phased implementation roadmap
-
-### 6.1 Pipeline
-
-```mermaid
-flowchart LR
-  scan[Scan graph: pages/ journals/ assets/] --> parse[Parse blocks + properties]
-  parse --> index[Build id and block index]
-  index --> convert[Per-file syntax conversion]
-  convert --> outline{Outline mode?}
-  outline -->|preserve| writeP[Serialize bullets]
-  outline -->|flatten| flat[De-outline] --> writeF[Serialize flat markdown]
-  writeP --> refs[Two-pass ref/embed fixup]
-  writeF --> refs
-  refs --> assets[Copy assets + rewrite links]
-  assets --> report[Report skipped/failed]
-```
-
-A two-pass design is required because `((uuid))` references can point at blocks in other files,
-so the full id index must be built before link rewriting (same shape as the Roam importer).
-
-### 6.2 Phases
-
-**Phase 0 — Scaffold.**
-- `src/formats/logseq.ts` extending `FormatImporter`; register `'logseq'` in
-  [src/main.ts](../src/main.ts).
-- `init()`: graph-folder picker, output-folder setting, and options:
-  - **Task format**: plain / Tasks-emoji (default) / Tasks-Dataview / TaskNotes (3.2)
-  - **Document structure**: preserve (default) / flatten, plus flatten **scope** pages/journals/both (4.4)
-  - **Journal target**: Daily Notes (default) / Periodic Notes / Moments-style, with format+folder overrides (3.7)
-  - **Logseq-only content**: keep (default) / drop per feature group (5.1)
-  - **Block IDs**: shorten (default) / keep full UUID (5.2)
-  - copy-assets, properties->frontmatter, tag-vs-link toggles
-- Walk `pages/` + `journals/`; skip `logseq/`, `whiteboards/`, `.recycle/`, mirror.
-
-**Phase 1 — Core lossless conversion (reach sercxanto parity in Preserve mode).**
-- Page properties -> YAML frontmatter (alias/tags/wiki-link quoting; drop `title::`/`collapsed::`).
-- Tasks (plain + Tasks-emoji + Tasks-Dataview) + priorities + SCHEDULED/DEADLINE/repeaters + task
-  date props; LOGBOOK keep/drop.
-- Links: `[[page]]`, `[alias]([[page]])` -> `[[page|alias]]`; `#tag`/`#[[..]]`; **alias-reference
-  rewriting** to canonical (3.3).
-- Block `id::` -> shortened `^id`; `((uuid))`/`{{embed}}` two-pass resolution through the shared
-  id map (reuse [src/formats/roam/block-refs.ts](../src/formats/roam/block-refs.ts) logic).
-- Org blocks -> callouts/quote/comment; highlights; numbered lists; code-in-list fix.
-- Assets: copy via `getAvailablePathForAttachment`, rewrite `![[..]]`, handle `{:height,:width}`.
-- Namespaces (`a___b.md` -> `a/b.md`) incl. **wikilink** rewriting; journal filename/date conversion
-  reading `config.edn` and the Daily Notes plugin config.
-
-**Phase 2 — Structure + fidelity improvements.**
-- De-outline (flatten) mode (4.2) with heading fixes and the pages/journals/both scope (4.3).
-- Configurable task-state preservation (custom states / tags).
-- Percent-encoded filename decoding.
-
-**Phase 3 — Logseq-only features + richer targets.**
-- Queries / flashcards / templates / macros: keep-verbatim or clean-drop + `reportSkipped` (5.1).
-- **TaskNotes** target: extract tasks into per-task notes with YAML frontmatter, map LOGBOOK
-  `CLOCK:` -> `timeEntries`, recurrence -> `recurrence`, and optionally a Bases view (3.2).
-- **Periodic Notes / Moments** journal targets (3.7).
-- Whiteboards keep-as-asset or skip.
-
-### 6.3 TDD workflow
-
-The implementation follows test-driven development: **write the unit tests first**, then implement
-until green. End-to-end tests come later.
-
-1. For each feature row in section 3, write a focused **unit test** (input snippet -> expected
-   output) against a small pure transform function, before writing that transform. Tests start red.
-2. Implement the transform until its tests pass; refactor with tests green.
-3. Keep transforms as small, pure, independently testable functions (mirrors sercxanto's
-   `transformer.py` and outbreak's `translate.ts` rule list), so each is unit-testable without a
-   running Obsidian/vault.
-4. Only after a phase's units are green, add **end-to-end** tests that run the whole importer over a
-   fixture graph and assert the output tree.
-
-### 6.4 Test assets and harness
-
-- Unit tests: Node test runner, following [tests/roam/block-refs.test.ts](../tests/roam/block-refs.test.ts).
-  One file per transform group (tasks, links/aliases, properties, blocks, assets, journals, outline).
-- Fixtures: reuse the example vaults already in this repo as inputs —
-  [prior-art/NishantTharani_LogSeqToObsidian/example/logseq_vault](../prior-art/NishantTharani_LogSeqToObsidian/example/logseq_vault)
-  and [prior-art/sercxanto_logseq_to_obsidian/tests/fixtures/logseq/basic](../prior-art/sercxanto_logseq_to_obsidian/tests/fixtures/logseq/basic)
-  — and add small targeted fixtures for cases they miss (alias references, block-id shortening,
-  de-outline scope, TaskNotes extraction).
-- End-to-end (later): convert a fixture graph and assert the output tree, that block refs resolve,
-  and that nothing is silently dropped.
-
----
-
-## 7. Declared limitations and conscious tradeoffs
-
-Intentionally **out of scope for v1** (text preserved, never silently lost):
-
-- Query translation to Dataview (queries preserved verbatim).
-- Flashcard/SRS scheduling, PDF area-highlight geometry, whiteboards (skipped + reported).
-- Templates/macros/dynamic-variable execution (preserved verbatim).
-- The Logseq **DB graph** format — we target the **markdown/file-based** graph only.
-
-Accepted, documented information loss:
-
-- Task **workflow** states beyond open/done are collapsed unless the preserve-state option is on.
-- Priority granularity collapses from Logseq's 3 levels to the chosen Obsidian scheme.
-- **LOGBOOK / `CLOCK:` time tracking** has no target in the Tasks-plugin or plain paths and is
-  dropped there; it is **only preserved on the TaskNotes path** (-> `timeEntries`).
-- De-outline mode is heuristic and may restructure incidental list/paragraph nesting; this is
-  why **Preserve is the default** (and pages-only when enabled).
-
-Key decisions made configurable (not assumed):
-
-- **Task format** is user-chosen among plain / Tasks-emoji (default) / Tasks-Dataview / TaskNotes.
-- Every **Logseq-only feature** can be kept (verbatim) or dropped cleanly (5.1).
-- **Journal date formats** are read from `config.edn` (source) and the Daily Notes/Periodic Notes
-  config (target), with manual overrides — never hard-coded.
-- **Block IDs** are shortened to Obsidian-style short anchors by default, with an option to keep
-  full UUIDs (5.2).
-
-Correctness guarantees we commit to:
-
-- Block references are always either resolved or kept raw — **never deleted** (unlike Nishant).
-- **Alias references** are rewritten to canonical targets so links don't break in Obsidian (3.3).
-- Assets are de-duplicated on import (no basename collisions).
-- Unconvertible content is reported to the user via `ImportContext`, not dropped silently.
+# Logseq Importer: Implementation Summary and Design Decisions
+
+This document summarizes the implemented Logseq Markdown-graph importer, the main design
+considerations, and the decisions made while building it. It is intended as a concise technical
+record and as source material for an upstream pull-request description.
+
+The exact behavior and defaults are documented in the
+[transformation reference](./logseq-importer-transformations.md).
+
+## 1. What was implemented
+
+The importer adds **Logseq (Markdown graph)** as a first-class source format in the Obsidian
+Importer plugin. It is registered in `src/main.ts` and implemented by
+`LogseqImporter` in `src/formats/logseq.ts`.
+
+On desktop, the user selects a Logseq graph root containing `pages/`, `journals/`, and optionally
+`assets/`. The importer:
+
+- recursively reads Markdown notes under `pages/` and `journals/`;
+- maps namespaced pages to folders and journals to the configured Daily Notes format;
+- converts Logseq tasks, properties, block references, embeds, aliases, tags, org blocks,
+  highlights, numbered lists, media, and local assets;
+- optionally de-outlines pages and journals into flatter Markdown;
+- writes notes into a selected vault folder and copies referenced assets into its `assets/`
+  subfolder;
+- reports note, attachment, skipped-file, and failure progress through `ImportContext`.
+
+The feature is desktop-only because graph selection and source reads use Electron/Node filesystem
+APIs. It targets Logseq's Markdown/file graph format, not the newer database graph format.
+
+## 2. Architecture
+
+### 2.1 Obsidian integration at the boundary
+
+`src/formats/logseq.ts` owns the Obsidian-specific concerns:
+
+- settings UI and graph-folder selection;
+- Daily Notes configuration lookup;
+- filesystem traversal and source-path resolution;
+- output planning, collision reporting, vault writes, and asset copies;
+- the vault-wide indexes required for cross-file conversion.
+
+All modules under `src/formats/logseq/` are pure and Obsidian-independent. This keeps the
+transformation logic directly testable with Node:
+
+| Module | Responsibility |
+|---|---|
+| `options.ts` | option types and defaults |
+| `pipeline.ts` | ordered per-file conversion |
+| `paths.ts` | namespace and percent-encoded filename handling |
+| `properties.ts` | frontmatter and block properties |
+| `tasks.ts` | task states, metadata, repeaters, and LOGBOOK drawers |
+| `blocks.ts` | org blocks, highlights, numbered lists, media, and fence fixes |
+| `block-ids.ts` | block anchors, references, embeds, and orphan handling |
+| `links.ts` | aliases, tags, and same-basename disambiguation |
+| `journals.ts` | source date parsing and target date-link formatting |
+| `assets.ts` | local asset-link conversion and copy planning |
+| `de-outline.ts` | optional outline-to-Markdown restructuring |
+| `normalize.ts` | whitespace cleanup |
+
+### 2.2 Why the importer uses two passes
+
+Logseq block references and alias references can target content in another file. Tag conversion can
+also depend on whether a page exists anywhere in the graph. A single-file streaming conversion
+cannot resolve those cases reliably.
+
+The implemented pipeline therefore has three stages:
+
+1. **Plan:** determine canonical names and output paths, detect exact output-path collisions, and
+   build the same-basename index.
+2. **Pass 1:** convert each file locally while collecting block IDs, aliases, referenced assets,
+   and non-empty canonical page names.
+3. **Pass 2:** resolve block references and aliases, disambiguate same-basename links, convert tags
+   and tag-like frontmatter values, reformat date links, optionally de-outline, skip empty output,
+   and write the note.
+
+This design follows the useful precedent of the existing Roam importer while accounting for
+Logseq's on-disk Markdown layout.
+
+## 3. Main design decisions
+
+### 3.1 Preserve outlines by default; flatten only by explicit choice
+
+Logseq uses indentation and bullets as its document model. Automatically flattening every graph
+would be more idiomatic in Obsidian but could change meaning in mixed prose/list trees.
+
+The importer therefore preserves the outline by default. Independent **De-outline pages** and
+**De-outline journals** toggles allow users to opt in for either kind of note. The de-outliner:
+
+- promotes heading blocks to real Markdown headings;
+- keeps tasks and genuine sibling lists as lists;
+- collapses simple single-child prose chains;
+- turns other prose blocks into paragraphs;
+- preserves block anchors and list-nested fenced code.
+
+The separate toggles were chosen instead of one global mode because long-form pages and journal
+logs often need different treatment. The feature remains marked experimental because the
+paragraph/list distinction is necessarily heuristic.
+
+### 3.2 Keep task conversion inline
+
+The implementation supports three targets:
+
+- **Tasks emoji** (default);
+- **Tasks Dataview fields**;
+- **Plain checkboxes**.
+
+All three keep tasks in their original notes and outline context. The converter recognizes Logseq's
+common workflow states, priorities, scheduled and deadline dates, repeaters, creation/completion/
+cancellation dates, and LOGBOOK drawers.
+
+The default Tasks emoji format gives the best balance of fidelity, readability, and implementation
+risk. Dataview fields expose the same metadata in queryable text. Plain mode requires no community
+plugin and keeps continuation metadata as source text, but collapses workflow states to open/done
+checkboxes.
+
+TaskNotes-style extraction into one file per task was considered but not implemented. It would
+preserve richer status and time-tracking semantics at the cost of breaking in-note context,
+creating potentially thousands of files, and adding a plugin-specific data model.
+
+### 3.3 Treat block references as a graph-wide integrity problem
+
+Logseq stores a full UUID in `id::` and references it as `((uuid))`. Obsidian expects an anchor on
+the target block and a page-qualified wikilink.
+
+Pass 1 builds a graph-wide UUID index and replaces each definition with an Obsidian anchor. By
+default the anchor is the UUID's first six alphanumeric characters, with a per-note suffix for
+short-ID collisions. Users can retain full UUIDs instead.
+
+Pass 2 rewrites:
+
+- bare block references to `[[Page#^anchor]]`, or embeds when configured;
+- block embeds to `![[Page#^anchor]]`;
+- page embeds to `![[Page]]`.
+
+Anchors are placed carefully around headings and fenced code blocks so both Markdown rendering and
+Obsidian block resolution remain valid. Unresolved references are preserved by default; users can
+choose to remove them.
+
+### 3.4 Rewrite references made through aliases
+
+Logseq treats a page alias as an alternate target name. Obsidian aliases improve lookup and display
+but do not make `[[Alias]]` target the canonical note automatically.
+
+The importer therefore:
+
+- writes `alias::`, `aliases::`, and `title::` values to Obsidian's `aliases` frontmatter;
+- builds a case-insensitive alias-to-canonical map;
+- rewrites `[[Alias]]` as `[[Canonical|Alias]]`;
+- leaves an alias unchanged when multiple pages claim it.
+
+This avoids creating dangling notes named after aliases while preserving the user's display text.
+
+### 3.5 Preserve namespace paths and handle ambiguity explicitly
+
+Logseq's `___` and `%2F` namespace encodings become folder separators, and valid percent escapes are
+decoded before filename sanitization. The resulting full path is the page's canonical name.
+
+Two collision classes are handled separately:
+
+- **Exact output-path collisions:** the first planned source is imported and later sources are
+  reported and skipped.
+- **Same basename in different namespaces:** both notes are valid. Bare ambiguous links are
+  rewritten to a full-path target with the original basename as display text. A real top-level note
+  with that basename remains the natural target.
+
+This keeps namespace structure instead of flattening or globally renaming notes.
+
+### 3.6 Make properties safe and useful in Obsidian
+
+Leading page properties become YAML frontmatter. Aliases and tags receive dedicated list handling;
+YAML-sensitive values are quoted; duplicate keys use the last value; and `created`/`updated`
+wikilink dates are normalized when they are plain ISO dates.
+
+Properties used only by Logseq's UI, queries, templates, or internal metadata are always removed.
+Additional page and block keys can be dropped by the user. Retained block properties default to
+Dataview inline-field syntax, with options to keep the raw `key:: value` line or drop it.
+
+Optional kebab-case-to-snake_case conversion was added independently for page and block keys
+because hyphenated property names are awkward to query in Bases and Dataview. Drop-list matching
+still uses the original source key.
+
+### 3.7 Keep tag conversion conservative
+
+Tags remain tags by default. Multi-word Logseq tags are converted to Obsidian-compatible hyphenated
+tags, and six-digit hex colors are protected from tag parsing.
+
+Users can convert tags to wikilinks. The default guard only performs that conversion when the full,
+case-insensitive canonical page name exists in the graph; otherwise the tag remains a tag. The same
+policy applies to scalar frontmatter values such as `status:: #State`.
+
+The separate `dropTags` list applies to body tags and frontmatter tags. `card` is dropped by default
+because it is commonly Logseq SRS metadata rather than a durable topic.
+
+### 3.8 Integrate journals with Daily Notes without assuming more than implemented
+
+The importer reads the target folder and date format from Obsidian's Daily Notes core plugin and
+allows both values to be overridden. Journal filenames matching `YYYY_MM_DD` or `YYYY-MM-DD` are
+normalized through ISO and formatted for the target. English month-name date links are normalized
+and then reformatted to the same target format.
+
+The implementation deliberately does not claim arbitrary source-format support: it does not parse
+Logseq's `config.edn`, custom journal filename/page-title formats, or Periodic Notes settings.
+Unrecognized journal basenames are retained.
+
+### 3.9 Prefer documented preservation or explicit cleanup for Logseq-only syntax
+
+Where there is no direct Obsidian equivalent:
+
+- simple `{{query}}` macros can be kept or removed;
+- org `#+BEGIN_QUERY` blocks become fenced `query` blocks;
+- flashcard cloze wrappers can be kept or unwrapped;
+- `#card` continues through the normal tag/drop-tag pipeline;
+- LOGBOOK drawers can be kept or removed and default to removal;
+- template macros and dynamic variables remain literal text.
+
+Kept simple queries and flashcard syntax add an import report entry so the user can find content
+that may need manual follow-up. Query translation to Dataview, SRS schedule migration, template
+execution, PDF annotation geometry, and whiteboard-to-Canvas conversion are not attempted.
+
+### 3.10 Convert referenced assets, but keep the copy model simple
+
+Markdown links and embeds whose path contains `assets/` become Obsidian wikilinks. Image dimensions
+take precedence over optional alt text. Referenced bytes are resolved relative to the source note
+and copied into `<output>/assets/`.
+
+The current implementation flattens assets by basename. If a destination filename already exists,
+it is retained and a later asset with the same basename is not copied. Renaming and rewriting
+colliding asset basenames remains a known limitation.
+
+## 4. User-facing options and defaults
+
+| Area | Default decision |
+|---|---|
+| Task format | Tasks emoji |
+| Journal target | Daily Notes folder and format |
+| Page/journal structure | Preserve outlines |
+| Tags | Keep as tags; only-existing-page guard ready when conversion is enabled |
+| Dropped tags | `card` |
+| Queries / flashcards | Keep |
+| LOGBOOK drawers | Drop |
+| Block IDs | Shorten |
+| Unresolved block references | Preserve |
+| Bare block references | Link, not embed |
+| Unknown block properties | Wrap as Dataview inline fields |
+| Property key style | Preserve kebab-case |
+| Asset alt text | Drop unless dimensions are present |
+| Whitespace cleanup | Enabled |
+
+The defaults favor low-loss note content and broadly readable Markdown while removing Logseq-only
+operational metadata that has no useful Obsidian meaning.
+
+## 5. Testing and maintainability
+
+The transformation modules are covered by focused Node tests under `tests/logseq/`:
+
+- unit suites for paths, journals, tasks, properties, links, blocks, block IDs, assets,
+  de-outlining, normalization, and orchestration helpers;
+- a multi-file end-to-end fixture graph covering cross-file references, aliases, namespaces,
+  journals, tasks, org blocks, tags, properties, and assets;
+- regression cases for code fences, headings, retained anchors, duplicate names, YAML safety, and
+  option variants.
+
+Fixtures use synthetic graph data. Keeping pure transforms independent of `obsidian` allows the
+same pipeline to be exercised without a running vault, while the orchestrator remains responsible
+for the comparatively small integration surface.
+
+## 6. Known limitations and conscious tradeoffs
+
+- Only Markdown/file-based graphs are supported, and graph selection requires the desktop app.
+- Only Markdown under `pages/` and `journals/` is scanned. Graph-level whiteboards are outside the
+  import and are not individually reported.
+- Physical subdirectories below `pages/` and `journals/` are not preserved by output planning;
+  namespace structure must be encoded in the filename.
+- Source journal formats are pattern-based; `config.edn`, Periodic Notes, weekly/monthly journals,
+  and locale-specific date titles are not parsed.
+- De-outlining is heuristic and therefore opt-in.
+- Rich task modes consume malformed or template-based task date properties without emitting a
+  replacement date; plain mode retains those lines.
+- Advanced org queries are converted to fenced query blocks before the simple-query keep/drop
+  option runs, so they are currently always retained.
+- With the defaults, `flashcards: keep` preserves cloze wrappers but `dropTags: ['card']` still
+  removes `#card`.
+- Ambiguous aliases are left unresolved; ambiguous same-basename links choose the first planned
+  namespaced path when there is no exact top-level note.
+- Duplicate block UUID definitions use the later pass-1 target.
+- Assets are flattened by basename and collisions are not renamed or reported. A missing source
+  asset can leave a rewritten link without a copied file.
+- Existing vault notes at planned output paths are replaced; collision checks only prevent two
+  sources in the same import from claiming one output path.
+- There is no TaskNotes extraction, query-language translation, SRS schedule migration,
+  template/macro execution, PDF geometry migration, or whiteboard conversion.
+
+These constraints keep the first-class importer understandable, testable, and conservative while
+covering the Markdown conventions that most directly affect whether a migrated graph remains
+navigable and useful.

--- a/docs/logseq-importer-transformations.md
+++ b/docs/logseq-importer-transformations.md
@@ -164,8 +164,9 @@ and re-serializes it as idiomatic markdown using these heuristics:
   when the only continuation is a `^anchor` — in that case the anchor lands directly on the next
   line with no gap (required for Obsidian block-reference resolution).
 - A subtree that is a **genuine list** (2+ siblings where all are list-compatible — leaves, tasks,
-  or recursively list-compatible nodes with their own children) stays a list, re-indented from
-  depth 0.
+  or recursively list-compatible nodes with their own children — but **not headings**) stays a
+  list, re-indented from depth 0. Headings are never list-compatible and always promoted to real
+  headings, even when siblings of list items.
 - A **single-child chain** of prose collapses into one paragraph (avoids one-item lists), provided
   the leaf has no children of its own.
 - Other prose bullets become paragraphs separated by blank lines.
@@ -299,6 +300,16 @@ that the UUID must exist in the block index — unrecognised UUIDs are left as-i
 copy-pasteable code examples that include Logseq embed syntax are updated to the equivalent Obsidian
 form. Inline-code spans (single backticks) are still protected and never rewritten.
 
+**Always-embed option (`alwaysEmbedBlockRefs`).** By default, bare `((uuid))` references become
+plain links `[[Page#^id]]`. With `alwaysEmbedBlockRefs: true`, they become embeds `![[Page#^id]]`
+instead — useful because Obsidian displays embeds inline while plain links just show the anchor
+text. Block embeds (`{{embed ((uuid))}}`) always produce `![[...]]` regardless of this option.
+
+**Orphan block references.** A `((uuid))` whose target was never defined in the graph is left
+untouched by default (the raw text survives). With `removeOrphanBlockRefs` on, such unresolved
+`((uuid))` references and `{{embed ((uuid))}}` embeds are removed cleanly (including lines that
+become empty). This runs *after* `resolveBlockRefs`, so only genuine orphans remain to remove.
+
 ---
 
 ## 8. Tags
@@ -400,6 +411,7 @@ user block properties (e.g. `rating:: 5`) are **kept** by default.
 |---|---|---|
 | `![alt](../assets/x.png)` | `![[x.png]]` | bytes copied to `<output>/assets/` |
 | `[label](../assets/x.pdf)` | `[[x.pdf]]` | plain (non-embed) asset links also converted |
+| `[label [nested] label](../assets/x.pdf)` | `[[x.pdf]]` | label allows one level of nested brackets |
 | `![alt](../assets/x.png){:height H, :width W}` | `![[x.png\|WxH]]` | dimensions always win over alt text |
 | `![alt](../assets/x.png)` with `keepAssetAltText` | `![[x.png\|alt]]` | only when no dimensions and alt is non-empty |
 | `![](../assets/Book_(2024).pdf)` | `![[Book_(2024).pdf]]` | paren-balanced path matching |

--- a/docs/logseq-importer-transformations.md
+++ b/docs/logseq-importer-transformations.md
@@ -6,35 +6,39 @@ under `src/formats/logseq/`, including all adjustments made after the original
 [assessment](./logseq-importer-assessment.md) (which remains the design-rationale and roadmap
 document).
 
+Tests and implementation comments cross-reference this document with letter-number labels: one
+letter per top-level section (`A` through `M`) plus a rule number, such as `[G1]`. Older
+development-phase labels are no longer used as public references.
+
 Guiding principle throughout: **never silently delete content.** Anything that cannot be faithfully
 converted is either preserved verbatim or skipped with an explicit `ctx.reportSkipped` /
 `reportFailed` entry, so the user always knows.
 
 ## Contents
 
-1. [Pipeline overview](#1-pipeline-overview)
-2. [Options reference](#2-options-reference)
-3. [Document structure & de-outlining](#3-document-structure--de-outlining)
-4. [Tasks](#4-tasks)
-5. [Journals & dates](#5-journals--dates)
-6. [Pages, namespaces & output paths](#6-pages-namespaces--output-paths)
-7. [Links, references & embeds](#7-links-references--embeds)
-8. [Tags](#8-tags)
-9. [Properties](#9-properties)
-10. [Inline syntax & blocks](#10-inline-syntax--blocks)
-11. [Media & assets](#11-media--assets)
-12. [Logseq-only content](#12-logseq-only-content)
-13. [Name collisions & disambiguation](#13-name-collisions--disambiguation)
+- [A. Pipeline overview](#a-pipeline-overview)
+- [B. Options reference](#b-options-reference)
+- [C. Document structure & de-outlining](#c-document-structure--de-outlining)
+- [D. Tasks](#d-tasks)
+- [E. Journals & dates](#e-journals--dates)
+- [F. Pages, namespaces & output paths](#f-pages-namespaces--output-paths)
+- [G. Links, references & embeds](#g-links-references--embeds)
+- [H. Tags](#h-tags)
+- [I. Properties](#i-properties)
+- [J. Inline syntax & blocks](#j-inline-syntax--blocks)
+- [K. Media & assets](#k-media--assets)
+- [L. Logseq-only content](#l-logseq-only-content)
+- [M. Name collisions & disambiguation](#m-name-collisions--disambiguation)
 
 ---
 
-## 1. Pipeline overview
+## A. Pipeline overview
 
 The import runs in **two passes** so that cross-file references can be resolved against a
 vault-wide index that only exists once every file has been planned and locally converted.
 
 **Planning.** Files under `pages/` and `journals/` are enumerated. Each is assigned a canonical
-name and an output path (section 6). During planning, files are skipped when:
+name and an output path (section F). During planning, files are skipped when:
 
 - The path matches `whiteboards/` — not supported.
 - Two sources would map to the *same output path* — the first wins; later colliders are reported
@@ -42,14 +46,14 @@ name and an output path (section 6). During planning, files are skipped when:
 
 From the surviving plans we build:
 
-- a **basename disambiguation index** (`basename → [full path, …]`, section 13).
+- a **basename disambiguation index** (`basename → [full path, …]`, section M).
 
 **Pass 1 — per-file local conversion** (`convertLocal` in `pipeline.ts`). Everything that can be
 done on a single file without the vault index. In order:
 
-1. `extractPageProperties` — leading `key:: value` block → YAML frontmatter (section 9).
+1. `extractPageProperties` — leading `key:: value` block → YAML frontmatter (section I).
 2. `convertHeadingProperty` — `heading:: N` → `#`×N prefix on the block.
-3. `convertTasks` — task keywords + metadata → chosen task format (section 4).
+3. `convertTasks` — task keywords + metadata → chosen task format (section D).
 4. `convertNumberedLists` — `logseq.order-list-type:: number` → `1.`/`2.`/…
 5. `convertOrgBlocks` — `#+BEGIN_*`/`#+END_*` → callouts / blockquotes / comments.
 6. `convertHighlights` — `^^text^^` → `==text==`.
@@ -81,16 +85,16 @@ links to pages that will never be written.
 2. `removeOrphanBlockRefs` — *(option)* strip references whose uuid was never defined.
 3. `rewriteAliasReferences` — `[[Alias]]` → `[[Canonical|Alias]]`.
 4. `disambiguateBasenameLinks` — bare `[[name]]` → `[[full/path|name]]` when the basename is shared.
-5. `convertTags` — keep / sanitize / link / drop tags (section 8).
+5. `convertTags` — keep / sanitize / link / drop tags (section H).
 6. ISO date-link reformat — `[[YYYY-MM-DD]]` → target Daily-Notes format if it differs.
 7. `deOutline` — *(option)* flatten the outline for journals and/or pages.
-8. **Empty-page check** — if the resulting body is blank and there is no YAML frontmatter, the page
+8. **[A1] Empty-page check** — if the resulting body is blank and there is no YAML frontmatter, the page
    is skipped (reported via `ctx.reportSkipped`) rather than written as an empty file.
 9. Write the note (`yaml + body`), then copy assets.
 
 ---
 
-## 2. Options reference
+## B. Options reference
 
 All options live in `src/formats/logseq/options.ts` (`LogseqImportOptions`). Defaults below are
 `DEFAULT_LOGSEQ_OPTIONS`. The settings UI (`logseq.ts`) groups them into the sections shown.
@@ -99,7 +103,7 @@ All options live in `src/formats/logseq/options.ts` (`LogseqImportOptions`). Def
 
 | Option | Type | Default | Effect |
 |---|---|---|---|
-| `taskFormat` | `'tasks-emoji' \| 'tasks-dataview' \| 'plain'` | `tasks-emoji` | How rich task metadata is serialized (section 4). |
+| `taskFormat` | `'tasks-emoji' \| 'tasks-dataview' \| 'plain'` | `tasks-emoji` | How rich task metadata is serialized (section D). |
 
 ### Journals
 
@@ -108,14 +112,14 @@ All options live in `src/formats/logseq/options.ts` (`LogseqImportOptions`). Def
 | `useDailyNotes` | boolean | `true` | Migrate journals into the Daily Notes folder using its date format. When on, the folder/format fields are filled from Daily Notes config and disabled. |
 | `journalFolder` | string | from Daily Notes, else `Journals` | Vault folder (relative to output) for journals. |
 | `journalDateFormat` | string | from Daily Notes, else `YYYY-MM-DD` | moment.js format for journal filenames. |
-| `deOutlineJournals` | boolean | `false` | Flatten journal outlines to paragraphs/headings (section 3). |
+| `deOutlineJournals` | boolean | `false` | Flatten journal outlines to paragraphs/headings (section C). |
 
 ### Pages
 
 | Option | Type | Default | Effect |
 |---|---|---|---|
 | `pagesFolder` | string | `''` | Vault folder (relative to output) for pages. Empty = output root. |
-| `deOutlinePages` | boolean | `false` | Flatten page outlines to paragraphs/headings (section 3). |
+| `deOutlinePages` | boolean | `false` | Flatten page outlines to paragraphs/headings (section C). |
 
 ### Links & tags
 
@@ -129,8 +133,8 @@ All options live in `src/formats/logseq/options.ts` (`LogseqImportOptions`). Def
 
 | Option | Type | Default | Effect |
 |---|---|---|---|
-| `queries` | `'keep' \| 'drop'` | `keep` | `{{query}}` / `#+BEGIN_QUERY` blocks (section 12). |
-| `flashcards` | `'keep' \| 'drop'` | `keep` | `#card` markers and `{{cloze}}` wrappers (section 12). |
+| `queries` | `'keep' \| 'drop'` | `keep` | `{{query}}` / `#+BEGIN_QUERY` blocks (section L). |
+| `flashcards` | `'keep' \| 'drop'` | `keep` | `#card` markers and `{{cloze}}` wrappers (section L). |
 | `logbook` | `'keep' \| 'drop'` | `drop` | `:LOGBOOK:` / `CLOCK:` time-tracking blocks on tasks. |
 
 ### Assets
@@ -159,11 +163,11 @@ All options live in `src/formats/logseq/options.ts` (`LogseqImportOptions`). Def
 
 | Option | Type | Default | Effect |
 |---|---|---|---|
-| `normalizeWhitespace` | boolean | `true` | Trim trailing whitespace, remove lone empty bullets (`- `), and convert non-breaking spaces (U+00A0) to regular spaces. Fenced code blocks (both standard ` ``` ` and bullet-prefixed `- ``` ` fences) and intentional blank lines are left untouched; empty bullets that carry a `^anchor` are kept. |
+| `normalizeWhitespace` | boolean | `true` | **[B1]** Trim trailing whitespace, remove lone empty bullets (`- `), and convert non-breaking spaces (U+00A0) to regular spaces. Fenced code blocks (both standard ` ``` ` and bullet-prefixed `- ``` ` fences) and intentional blank lines are left untouched; empty bullets that carry a `^anchor` are kept. |
 
 ---
 
-## 3. Document structure & de-outlining
+## C. Document structure & de-outlining
 
 Logseq treats every document as an outline of nested `- ` bullets; indentation *is* the structure.
 Obsidian uses flat markdown.
@@ -177,20 +181,20 @@ gets a `- ` prefix so Obsidian renders the children correctly).
 dynamic UI; both are always-visible switches). `deOutline` (`de-outline.ts`) parses the bullet tree
 and re-serializes it as idiomatic markdown using these heuristics:
 
-- A bullet whose content is a **heading** (`# …`) de-nests to a real heading; its children become
-  the body under it. Multiline heading continuations get a blank line separator (F6), **except**
+- **[C1]** A bullet whose content is a **heading** (`# …`) de-nests to a real heading; its children become
+  the body under it. Multiline heading continuations get a blank line separator, **except**
   when the only continuation is a `^anchor` — in that case the anchor lands directly on the next
   line with no gap (required for Obsidian block-reference resolution).
-- A subtree that is a **genuine list** (2+ siblings where all are list-compatible — leaves, tasks,
+- **[C1]** A subtree that is a **genuine list** (2+ siblings where all are list-compatible — leaves, tasks,
   or recursively list-compatible nodes with their own children — but **not headings**) stays a
   list, re-indented from depth 0. Headings are never list-compatible and always promoted to real
   headings, even when siblings of list items.
-- A **single-child chain** of prose collapses into one paragraph (avoids one-item lists), provided
+- **[C1]** A **single-child chain** of prose collapses into one paragraph (avoids one-item lists), provided
   the leaf has no children of its own.
-- Other prose bullets become paragraphs separated by blank lines.
-- **Tasks** always remain list items; consecutive tasks are grouped into a compact list.
-- **Code blocks** with a trailing `^anchor` on the closing fence are recognized as terminated (F1).
-- **Tab-aware de-indent** (F2): continuation lines are stripped of their actual whitespace prefix
+- **[C1]** Other prose bullets become paragraphs separated by blank lines.
+- **[C1]** **Tasks** always remain list items; consecutive tasks are grouped into a compact list.
+- **[C1]** **Code blocks** with a trailing `^anchor` on the closing fence are recognized as terminated.
+- **[C1]** **Tab-aware de-indent:** continuation lines are stripped of their actual whitespace prefix
   (not a fixed character count), so tabs and spaces are both handled correctly.
 
 De-outline runs **last** in pass 2, after all other conversions, so tasks/properties/links are
@@ -199,15 +203,15 @@ Preserve is the default.
 
 ---
 
-## 4. Tasks
+## D. Tasks
 
 Logseq tasks are bullets whose text starts with a workflow keyword. Recognized keywords:
 `TODO, DOING, DONE, LATER, NOW, WAITING, WAIT, IN-PROGRESS, CANCELLED, CANCELED`.
 
-A colon may follow the keyword (`- TODO: do the thing`); it is recognized as a task and the colon is
+A colon may follow the keyword (`- TODO: do the thing`); **[D1]** it is recognized as a task and the colon is
 dropped from the emitted text.
 
-The task line plus its indented continuation lines (`SCHEDULED:`, `DEADLINE:`, `:LOGBOOK:`, and
+**[D1]** The task line plus its indented continuation lines (`SCHEDULED:`, `DEADLINE:`, `:LOGBOOK:`, and
 `created/completed/done/cancelled` properties) are parsed as one unit and re-emitted. A Logseq
 set-literal date value (`completed:: #{"Mar 3rd, 2025"}`) is unwrapped to its quoted date; a
 malformed set literal emits no completion date.
@@ -238,12 +242,14 @@ Notes:
 - In **plain** format, priority and scheduling are not extracted into metadata — continuation lines
   are kept as-is, so no information is destroyed (it just stays inline).
 - The **repeater** emoji form distinguishes `.+`/`++` (→ "when done") from `+` (fixed).
-- **LOGBOOK** has no Obsidian target; with `logbook: 'drop'` (default) it is removed cleanly,
+- **[D1]** Task metadata dates normalize ISO and Logseq long-date values to `YYYY-MM-DD`; unparsable values
+  such as template tokens are not emitted as task metadata.
+- **[D1]** **LOGBOOK** has no Obsidian target; with `logbook: 'drop'` (default) it is removed cleanly,
   with `logbook: 'keep'` the `:LOGBOOK:`/`CLOCK:` lines are preserved verbatim.
 
 ---
 
-## 5. Journals & dates
+## E. Journals & dates
 
 Journals have two distinct format ends, neither hard-coded:
 
@@ -257,14 +263,14 @@ Journals have two distinct format ends, neither hard-coded:
 core plugin (`app.internalPlugins.getPluginById('daily-notes')`), falling back to `Journals` /
 `YYYY-MM-DD`. When off, the user's `journalFolder` / `journalDateFormat` are used.
 
-If the target format differs from ISO, pass 2 reformats every in-content `[[YYYY-MM-DD]]` link to
+**[E1]** If the target format differs from ISO, pass 2 reformats every in-content `[[YYYY-MM-DD]]` link to
 the target format so links keep matching the filenames.
 
 ---
 
-## 6. Pages, namespaces & output paths
+## F. Pages, namespaces & output paths
 
-- **Pages** are placed under `pagesFolder` (or the output root if empty). A namespaced Logseq page
+- **[F1]** **Pages** are placed under `pagesFolder` (or the output root if empty). A namespaced Logseq page
   filename is converted to a folder path: `namespaceToPath` splits on `%2F` if present, otherwise
   on the `___` separator, percent-decodes each segment (`decodeLogseqName`, tolerant of malformed
   escapes), and joins with `/`. So `a___b.md` → `a/b.md` and `Encoded%3AColon.md` → `Encoded:Colon.md`.
@@ -277,19 +283,19 @@ the target format so links keep matching the filenames.
   and `journals/`.
 ---
 
-## 7. Links, references & embeds
+## G. Links, references & embeds
 
 | Logseq | Obsidian | When |
 |---|---|---|
 | `[[Page]]` | `[[Page]]` (namespace text matches output path) | always |
-| `[display]([[Page]])` | `[[Page\|display]]` | pass 1, skips code fences; strips any pre-existing pipe in target (L2) |
+| `[display]([[Page]])` | `[[Page\|display]]` | **[G1]** pass 1, skips code fences; strips any pre-existing pipe in target |
 | `[[Alias]]` (reference *by alias*) | `[[Canonical\|Alias]]` | pass 2 |
 | `id:: <uuid>` block property | `^shortid` appended to the block line | pass 1 |
 | `((uuid))` | `[[Page#^shortid]]` | pass 2, if resolved |
 | `{{embed ((uuid))}}` | `![[Page#^shortid]]` | pass 2, if resolved |
 | `{{embed [[Page]]}}` | `![[Page]]` | pass 2 |
 
-**Aliases are not interchangeable between the two apps.** Logseq resolves `[[Some Alias]]` to the
+**[G1] Aliases are not interchangeable between the two apps.** Logseq resolves `[[Some Alias]]` to the
 canonical page anywhere; Obsidian links must target the canonical note name. So the importer builds
 an **alias → canonical** map from every page's `alias::`/`aliases::` property (and `title::`) and
 rewrites any reference that targets an alias into `[[Canonical|Alias]]` (keeping the alias as
@@ -299,7 +305,7 @@ The alias values still go into the note's `aliases:` frontmatter so Obsidian aut
 **Ambiguous aliases** (the same alias claimed by multiple pages) are dropped from the map and left
 unrewritten.
 
-**Block IDs.** Logseq UUIDs (e.g. `64ab9aa4-459a-41b1-8c21-dbb38dc0c79b`) are shortened to a stable
+**[G1] Block IDs.** Logseq UUIDs (e.g. `64ab9aa4-459a-41b1-8c21-dbb38dc0c79b`) are shortened to a stable
 6-char anchor (`^64ab9a`) when `shortenBlockIds` is on (default), or kept full when off. Short-id
 collisions **within one note** are disambiguated by appending `-1`, `-2`, … The same mapping is
 used to rewrite every `((uuid))` reference, so anchors and links stay consistent. Anchor placement
@@ -316,31 +322,31 @@ is context-aware:
 - After retained block properties: the anchor lands on the **last non-blank line** (including kept
   property lines), not the content line before them.
 
-**Block references inside code blocks.** `resolveBlockRefs` converts `((uuid))` and
+**[G1] Block references inside code blocks.** `resolveBlockRefs` converts `((uuid))` and
 `{{embed ((uuid))}}` references **everywhere**, including inside fenced code blocks. The guard is
 that the UUID must exist in the block index — unrecognised UUIDs are left as-is. This means
 copy-pasteable code examples that include Logseq embed syntax are updated to the equivalent Obsidian
 form. Inline-code spans (single backticks) are still protected and never rewritten.
 
-**Always-embed option (`alwaysEmbedBlockRefs`).** By default, bare `((uuid))` references become
+**[G1] Always-embed option (`alwaysEmbedBlockRefs`).** By default, bare `((uuid))` references become
 plain links `[[Page#^id]]`. With `alwaysEmbedBlockRefs: true`, they become embeds `![[Page#^id]]`
 instead — useful because Obsidian displays embeds inline while plain links just show the anchor
 text. Block embeds (`{{embed ((uuid))}}`) always produce `![[...]]` regardless of this option.
 
-**Orphan block references.** A `((uuid))` whose target was never defined in the graph is left
+**[G1] Orphan block references.** A `((uuid))` whose target was never defined in the graph is left
 untouched by default (the raw text survives). With `removeOrphanBlockRefs` on, such unresolved
 `((uuid))` references and `{{embed ((uuid))}}` embeds are removed cleanly (including lines that
 become empty). This runs *after* `resolveBlockRefs`, so only genuine orphans remain to remove.
 
 ---
 
-## 8. Tags
+## H. Tags
 
 Tag handling happens in pass 2 (`convertTags`), outside code fences. Two syntaxes are recognized:
 `#simple-tag` and `#[[multi word tag]]`. Tags must follow the start of line, whitespace, or an
 opening bracket/paren (`([`). For each tag, in order:
 
-1. **Hex color?** Pure 6-digit hex tokens (`#FF0000`) are never treated as tags — left as-is.
+1. **[H1] Hex color?** Pure 6-digit hex tokens (`#FF0000`) are never treated as tags — left as-is.
 2. **Drop?** If the tag (or its hyphenated form) is in `dropTags`, it is removed entirely.
    Default `dropTags` is `['card']`.
 3. **Convert to link?** Only if `convertTagsToLinks` is on:
@@ -351,15 +357,15 @@ opening bracket/paren (`([`). For each tag, in order:
 4. **Keep as tag (default).** Multi-word `#[[multi word]]` is sanitized to `#multi-word`; simple
    tags are left as-is.
 
-Tags listed in `dropTags` are also removed from frontmatter `tags:` (section 9).
+Tags listed in `dropTags` are also removed from frontmatter `tags:` (section I).
 
 ---
 
-## 9. Properties
+## I. Properties
 
 ### Page properties → frontmatter
 
-The leading block of unindented `key:: value` lines becomes YAML frontmatter
+**[I1]** The leading block of unindented `key:: value` lines becomes YAML frontmatter
 (`extractPageProperties`):
 
 - `alias` / `aliases` → an `aliases:` list (wikilink brackets stripped).
@@ -369,29 +375,29 @@ The leading block of unindented `key:: value` lines becomes YAML frontmatter
   removed from YAML as a standalone key. Also kept in `raw` for the filename / reporting.
 - Keys listed in `dropPageProperties` → dropped. Default: `public`, `exclude-from-graph-view`,
   `icon`. (`icon` carries a Logseq private-use glyph that renders as □ in Obsidian.)
-- **Tag-style values → links (pass-2):** a scalar value that is a single tag (`status:: #IN-PROGRESS`,
+- **[I1]** **Tag-style values → links (pass-2):** a scalar value that is a single tag (`status:: #IN-PROGRESS`,
   `area:: #[[Page One]]`) is emitted as quoted text (`status: "#IN-PROGRESS"`) by default. When tag
   conversion is enabled (`convertTagsToLinks`), the value is linkified to a wikilink
   (`status: "[[IN-PROGRESS]]"`) using the vault-wide page set, respecting
   `convertTagsOnlyExistingPages`. With tag conversion off (the default) these values stay quoted text,
   so default output is unchanged. `tags:` / `aliases:` lists are never affected.
-- **YAML quoting:** values that are YAML-unsafe (contain `: `, `#`, start with `[`, `{`, are
+- **[I1]** **YAML quoting:** values that are YAML-unsafe (contain `: `, `#`, start with `[`, `{`, are
   boolean words, integers, floats, or reserved YAML tokens) are double-quoted. Wikilink-valued
   scalars are also quoted (`project: "[[Big Project]]"`); multiple wikilink values become a quoted
   list.
-- **Date extraction:** values wrapped in `[[…]]` that parse as dates are unwrapped and emitted as
+- **[I1]** **Date extraction:** values wrapped in `[[…]]` that parse as dates are unwrapped and emitted as
   bare ISO dates (not quoted). Template tokens like `{{date}}` are left as-is.
-- **List splitting:** comma-separated values are split with bracket-awareness (respects `[[…]]`
+- **[I1]** **List splitting:** comma-separated values are split with bracket-awareness (respects `[[…]]`
   and `(…)` boundaries so `[[a, b]]` is not split mid-link).
-- **Duplicate keys:** when the same key appears multiple times, last value wins; insertion order
+- **[I1]** **Duplicate keys:** when the same key appears multiple times, last value wins; insertion order
   of first occurrence is preserved in the YAML output.
-- Empty-valued properties (key with no value) are silently dropped.
+- **[I1]** Empty-valued properties (key with no value) are silently dropped.
 
 If a file starts with a `- ` bullet, it has no page-property block.
 
 ### Block properties → cleaned from body
 
-Indented `key:: value` continuation lines are stripped by `removeLeftoverBlockProperties` (after
+**[I1]** Indented `key:: value` continuation lines are stripped by `removeLeftoverBlockProperties` (after
 `heading::`, `id::`, and `logseq.order-list-type::` have been handled by their own converters).
 Both standard indented form (`  key:: value`) and bullet form (`- key:: value`) are recognized.
 
@@ -402,7 +408,7 @@ starting with `logseq.`**, **`query-`**, **`hl-`**, or **`ls-`** (highlight/anno
 
 **Additionally dropped:** any key the user lists in `dropBlockProperties` (default empty).
 
-**Retained (unknown) block properties** (e.g. `rating:: 5`, `participants:: [[Alice]], [[Bob]]`) are
+**[I1] Retained (unknown) block properties** (e.g. `rating:: 5`, `participants:: [[Alice]], [[Bob]]`) are
 handled by the `blockProperties` option:
 
 - `keep` — the raw `key:: value` line is left as-is.
@@ -422,51 +428,51 @@ The always-dropped set and `dropBlockProperties` keys win in every mode.
 | `heading:: N` (1–6) | `#`×N prefix on the owning bullet; the property line is dropped |
 | `heading:: true` (auto) | property line dropped, no prefix |
 | `logseq.order-list-type:: number` | bullet becomes `1.`, `2.`, … (counter per indent level) |
-| `id:: <uuid>` | `^shortid` anchor (section 7) |
+| `id:: <uuid>` | `^shortid` anchor (section G) |
 
 ---
 
-## 10. Inline syntax & blocks
+## J. Inline syntax & blocks
 
 | Logseq | Obsidian | Notes |
 |---|---|---|
-| `^^highlight^^` | `==highlight==` | skips fenced **and** inline code |
-| `#+BEGIN_QUOTE` … `#+END_QUOTE` | `> ` blockquote | |
-| `- #+BEGIN_QUOTE` (bullet-prefixed) | `- > text` blockquote under bullet | Issue 1: preserves list structure |
-| `#+BEGIN_NOTE/TIP/WARNING/IMPORTANT/CAUTION/EXAMPLE` | `> [!type]` callout | first `**bold**` line becomes the callout title |
-| `- #+BEGIN_TIP` (bullet-prefixed) | `- > [!tip]` callout under bullet | |
+| `^^highlight^^` | `==highlight==` | **[J1]** skips fenced **and** inline code |
+| `#+BEGIN_QUOTE` … `#+END_QUOTE` | `> ` blockquote | **[J1]** |
+| `- #+BEGIN_QUOTE` (bullet-prefixed) | `- > text` blockquote under bullet | **[J1]** preserves list structure |
+| `#+BEGIN_NOTE/TIP/WARNING/IMPORTANT/CAUTION/EXAMPLE` | `> [!type]` callout | **[J1]** first `**bold**` line becomes the callout title |
+| `- #+BEGIN_TIP` (bullet-prefixed) | `- > [!tip]` callout under bullet | **[J1]** |
 | `#+BEGIN_COMMENT` | `%% … %%` | |
-| `#+BEGIN_QUERY` … `#+END_QUERY` | `` ```query `` … `` ``` `` | preserves query DSL verbatim in a fenced block |
+| `#+BEGIN_QUERY` … `#+END_QUERY` | `` ```query `` … `` ``` `` | **[J1]** preserves query DSL verbatim in a fenced block |
 | other `#+BEGIN_*` (CENTER/VERSE/PINNED/…) | `> [!note]` fallback | nesting supported |
-| `#+BEGIN_*` inside a fenced code block | left unchanged | fence-aware: org markers in code are inert |
-| numbered list (bullet + `logseq.order-list-type:: number`) | `1.` `2.` `3.` | counter resets on level change / non-numbered sibling |
-| code fences in bullets | code fence with aligned closing fence | `fixCodeBlocksInLists` (tab-safe indent) |
+| `#+BEGIN_*` inside a fenced code block | left unchanged | **[J1]** fence-aware: org markers in code are inert |
+| numbered list (bullet + `logseq.order-list-type:: number`) | `1.` `2.` `3.` | **[J1]** counter resets on level change / non-numbered sibling |
+| code fences in bullets | code fence with aligned closing fence | **[J1]** `fixCodeBlocksInLists` (tab-safe indent) |
 | heading followed by indented list | `- # Heading` + list | `fixHeadingChildLists` |
 | `$inline$` / `$$block$$` math | unchanged | both apps use MathJax |
 
 ---
 
-## 11. Media & assets
+## K. Media & assets
 
 | Logseq | Obsidian | Notes |
 |---|---|---|
-| `![alt](../assets/x.png)` | `![[x.png]]` | bytes copied to `<output>/assets/` |
-| `[label](../assets/x.pdf)` | `[[x.pdf]]` | plain (non-embed) asset links also converted |
-| `[label [nested] label](../assets/x.pdf)` | `[[x.pdf]]` | label allows one level of nested brackets |
+| `![alt](../assets/x.png)` | `![[x.png]]` | **[K1]** bytes copied to `<output>/assets/` |
+| `[label](../assets/x.pdf)` | `[[x.pdf]]` | **[K1]** plain (non-embed) asset links also converted |
+| `[label [nested] label](../assets/x.pdf)` | `[[x.pdf]]` | **[K1]** label allows one level of nested brackets |
 | `![alt](../assets/x.png){:height H, :width W}` | `![[x.png\|WxH]]` | dimensions always win over alt text |
 | `![alt](../assets/x.png)` with `keepAssetAltText` | `![[x.png\|alt]]` | only when no dimensions and alt is non-empty |
-| `![](../assets/Book_(2024).pdf)` | `![[Book_(2024).pdf]]` | paren-balanced path matching |
+| `![](../assets/Book_(2024).pdf)` | `![[Book_(2024).pdf]]` | **[K1]** paren-balanced path matching |
 | `{{video URL}}` / `{{youtube URL}}` | `![](URL)` | |
 | `{{tweet URL}}` | `![](URL)` | |
 
-Only links whose path contains `assets/` are treated as local assets; URLs (`http:`, `https:`,
+**[K1]** Only links whose path contains `assets/` are treated as local assets; URLs (`http:`, `https:`,
 `data:`) and other paths are left alone. Asset links inside fenced code blocks **and inline code
 spans** are not converted. Assets are de-duplicated by filename when copied; the byte copy resolves
 the source relative to the note's directory (tolerant of `../` prefixes).
 
 ---
 
-## 12. Logseq-only content
+## L. Logseq-only content
 
 Each Logseq-only feature has an independent keep/drop choice. "Keep" preserves the text verbatim
 (and reports it via `ctx.reportSkipped` so the user can revisit it); "drop" removes it cleanly.
@@ -485,7 +491,7 @@ Templater/QuickAdd syntax is not attempted. They typically appear only on `templ
 
 ---
 
-## 13. Name collisions & disambiguation
+## M. Name collisions & disambiguation
 
 Because namespaces become folders, two notes in different folders can share a basename
 (e.g. `projects/notes` and `personal/notes`). This is **valid in Obsidian** — a note's canonical
@@ -496,7 +502,7 @@ The importer handles this natively, with no flattening:
 
 - **Output-path collisions** (two sources mapping to the *exact same* path) are detected during
   planning. The first writer wins; later colliders are reported and skipped — no silent overwrite.
-- **Ambiguous bare links.** A `basename → [paths]` index is built from all plans. In pass 2,
+- **[M1] Ambiguous bare links.** A `basename → [paths]` index is built from all plans. In pass 2,
   `disambiguateBasenameLinks` rewrites any bare `[[name]]` whose basename maps to 2+ notes into
   `[[full/path|name]]` (using the first path as canonical, and preserving any explicit display
   text). If one of the paths is an **exact top-level match** (no namespace / folder), the link is

--- a/docs/logseq-importer-transformations.md
+++ b/docs/logseq-importer-transformations.md
@@ -160,12 +160,17 @@ dynamic UI; both are always-visible switches). `deOutline` (`de-outline.ts`) par
 and re-serializes it as idiomatic markdown using these heuristics:
 
 - A bullet whose content is a **heading** (`# …`) de-nests to a real heading; its children become
-  the body under it.
-- A subtree that is a **genuine list** (2+ leaf-ish siblings, or any all-task group) stays a list,
-  re-indented from depth 0.
-- A **single-child chain** of prose collapses into one paragraph (avoids one-item lists).
+  the body under it. Multiline heading continuations get a blank line separator (F6).
+- A subtree that is a **genuine list** (2+ siblings where all are list-compatible — leaves, tasks,
+  or recursively list-compatible nodes with their own children) stays a list, re-indented from
+  depth 0.
+- A **single-child chain** of prose collapses into one paragraph (avoids one-item lists), provided
+  the leaf has no children of its own.
 - Other prose bullets become paragraphs separated by blank lines.
 - **Tasks** always remain list items; consecutive tasks are grouped into a compact list.
+- **Code blocks** with a trailing `^anchor` on the closing fence are recognized as terminated (F1).
+- **Tab-aware de-indent** (F2): continuation lines are stripped of their actual whitespace prefix
+  (not a fixed character count), so tabs and spaces are both handled correctly.
 
 De-outline runs **last** in pass 2, after all other conversions, so tasks/properties/links are
 already in their final form. It is heuristic and may restructure incidental nesting — which is why
@@ -252,7 +257,7 @@ the target format so links keep matching the filenames.
 | Logseq | Obsidian | When |
 |---|---|---|
 | `[[Page]]` | `[[Page]]` (namespace text matches output path) | always |
-| `[display]([[Page]])` | `[[Page\|display]]` | pass 1, skips code fences |
+| `[display]([[Page]])` | `[[Page\|display]]` | pass 1, skips code fences; strips any pre-existing pipe in target (L2) |
 | `[[Alias]]` (reference *by alias*) | `[[Canonical\|Alias]]` | pass 2 |
 | `id:: <uuid>` block property | `^shortid` appended to the block line | pass 1 |
 | `((uuid))` | `[[Page#^shortid]]` | pass 2, if resolved |
@@ -261,37 +266,52 @@ the target format so links keep matching the filenames.
 
 **Aliases are not interchangeable between the two apps.** Logseq resolves `[[Some Alias]]` to the
 canonical page anywhere; Obsidian links must target the canonical note name. So the importer builds
-an **alias → canonical** map from every page's `alias::`/`aliases::` property and rewrites any
-reference that targets an alias into `[[Canonical|Alias]]` (keeping the alias as display text). The
-alias values still go into the note's `aliases:` frontmatter so Obsidian autocomplete works.
+an **alias → canonical** map from every page's `alias::`/`aliases::` property (and `title::`) and
+rewrites any reference that targets an alias into `[[Canonical|Alias]]` (keeping the alias as
+display text). **Self-aliases** (where the alias matches the canonical page name) are skipped to
+avoid redundant `[[Name|Name]]` rewrites. Alias rewriting also skips inline-code spans.
+The alias values still go into the note's `aliases:` frontmatter so Obsidian autocomplete works.
 **Ambiguous aliases** (the same alias claimed by multiple pages) are dropped from the map and left
 unrewritten.
 
 **Block IDs.** Logseq UUIDs (e.g. `64ab9aa4-459a-41b1-8c21-dbb38dc0c79b`) are shortened to a stable
 6-char anchor (`^64ab9a`) when `shortenBlockIds` is on (default), or kept full when off. Short-id
 collisions **within one note** are disambiguated by appending `-1`, `-2`, … The same mapping is
-used to rewrite every `((uuid))` reference, so anchors and links stay consistent.
+used to rewrite every `((uuid))` reference, so anchors and links stay consistent. Anchor placement
+is context-aware:
+
+- On a closing code fence (`` ``` ``): the anchor goes on a **new line after** the fence (appending
+  to the fence would break CommonMark).
+- On a heading line: the anchor goes on its own line **below** the heading (Obsidian renders anchors
+  on heading lines as literal text).
+- After retained block properties: the anchor lands on the **last non-blank line** (including kept
+  property lines), not the content line before them.
 
 **Orphan block references.** A `((uuid))` whose target was never defined in the graph is left
 untouched by default (the raw text survives). With `removeOrphanBlockRefs` on, such unresolved
 `((uuid))` references and `{{embed ((uuid))}}` embeds are removed cleanly (including lines that
 become empty). This runs *after* `resolveBlockRefs`, so only genuine orphans remain to remove.
 
+**Code protection.** Block reference resolution (`resolveBlockRefs`) skips both fenced code blocks
+and inline-code spans — `((uuid))` appearing inside code is not rewritten.
+
 ---
 
 ## 8. Tags
 
 Tag handling happens in pass 2 (`convertTags`), outside code fences. Two syntaxes are recognized:
-`#simple-tag` and `#[[multi word tag]]`. For each tag, in order:
+`#simple-tag` and `#[[multi word tag]]`. Tags must follow the start of line, whitespace, or an
+opening bracket/paren (`([`). For each tag, in order:
 
-1. **Drop?** If the tag (or its hyphenated form) is in `dropTags`, it is removed entirely.
+1. **Hex color?** Pure 6-digit hex tokens (`#FF0000`) are never treated as tags — left as-is.
+2. **Drop?** If the tag (or its hyphenated form) is in `dropTags`, it is removed entirely.
    Default `dropTags` is `['card']`.
-2. **Convert to link?** Only if `convertTagsToLinks` is on:
+3. **Convert to link?** Only if `convertTagsToLinks` is on:
    - If `convertTagsOnlyExistingPages` is on (default), the tag becomes `[[tag]]` **only when a
      page with that name exists** in the graph; otherwise it stays a `#tag`. This is the "smart"
      conversion: real pages become links, ad-hoc tags stay tags.
    - If `convertTagsOnlyExistingPages` is off, every tag becomes `[[tag]]`.
-3. **Keep as tag (default).** Multi-word `#[[multi word]]` is sanitized to `#multi-word`; simple
+4. **Keep as tag (default).** Multi-word `#[[multi word]]` is sanitized to `#multi-word`; simple
    tags are left as-is.
 
 Tags listed in `dropTags` are also removed from frontmatter `tags:` (section 9).
@@ -308,12 +328,20 @@ The leading block of unindented `key:: value` lines becomes YAML frontmatter
 - `alias` / `aliases` → an `aliases:` list (wikilink brackets stripped).
 - `tags` → a `tags:` list (`#` and `[[…]]` stripped; comma- and space-separated values both
   handled; values in `dropTags` removed; if all are removed, no `tags:` key is emitted).
-- `title` → dropped from YAML but kept in `raw` (used for the filename / reporting; the Logseq
-  filename remains the source of truth).
+- `title` → registered as an additional alias (so the page is findable by title in Obsidian);
+  removed from YAML as a standalone key. Also kept in `raw` for the filename / reporting.
 - Keys listed in `dropPageProperties` → dropped. Default: `public`, `exclude-from-graph-view`.
-- Wikilink-valued scalars are quoted (`project: "[[Big Project]]"`); multiple wikilink values
-  become a quoted list.
-- Other scalars are passed through as `key: value`.
+- **YAML quoting:** values that are YAML-unsafe (contain `: `, `#`, start with `[`, `{`, are
+  boolean words, integers, floats, or reserved YAML tokens) are double-quoted. Wikilink-valued
+  scalars are also quoted (`project: "[[Big Project]]"`); multiple wikilink values become a quoted
+  list.
+- **Date extraction:** values wrapped in `[[…]]` that parse as dates are unwrapped and emitted as
+  bare ISO dates (not quoted). Template tokens like `{{date}}` are left as-is.
+- **List splitting:** comma-separated values are split with bracket-awareness (respects `[[…]]`
+  and `(…)` boundaries so `[[a, b]]` is not split mid-link).
+- **Duplicate keys:** when the same key appears multiple times, last value wins; insertion order
+  of first occurrence is preserved in the YAML output.
+- Empty-valued properties (key with no value) are silently dropped.
 
 If a file starts with a `- ` bullet, it has no page-property block.
 
@@ -321,11 +349,12 @@ If a file starts with a `- ` bullet, it has no page-property block.
 
 Indented `key:: value` continuation lines are stripped by `removeLeftoverBlockProperties` (after
 `heading::`, `id::`, and `logseq.order-list-type::` have been handled by their own converters).
+Both standard indented form (`  key:: value`) and bullet form (`- key:: value`) are recognized.
 
 **Always dropped** (Logseq-internal, never meaningful in Obsidian — not user-overridable):
 `collapsed`, `background-color`, `heading`, `filters`, `public`, `exclude-from-graph-view`,
 `query-table`, `query-properties`, `query-sort-by`, `query-sort-desc`, `query-flag`, plus **any key
-starting with `logseq.` or `query-`**.
+starting with `logseq.`**, **`query-`**, **`hl-`**, or **`ls-`** (highlight/annotation-related).
 
 **Additionally dropped:** any key the user lists in `dropBlockProperties` (default empty). Unknown
 user block properties (e.g. `rating:: 5`) are **kept** by default.
@@ -347,11 +376,15 @@ user block properties (e.g. `rating:: 5`) are **kept** by default.
 |---|---|---|
 | `^^highlight^^` | `==highlight==` | skips fenced **and** inline code |
 | `#+BEGIN_QUOTE` … `#+END_QUOTE` | `> ` blockquote | |
+| `- #+BEGIN_QUOTE` (bullet-prefixed) | `- > text` blockquote under bullet | Issue 1: preserves list structure |
 | `#+BEGIN_NOTE/TIP/WARNING/IMPORTANT/CAUTION/EXAMPLE` | `> [!type]` callout | first `**bold**` line becomes the callout title |
+| `- #+BEGIN_TIP` (bullet-prefixed) | `- > [!tip]` callout under bullet | |
 | `#+BEGIN_COMMENT` | `%% … %%` | |
+| `#+BEGIN_QUERY` … `#+END_QUERY` | `` ```query `` … `` ``` `` | preserves query DSL verbatim in a fenced block |
 | other `#+BEGIN_*` (CENTER/VERSE/PINNED/…) | `> [!note]` fallback | nesting supported |
+| `#+BEGIN_*` inside a fenced code block | left unchanged | fence-aware: org markers in code are inert |
 | numbered list (bullet + `logseq.order-list-type:: number`) | `1.` `2.` `3.` | counter resets on level change / non-numbered sibling |
-| code fences in bullets | code fence with aligned closing fence | `fixCodeBlocksInLists` |
+| code fences in bullets | code fence with aligned closing fence | `fixCodeBlocksInLists` (tab-safe indent) |
 | heading followed by indented list | `- # Heading` + list | `fixHeadingChildLists` |
 | `$inline$` / `$$block$$` math | unchanged | both apps use MathJax |
 
@@ -362,15 +395,17 @@ user block properties (e.g. `rating:: 5`) are **kept** by default.
 | Logseq | Obsidian | Notes |
 |---|---|---|
 | `![alt](../assets/x.png)` | `![[x.png]]` | bytes copied to `<output>/assets/` |
+| `[label](../assets/x.pdf)` | `[[x.pdf]]` | plain (non-embed) asset links also converted |
 | `![alt](../assets/x.png){:height H, :width W}` | `![[x.png\|WxH]]` | dimensions always win over alt text |
 | `![alt](../assets/x.png)` with `keepAssetAltText` | `![[x.png\|alt]]` | only when no dimensions and alt is non-empty |
+| `![](../assets/Book_(2024).pdf)` | `![[Book_(2024).pdf]]` | paren-balanced path matching |
 | `{{video URL}}` / `{{youtube URL}}` | `![](URL)` | |
 | `{{tweet URL}}` | `![](URL)` | |
 
 Only links whose path contains `assets/` are treated as local assets; URLs (`http:`, `https:`,
-`data:`) and other paths are left alone. Asset links inside fenced code blocks are not converted.
-Assets are de-duplicated by filename when copied; the byte copy resolves the source relative to the
-note's directory (tolerant of `../` prefixes).
+`data:`) and other paths are left alone. Asset links inside fenced code blocks **and inline code
+spans** are not converted. Assets are de-duplicated by filename when copied; the byte copy resolves
+the source relative to the note's directory (tolerant of `../` prefixes).
 
 ---
 
@@ -403,8 +438,9 @@ The importer handles this natively, with no flattening:
 - **Ambiguous bare links.** A `basename → [paths]` index is built from all plans. In pass 2,
   `disambiguateBasenameLinks` rewrites any bare `[[name]]` whose basename maps to 2+ notes into
   `[[full/path|name]]` (using the first path as canonical, and preserving any explicit display
-  text). Links that already contain a `/` (namespace-style) or a `#` (block/heading ref) are left
-  untouched — they already resolve unambiguously.
+  text). If one of the paths is an **exact top-level match** (no namespace / folder), the link is
+  left as-is — it already resolves unambiguously in Obsidian's shortest-path resolution. Links that
+  already contain a `/` (namespace-style) or a `#` (block/heading ref) are also left untouched.
 
 This mirrors exactly how Obsidian itself disambiguates same-named notes, so the output stays
 idiomatic and no data is lost.

--- a/docs/logseq-importer-transformations.md
+++ b/docs/logseq-importer-transformations.md
@@ -375,6 +375,10 @@ Tags listed in `dropTags` are also removed from frontmatter `tags:` (section I).
   removed from YAML as a standalone key. Also kept in `raw` for the filename / reporting.
 - Keys listed in `dropPageProperties` → dropped. Default: `public`, `exclude-from-graph-view`,
   `icon`. (`icon` carries a Logseq private-use glyph that renders as □ in Obsidian.)
+- **Always dropped** (Logseq-internal, never meaningful in Obsidian — not user-overridable):
+  `collapsed`, `filters`, `background-color`, `heading`, `template`, `template-including-parent`,
+  plus **any key starting with `logseq.`**, **`query-`**, **`hl-`**, or **`ls-`**.
+  These keys cannot be un-dropped via `dropPageProperties`.
 - **[I1]** **Tag-style values → links (pass-2):** a scalar value that is a single tag (`status:: #IN-PROGRESS`,
   `area:: #[[Page One]]`) is emitted as quoted text (`status: "#IN-PROGRESS"`) by default. When tag
   conversion is enabled (`convertTagsToLinks`), the value is linkified to a wikilink
@@ -402,9 +406,13 @@ If a file starts with a `- ` bullet, it has no page-property block.
 Both standard indented form (`  key:: value`) and bullet form (`- key:: value`) are recognized.
 
 **Always dropped** (Logseq-internal, never meaningful in Obsidian — not user-overridable):
-`collapsed`, `background-color`, `heading`, `filters`, `public`, `exclude-from-graph-view`,
+`alias`, `aliases`, `collapsed`, `background-color`, `heading`, `filters`, `public`,
+`exclude-from-graph-view`, `template`, `template-including-parent`,
 `query-table`, `query-properties`, `query-sort-by`, `query-sort-desc`, `query-flag`, plus **any key
 starting with `logseq.`**, **`query-`**, **`hl-`**, or **`ls-`** (highlight/annotation-related).
+
+(`alias`/`aliases` are always dropped from blocks because they are only meaningful as page-level
+properties, where they are already handled by the frontmatter converter.)
 
 **Additionally dropped:** any key the user lists in `dropBlockProperties` (default empty).
 

--- a/docs/logseq-importer-transformations.md
+++ b/docs/logseq-importer-transformations.md
@@ -1,0 +1,410 @@
+# Logseq Importer: Transformation Reference
+
+This document is the authoritative, up-to-date reference for **every transformation the Logseq
+importer performs** and **every option that controls it**. It reflects the actual implementation
+under `src/formats/logseq/`, including all adjustments made after the original
+[assessment](./logseq-importer-assessment.md) (which remains the design-rationale and roadmap
+document).
+
+Guiding principle throughout: **never silently delete content.** Anything that cannot be faithfully
+converted is either preserved verbatim or skipped with an explicit `ctx.reportSkipped` /
+`reportFailed` entry, so the user always knows.
+
+## Contents
+
+1. [Pipeline overview](#1-pipeline-overview)
+2. [Options reference](#2-options-reference)
+3. [Document structure & de-outlining](#3-document-structure--de-outlining)
+4. [Tasks](#4-tasks)
+5. [Journals & dates](#5-journals--dates)
+6. [Pages, namespaces & output paths](#6-pages-namespaces--output-paths)
+7. [Links, references & embeds](#7-links-references--embeds)
+8. [Tags](#8-tags)
+9. [Properties](#9-properties)
+10. [Inline syntax & blocks](#10-inline-syntax--blocks)
+11. [Media & assets](#11-media--assets)
+12. [Logseq-only content](#12-logseq-only-content)
+13. [Name collisions & disambiguation](#13-name-collisions--disambiguation)
+
+---
+
+## 1. Pipeline overview
+
+The import runs in **two passes** so that cross-file references can be resolved against a
+vault-wide index that only exists once every file has been planned and locally converted.
+
+**Planning.** Files under `pages/` and `journals/` are enumerated. Each is assigned a canonical
+name and an output path (section 6). Output-path collisions are detected here: the first writer
+wins; later colliders are reported via `ctx.reportSkipped` and skipped. From the plans we build:
+
+- a **basename disambiguation index** (`basename → [full path, …]`, section 13),
+- a **known-pages set** (`canonicalName` lower-cased, used for page-aware tag conversion).
+
+**Pass 1 — per-file local conversion** (`convertLocal` in `pipeline.ts`). Everything that can be
+done on a single file without the vault index. In order:
+
+1. `extractPageProperties` — leading `key:: value` block → YAML frontmatter (section 9).
+2. `convertHeadingProperty` — `heading:: N` → `#`×N prefix on the block.
+3. `convertTasks` — task keywords + metadata → chosen task format (section 4).
+4. `convertNumberedLists` — `logseq.order-list-type:: number` → `1.`/`2.`/…
+5. `convertOrgBlocks` — `#+BEGIN_*`/`#+END_*` → callouts / blockquotes / comments.
+6. `convertHighlights` — `^^text^^` → `==text==`.
+7. `convertMediaEmbeds` — `{{video|youtube|tweet URL}}` → `![](URL)`.
+8. `fixHeadingChildLists` — heading immediately followed by an indented list gets a `- ` prefix.
+9. `fixCodeBlocksInLists` — align a list-nested code block's closing fence.
+10. `convertAssetLinks` — `![alt](../assets/x.png)` → `![[x.png]]`, collecting assets to copy.
+11. `convertAliasLinks` — `[display]([[Page]])` → `[[Page|display]]`.
+12. `convertJournalDateLinks` — `[[Aug 30th, 2024]]` → `[[2024-08-30]]`.
+13. `attachBlockIds` — `id:: <uuid>` → `^shortid` anchor on the block; collect the id index.
+14. `removeLeftoverBlockProperties` — strip remaining internal/user-listed block properties.
+
+While iterating, pass 1 also builds the **block-id index** (`uuid → {page, shortId}`), the
+**alias index** (`alias → canonical page`, ambiguous aliases removed afterward), and the
+**asset plan** (absolute source → filename). Logseq-only content (queries, flashcards) is applied
+here too (`applyLogseqOnly`).
+
+> Tag conversion is **deliberately deferred to pass 2** because the `onlyExistingPages` option
+> needs the complete known-pages set, which is only available after planning.
+
+**Pass 2 — cross-file resolution + write** (in `logseq.ts`). For each file, in order:
+
+1. `resolveBlockRefs` — `((uuid))` → `[[Page#^shortid]]`, `{{embed ((uuid))}}` → `![[Page#^shortid]]`,
+   `{{embed [[Page]]}}` → `![[Page]]`.
+2. `removeOrphanBlockRefs` — *(option)* strip references whose uuid was never defined.
+3. `rewriteAliasReferences` — `[[Alias]]` → `[[Canonical|Alias]]`.
+4. `disambiguateBasenameLinks` — bare `[[name]]` → `[[full/path|name]]` when the basename is shared.
+5. `convertTags` — keep / sanitize / link / drop tags (section 8).
+6. ISO date-link reformat — `[[YYYY-MM-DD]]` → target Daily-Notes format if it differs.
+7. `deOutline` — *(option)* flatten the outline for journals and/or pages.
+8. Write the note (`yaml + body`), then copy assets.
+
+---
+
+## 2. Options reference
+
+All options live in `src/formats/logseq/options.ts` (`LogseqImportOptions`). Defaults below are
+`DEFAULT_LOGSEQ_OPTIONS`. The settings UI (`logseq.ts`) groups them into the sections shown.
+
+### Tasks
+
+| Option | Type | Default | Effect |
+|---|---|---|---|
+| `taskFormat` | `'tasks-emoji' \| 'tasks-dataview' \| 'plain'` | `tasks-emoji` | How rich task metadata is serialized (section 4). |
+
+### Journals
+
+| Option | Type | Default | Effect |
+|---|---|---|---|
+| `useDailyNotes` | boolean | `true` | Migrate journals into the Daily Notes folder using its date format. When on, the folder/format fields are filled from Daily Notes config and disabled. |
+| `journalFolder` | string | from Daily Notes, else `Journals` | Vault folder (relative to output) for journals. |
+| `journalDateFormat` | string | from Daily Notes, else `YYYY-MM-DD` | moment.js format for journal filenames. |
+| `deOutlineJournals` | boolean | `false` | Flatten journal outlines to paragraphs/headings (section 3). |
+
+### Pages
+
+| Option | Type | Default | Effect |
+|---|---|---|---|
+| `pagesFolder` | string | `''` | Vault folder (relative to output) for pages. Empty = output root. |
+| `deOutlinePages` | boolean | `false` | Flatten page outlines to paragraphs/headings (section 3). |
+
+### Links & tags
+
+| Option | Type | Default | Effect |
+|---|---|---|---|
+| `convertTagsToLinks` | boolean | `false` | Turn `#tags` into `[[wikilinks]]` instead of keeping them as tags. |
+| `convertTagsOnlyExistingPages` | boolean | `true` | When converting, only link tags that have a matching page; others stay `#tags`. |
+| `dropTags` | string[] | `['card']` | Tags removed entirely from body **and** frontmatter. |
+
+### Logseq-only content
+
+| Option | Type | Default | Effect |
+|---|---|---|---|
+| `queries` | `'keep' \| 'drop'` | `keep` | `{{query}}` / `#+BEGIN_QUERY` blocks (section 12). |
+| `flashcards` | `'keep' \| 'drop'` | `keep` | `#card` markers and `{{cloze}}` wrappers (section 12). |
+| `logbook` | `'keep' \| 'drop'` | `drop` | `:LOGBOOK:` / `CLOCK:` time-tracking blocks on tasks. |
+
+### Assets
+
+| Option | Type | Default | Effect |
+|---|---|---|---|
+| `keepAssetAltText` | boolean | `false` | Preserve image alt text as the embed display text (`![[x\|alt]]`). |
+
+### Block references
+
+| Option | Type | Default | Effect |
+|---|---|---|---|
+| `shortenBlockIds` | boolean | `true` | Shorten Logseq UUID block IDs to short Obsidian-style anchors. |
+| `removeOrphanBlockRefs` | boolean | `false` | Remove `((uuid))` references that could not be resolved to a known block. |
+
+### Properties
+
+| Option | Type | Default | Effect |
+|---|---|---|---|
+| `dropPageProperties` | string[] | `['public', 'exclude-from-graph-view']` | Page-level property keys excluded from frontmatter. |
+| `dropBlockProperties` | string[] | `[]` | **Additional** inline block-property keys to strip (beyond the always-dropped set). |
+
+---
+
+## 3. Document structure & de-outlining
+
+Logseq treats every document as an outline of nested `- ` bullets; indentation *is* the structure.
+Obsidian uses flat markdown.
+
+**Preserve (default).** Every block stays a `- ` bullet at its original indentation — lossless.
+The only structural touch-up is `fixHeadingChildLists` (a heading directly above an indented list
+gets a `- ` prefix so Obsidian renders the children correctly).
+
+**De-outline (opt-in, per kind).** Controlled by two independent toggles — `deOutlineJournals` and
+`deOutlinePages` — so you can flatten one kind and keep the other as an outline (there is no
+dynamic UI; both are always-visible switches). `deOutline` (`de-outline.ts`) parses the bullet tree
+and re-serializes it as idiomatic markdown using these heuristics:
+
+- A bullet whose content is a **heading** (`# …`) de-nests to a real heading; its children become
+  the body under it.
+- A subtree that is a **genuine list** (2+ leaf-ish siblings, or any all-task group) stays a list,
+  re-indented from depth 0.
+- A **single-child chain** of prose collapses into one paragraph (avoids one-item lists).
+- Other prose bullets become paragraphs separated by blank lines.
+- **Tasks** always remain list items; consecutive tasks are grouped into a compact list.
+
+De-outline runs **last** in pass 2, after all other conversions, so tasks/properties/links are
+already in their final form. It is heuristic and may restructure incidental nesting — which is why
+Preserve is the default.
+
+---
+
+## 4. Tasks
+
+Logseq tasks are bullets whose text starts with a workflow keyword. Recognized keywords:
+`TODO, DOING, DONE, LATER, NOW, WAITING, WAIT, IN-PROGRESS, CANCELLED, CANCELED`.
+
+The task line plus its indented continuation lines (`SCHEDULED:`, `DEADLINE:`, `:LOGBOOK:`, and
+`created/completed/done/cancelled` properties) are parsed as one unit and re-emitted.
+
+### Checkbox state mapping
+
+| Logseq state | `plain` | `tasks-emoji` / `tasks-dataview` |
+|---|---|---|
+| `TODO` / `LATER` / `WAITING` / `WAIT` / `IN-PROGRESS` | `[ ]` | `[ ]` |
+| `DOING` / `NOW` | `[ ]` | `[/]` |
+| `DONE` | `[x]` | `[x]` |
+| `CANCELLED` / `CANCELED` | `[x]` | `[-]` |
+
+### Metadata mapping
+
+| Logseq | `tasks-emoji` | `tasks-dataview` | `plain` |
+|---|---|---|---|
+| priority `[#A]` / `[#B]` / `[#C]` | `⏫` / `🔼` / `🔽` | `[priority:: high\|medium\|low]` | left in text |
+| `SCHEDULED: <date>` | `⏳ date` | `[scheduled:: date]` | dropped from metadata |
+| `DEADLINE: <date>` | `📅 date` | `[due:: date]` | dropped from metadata |
+| repeater (`.+1w` / `++2d`) | `🔁 every N unit [when done]` | `[repeat:: <raw>]` | — |
+| `created::` | `➕ date` | `[created:: date]` | — |
+| `completed::` / `done::` | `✅ date` | `[completion:: date]` | — |
+| `cancelled::` / `canceled::` | `❌ date` | `[cancelled:: date]` | — |
+| `:LOGBOOK:` … `:END:` | see `logbook` option | see `logbook` option | preserved as continuation |
+
+Notes:
+- In **plain** format, priority and scheduling are not extracted into metadata — continuation lines
+  are kept as-is, so no information is destroyed (it just stays inline).
+- The **repeater** emoji form distinguishes `.+`/`++` (→ "when done") from `+` (fixed).
+- **LOGBOOK** has no Obsidian target; with `logbook: 'drop'` (default) it is removed cleanly,
+  with `logbook: 'keep'` the `:LOGBOOK:`/`CLOCK:` lines are preserved verbatim.
+
+---
+
+## 5. Journals & dates
+
+Journals have two distinct format ends, neither hard-coded:
+
+- **Source filename** — `journals/2024_08_30.md` style. `journalFilenameToISO` parses
+  `YYYY[_-]M[_-]D` to ISO `YYYY-MM-DD`.
+- **Source date links** — `[[Aug 30th, 2024]]` style. `convertJournalDateLinks` parses the
+  `MMM do, yyyy` family to `[[2024-08-30]]`.
+
+**Target.** The journal filename is produced from the ISO date via moment using
+`journalDateFormat`. When `useDailyNotes` is on, the folder and format come from the **Daily Notes**
+core plugin (`app.internalPlugins.getPluginById('daily-notes')`), falling back to `Journals` /
+`YYYY-MM-DD`. When off, the user's `journalFolder` / `journalDateFormat` are used.
+
+If the target format differs from ISO, pass 2 reformats every in-content `[[YYYY-MM-DD]]` link to
+the target format so links keep matching the filenames.
+
+---
+
+## 6. Pages, namespaces & output paths
+
+- **Pages** are placed under `pagesFolder` (or the output root if empty). A namespaced Logseq page
+  filename is converted to a folder path: `namespaceToPath` splits on `%2F` if present, otherwise
+  on the `___` separator, percent-decodes each segment (`decodeLogseqName`, tolerant of malformed
+  escapes), and joins with `/`. So `a___b.md` → `a/b.md` and `Encoded%3AColon.md` → `Encoded:Colon.md`.
+- **Journals** are placed under `journalFolder` with the date-formatted filename.
+- All names are run through `sanitizeFileNameKeepPath` to remove OS-illegal characters while
+  keeping the folder hierarchy.
+- The **canonical name** (the namespace/date path without `.md`) is what block references and
+  wikilinks target.
+- `whiteboards/` files are reported as unsupported and skipped. The scan only includes `pages/`
+  and `journals/`.
+
+---
+
+## 7. Links, references & embeds
+
+| Logseq | Obsidian | When |
+|---|---|---|
+| `[[Page]]` | `[[Page]]` (namespace text matches output path) | always |
+| `[display]([[Page]])` | `[[Page\|display]]` | pass 1, skips code fences |
+| `[[Alias]]` (reference *by alias*) | `[[Canonical\|Alias]]` | pass 2 |
+| `id:: <uuid>` block property | `^shortid` appended to the block line | pass 1 |
+| `((uuid))` | `[[Page#^shortid]]` | pass 2, if resolved |
+| `{{embed ((uuid))}}` | `![[Page#^shortid]]` | pass 2, if resolved |
+| `{{embed [[Page]]}}` | `![[Page]]` | pass 2 |
+
+**Aliases are not interchangeable between the two apps.** Logseq resolves `[[Some Alias]]` to the
+canonical page anywhere; Obsidian links must target the canonical note name. So the importer builds
+an **alias → canonical** map from every page's `alias::`/`aliases::` property and rewrites any
+reference that targets an alias into `[[Canonical|Alias]]` (keeping the alias as display text). The
+alias values still go into the note's `aliases:` frontmatter so Obsidian autocomplete works.
+**Ambiguous aliases** (the same alias claimed by multiple pages) are dropped from the map and left
+unrewritten.
+
+**Block IDs.** Logseq UUIDs (e.g. `64ab9aa4-459a-41b1-8c21-dbb38dc0c79b`) are shortened to a stable
+6-char anchor (`^64ab9a`) when `shortenBlockIds` is on (default), or kept full when off. Short-id
+collisions **within one note** are disambiguated by appending `-1`, `-2`, … The same mapping is
+used to rewrite every `((uuid))` reference, so anchors and links stay consistent.
+
+**Orphan block references.** A `((uuid))` whose target was never defined in the graph is left
+untouched by default (the raw text survives). With `removeOrphanBlockRefs` on, such unresolved
+`((uuid))` references and `{{embed ((uuid))}}` embeds are removed cleanly (including lines that
+become empty). This runs *after* `resolveBlockRefs`, so only genuine orphans remain to remove.
+
+---
+
+## 8. Tags
+
+Tag handling happens in pass 2 (`convertTags`), outside code fences. Two syntaxes are recognized:
+`#simple-tag` and `#[[multi word tag]]`. For each tag, in order:
+
+1. **Drop?** If the tag (or its hyphenated form) is in `dropTags`, it is removed entirely.
+   Default `dropTags` is `['card']`.
+2. **Convert to link?** Only if `convertTagsToLinks` is on:
+   - If `convertTagsOnlyExistingPages` is on (default), the tag becomes `[[tag]]` **only when a
+     page with that name exists** in the graph; otherwise it stays a `#tag`. This is the "smart"
+     conversion: real pages become links, ad-hoc tags stay tags.
+   - If `convertTagsOnlyExistingPages` is off, every tag becomes `[[tag]]`.
+3. **Keep as tag (default).** Multi-word `#[[multi word]]` is sanitized to `#multi-word`; simple
+   tags are left as-is.
+
+Tags listed in `dropTags` are also removed from frontmatter `tags:` (section 9).
+
+---
+
+## 9. Properties
+
+### Page properties → frontmatter
+
+The leading block of unindented `key:: value` lines becomes YAML frontmatter
+(`extractPageProperties`):
+
+- `alias` / `aliases` → an `aliases:` list (wikilink brackets stripped).
+- `tags` → a `tags:` list (`#` and `[[…]]` stripped; comma- and space-separated values both
+  handled; values in `dropTags` removed; if all are removed, no `tags:` key is emitted).
+- `title` → dropped from YAML but kept in `raw` (used for the filename / reporting; the Logseq
+  filename remains the source of truth).
+- Keys listed in `dropPageProperties` → dropped. Default: `public`, `exclude-from-graph-view`.
+- Wikilink-valued scalars are quoted (`project: "[[Big Project]]"`); multiple wikilink values
+  become a quoted list.
+- Other scalars are passed through as `key: value`.
+
+If a file starts with a `- ` bullet, it has no page-property block.
+
+### Block properties → cleaned from body
+
+Indented `key:: value` continuation lines are stripped by `removeLeftoverBlockProperties` (after
+`heading::`, `id::`, and `logseq.order-list-type::` have been handled by their own converters).
+
+**Always dropped** (Logseq-internal, never meaningful in Obsidian — not user-overridable):
+`collapsed`, `background-color`, `heading`, `filters`, `public`, `exclude-from-graph-view`,
+`query-table`, `query-properties`, `query-sort-by`, `query-sort-desc`, `query-flag`, plus **any key
+starting with `logseq.` or `query-`**.
+
+**Additionally dropped:** any key the user lists in `dropBlockProperties` (default empty). Unknown
+user block properties (e.g. `rating:: 5`) are **kept** by default.
+
+### Special property conversions
+
+| Logseq | Obsidian |
+|---|---|
+| `heading:: N` (1–6) | `#`×N prefix on the owning bullet; the property line is dropped |
+| `heading:: true` (auto) | property line dropped, no prefix |
+| `logseq.order-list-type:: number` | bullet becomes `1.`, `2.`, … (counter per indent level) |
+| `id:: <uuid>` | `^shortid` anchor (section 7) |
+
+---
+
+## 10. Inline syntax & blocks
+
+| Logseq | Obsidian | Notes |
+|---|---|---|
+| `^^highlight^^` | `==highlight==` | skips fenced **and** inline code |
+| `#+BEGIN_QUOTE` … `#+END_QUOTE` | `> ` blockquote | |
+| `#+BEGIN_NOTE/TIP/WARNING/IMPORTANT/CAUTION/EXAMPLE` | `> [!type]` callout | first `**bold**` line becomes the callout title |
+| `#+BEGIN_COMMENT` | `%% … %%` | |
+| other `#+BEGIN_*` (CENTER/VERSE/PINNED/…) | `> [!note]` fallback | nesting supported |
+| numbered list (bullet + `logseq.order-list-type:: number`) | `1.` `2.` `3.` | counter resets on level change / non-numbered sibling |
+| code fences in bullets | code fence with aligned closing fence | `fixCodeBlocksInLists` |
+| heading followed by indented list | `- # Heading` + list | `fixHeadingChildLists` |
+| `$inline$` / `$$block$$` math | unchanged | both apps use MathJax |
+
+---
+
+## 11. Media & assets
+
+| Logseq | Obsidian | Notes |
+|---|---|---|
+| `![alt](../assets/x.png)` | `![[x.png]]` | bytes copied to `<output>/assets/` |
+| `![alt](../assets/x.png){:height H, :width W}` | `![[x.png\|WxH]]` | dimensions always win over alt text |
+| `![alt](../assets/x.png)` with `keepAssetAltText` | `![[x.png\|alt]]` | only when no dimensions and alt is non-empty |
+| `{{video URL}}` / `{{youtube URL}}` | `![](URL)` | |
+| `{{tweet URL}}` | `![](URL)` | |
+
+Only links whose path contains `assets/` are treated as local assets; URLs (`http:`, `https:`,
+`data:`) and other paths are left alone. Asset links inside fenced code blocks are not converted.
+Assets are de-duplicated by filename when copied; the byte copy resolves the source relative to the
+note's directory (tolerant of `../` prefixes).
+
+---
+
+## 12. Logseq-only content
+
+Each Logseq-only feature has an independent keep/drop choice. "Keep" preserves the text verbatim
+(and reports it via `ctx.reportSkipped` so the user can revisit it); "drop" removes it cleanly.
+
+| Feature | Syntax | Option | Default | If kept | If dropped |
+|---|---|---|---|---|---|
+| Queries | `{{query …}}`, `#+BEGIN_QUERY … #+END_QUERY` | `queries` | `keep` | left verbatim + reported | block removed, no residue |
+| Flashcards | `#card`, `{{cloze …}}` | `flashcards` | `keep` | left verbatim + reported | `{{cloze X}}` → `X`, `#card` removed |
+| Time tracking | `:LOGBOOK:` / `CLOCK:` on tasks | `logbook` | `drop` | lines kept on the task | lines removed cleanly |
+
+Whiteboards (`whiteboards/*.edn`) are always skipped and reported (not migratable).
+
+---
+
+## 13. Name collisions & disambiguation
+
+Because namespaces become folders, two notes in different folders can share a basename
+(e.g. `projects/notes` and `personal/notes`). This is **valid in Obsidian** — a note's canonical
+identity is its full vault path, and a link can carry the full path while displaying only the
+basename: `[[personal/notes|notes]]`.
+
+The importer handles this natively, with no flattening:
+
+- **Output-path collisions** (two sources mapping to the *exact same* path) are detected during
+  planning. The first writer wins; later colliders are reported and skipped — no silent overwrite.
+- **Ambiguous bare links.** A `basename → [paths]` index is built from all plans. In pass 2,
+  `disambiguateBasenameLinks` rewrites any bare `[[name]]` whose basename maps to 2+ notes into
+  `[[full/path|name]]` (using the first path as canonical, and preserving any explicit display
+  text). Links that already contain a `/` (namespace-style) or a `#` (block/heading ref) are left
+  untouched — they already resolve unambiguously.
+
+This mirrors exactly how Obsidian itself disambiguates same-named notes, so the output stays
+idiomatic and no data is lost.

--- a/docs/logseq-importer-transformations.md
+++ b/docs/logseq-importer-transformations.md
@@ -158,6 +158,8 @@ All options live in `src/formats/logseq/options.ts` (`LogseqImportOptions`). Def
 | `dropPageProperties` | string[] | `['public', 'exclude-from-graph-view', 'icon']` | Page-level property keys excluded from frontmatter. `icon` is dropped by default because it carries a Logseq private-use glyph that renders as a tofu box (□) in Obsidian. |
 | `dropBlockProperties` | string[] | `[]` | **Additional** inline block-property keys to strip (beyond the always-dropped set). |
 | `blockProperties` | `keep` \| `wrap` \| `drop` | `wrap` | How retained (unknown) inline block properties are emitted. `keep` leaves the raw `key:: value` line; `wrap` rewrites it to a Dataview inline field `[key:: value]` (label hidden in reading view, value stays queryable); `drop` removes the line. The always-dropped set and `dropBlockProperties` keys win in every mode. |
+| `snakeCasePageProperties` | boolean | `false` | Convert kebab-case page-property keys to snake_case (e.g. `test-hyphen` → `test_hyphen`). Drop-list matching (`dropPageProperties`) still uses the original kebab-case key. Hyphenated keys can break or complicate Bases/Dataview query syntax (`note["test-hyphen"]` vs. `test_underscore`). |
+| `snakeCaseBlockProperties` | boolean | `false` | Same as `snakeCasePageProperties`, but for retained inline block-property keys (applies in both `keep` and `wrap` modes). |
 
 ### Cleanup
 

--- a/docs/logseq-importer-transformations.md
+++ b/docs/logseq-importer-transformations.md
@@ -159,7 +159,7 @@ All options live in `src/formats/logseq/options.ts` (`LogseqImportOptions`). Def
 
 | Option | Type | Default | Effect |
 |---|---|---|---|
-| `normalizeWhitespace` | boolean | `true` | Trim trailing whitespace, remove lone empty bullets (`- `), and convert non-breaking spaces (U+00A0) to regular spaces. Fenced code blocks and intentional blank lines are left untouched; empty bullets that carry a `^anchor` are kept. |
+| `normalizeWhitespace` | boolean | `true` | Trim trailing whitespace, remove lone empty bullets (`- `), and convert non-breaking spaces (U+00A0) to regular spaces. Fenced code blocks (both standard ` ``` ` and bullet-prefixed `- ``` ` fences) and intentional blank lines are left untouched; empty bullets that carry a `^anchor` are kept. |
 
 ---
 

--- a/docs/logseq-importer-transformations.md
+++ b/docs/logseq-importer-transformations.md
@@ -2,17 +2,18 @@
 
 This document is the authoritative, up-to-date reference for **every transformation the Logseq
 importer performs** and **every option that controls it**. It reflects the actual implementation
-under `src/formats/logseq/`, including all adjustments made after the original
-[assessment](./logseq-importer-assessment.md) (which remains the design-rationale and roadmap
-document).
+under `src/formats/logseq/`. The companion
+[implementation summary](./logseq-importer-assessment.md) records the design considerations,
+decisions, and tradeoffs behind it.
 
 Tests and implementation comments cross-reference this document with letter-number labels: one
 letter per top-level section (`A` through `M`) plus a rule number, such as `[G1]`. Older
 development-phase labels are no longer used as public references.
 
-Guiding principle throughout: **never silently delete content.** Anything that cannot be faithfully
-converted is either preserved verbatim or skipped with an explicit `ctx.reportSkipped` /
-`reportFailed` entry, so the user always knows.
+Guiding principle throughout: preserve source content when there is no safe automatic mapping.
+Intentional cleanup is limited to documented defaults and user-selected drop options. Files that
+cannot be imported are reported through `ctx.reportSkipped` / `reportFailed`; individual syntax
+cleanup inside an imported note is governed by the options in section B.
 
 ## Contents
 
@@ -37,10 +38,10 @@ converted is either preserved verbatim or skipped with an explicit `ctx.reportSk
 The import runs in **two passes** so that cross-file references can be resolved against a
 vault-wide index that only exists once every file has been planned and locally converted.
 
-**Planning.** Files under `pages/` and `journals/` are enumerated. Each is assigned a canonical
-name and an output path (section F). During planning, files are skipped when:
+**Planning.** Markdown files under `pages/` and `journals/` are enumerated recursively. Each is
+assigned a canonical name and an output path (section F). During planning, files are skipped when:
 
-- The path matches `whiteboards/` — not supported.
+- A scanned Markdown path contains `/whiteboards/` — not supported.
 - Two sources would map to the *same output path* — the first wins; later colliders are reported
   and skipped (no silent overwrite).
 
@@ -64,16 +65,21 @@ done on a single file without the vault index. In order:
 11. `convertAliasLinks` — `[display]([[Page]])` → `[[Page|display]]`.
 12. `convertJournalDateLinks` — `[[Aug 30th, 2024]]` → `[[2024-08-30]]`.
 13. `attachBlockIds` — `id:: <uuid>` → `^shortid` anchor on the block; collect the id index.
-14. `removeLeftoverBlockProperties` — strip remaining internal/user-listed block properties.
+14. `removeLeftoverBlockProperties` — drop or serialize remaining block properties.
+15. `normalizeWhitespace` — optionally normalize non-breaking spaces, trailing whitespace, and
+    empty bullets.
 
 While iterating, pass 1 also builds the **block-id index** (`uuid → {page, shortId}`), the
 **alias index** (`alias → canonical page`, including `title::` — ambiguous aliases removed
 afterward), and the **asset plan** (absolute source → filename). Logseq-only content (queries,
-flashcards) is applied here too (`applyLogseqOnly`).
+flashcards) is applied after `convertLocal`; section L documents how this ordering affects advanced
+query blocks and flashcard tags.
 
-After pass 1, the **known-pages set** is built from intermediates whose YAML or body is non-empty.
-Pages that are blank after pass-1 transforms are excluded so that tag conversion doesn't create
-links to pages that will never be written.
+After pass 1, the **known-pages set** is built from the lower-cased canonical names of intermediates
+whose YAML or body is non-empty. Pages that are blank after pass-1 transforms are excluded so that
+tag conversion doesn't create links to pages that will never be written. A basename by itself does
+not represent a namespaced page in this set. A page that becomes empty only after pass-2 cleanup can
+still be present in the set.
 
 > Tag conversion is **deliberately deferred to pass 2** because the `onlyExistingPages` option
 > needs the complete known-pages set, which is only available after pass 1 is complete.
@@ -86,11 +92,12 @@ links to pages that will never be written.
 3. `rewriteAliasReferences` — `[[Alias]]` → `[[Canonical|Alias]]`.
 4. `disambiguateBasenameLinks` — bare `[[name]]` → `[[full/path|name]]` when the basename is shared.
 5. `convertTags` — keep / sanitize / link / drop tags (section H).
-6. ISO date-link reformat — `[[YYYY-MM-DD]]` → target Daily-Notes format if it differs.
-7. `deOutline` — *(option)* flatten the outline for journals and/or pages.
-8. **[A1] Empty-page check** — if the resulting body is blank and there is no YAML frontmatter, the page
+6. `linkifyTagValuesInFrontmatter` — apply the same tag-to-link policy to scalar frontmatter values.
+7. ISO date-link reformat — `[[YYYY-MM-DD]]` → target Daily-Notes format if it differs.
+8. `deOutline` — *(option)* flatten the outline for journals and/or pages.
+9. **[A1] Empty-page check** — if the resulting body is blank and there is no YAML frontmatter, the page
    is skipped (reported via `ctx.reportSkipped`) rather than written as an empty file.
-9. Write the note (`yaml + body`), then copy assets.
+10. Write or replace the note (`yaml + body`). After all notes, copy planned assets.
 
 ---
 
@@ -133,9 +140,9 @@ All options live in `src/formats/logseq/options.ts` (`LogseqImportOptions`). Def
 
 | Option | Type | Default | Effect |
 |---|---|---|---|
-| `queries` | `'keep' \| 'drop'` | `keep` | `{{query}}` / `#+BEGIN_QUERY` blocks (section L). |
-| `flashcards` | `'keep' \| 'drop'` | `keep` | `#card` markers and `{{cloze}}` wrappers (section L). |
-| `logbook` | `'keep' \| 'drop'` | `drop` | `:LOGBOOK:` / `CLOCK:` time-tracking blocks on tasks. |
+| `queries` | `'keep' \| 'drop'` | `keep` | Simple `{{query}}` macros. Org `#+BEGIN_QUERY` blocks are always converted to fenced `query` blocks earlier in pass 1 (section L). |
+| `flashcards` | `'keep' \| 'drop'` | `keep` | `#card` markers and `{{cloze}}` wrappers; `#card` is subsequently subject to `dropTags` (section L). |
+| `logbook` | `'keep' \| 'drop'` | `drop` | `:LOGBOOK:` / `CLOCK:` time-tracking drawers on any block. |
 
 ### Assets
 
@@ -165,7 +172,7 @@ All options live in `src/formats/logseq/options.ts` (`LogseqImportOptions`). Def
 
 | Option | Type | Default | Effect |
 |---|---|---|---|
-| `normalizeWhitespace` | boolean | `true` | **[B1]** Trim trailing whitespace, remove lone empty bullets (`- `), and convert non-breaking spaces (U+00A0) to regular spaces. Fenced code blocks (both standard ` ``` ` and bullet-prefixed `- ``` ` fences) and intentional blank lines are left untouched; empty bullets that carry a `^anchor` are kept. |
+| `normalizeWhitespace` | boolean | `true` | **[B1]** Trim trailing whitespace, remove lone empty bullets (`- `), and convert non-breaking spaces (U+00A0) to regular spaces. Fenced code blocks (both standard ` ``` ` and bullet-prefixed `- ``` ` fences) and intentional blank lines are left untouched; empty bullets that carry a `^anchor` are kept. This runs before Logseq-only drop operations and pass 2, not as a final cleanup pass. |
 
 ---
 
@@ -192,7 +199,7 @@ and re-serializes it as idiomatic markdown using these heuristics:
   list, re-indented from depth 0. Headings are never list-compatible and always promoted to real
   headings, even when siblings of list items.
 - **[C1]** A **single-child chain** of prose collapses into one paragraph (avoids one-item lists), provided
-  the leaf has no children of its own.
+  the descendants remain a simple non-heading, non-task chain without branching.
 - **[C1]** Other prose bullets become paragraphs separated by blank lines.
 - **[C1]** **Tasks** always remain list items; consecutive tasks are grouped into a compact list.
 - **[C1]** **Code blocks** with a trailing `^anchor` on the closing fence are recognized as terminated.
@@ -238,35 +245,40 @@ malformed set literal emits no completion date.
 | `created::` | `➕ date` | `[created:: date]` | — |
 | `completed::` / `done::` | `✅ date` | `[completion:: date]` | — |
 | `cancelled::` / `canceled::` | `❌ date` | `[cancelled:: date]` | — |
-| `:LOGBOOK:` … `:END:` | see `logbook` option | see `logbook` option | preserved as continuation |
+| `:LOGBOOK:` … `:END:` | see `logbook` option | see `logbook` option | see `logbook` option |
 
 Notes:
 - In **plain** format, priority and scheduling are not extracted into metadata — continuation lines
   are kept as-is, so no information is destroyed (it just stays inline).
 - The **repeater** emoji form distinguishes `.+`/`++` (→ "when done") from `+` (fixed).
 - **[D1]** Task metadata dates normalize ISO and Logseq long-date values to `YYYY-MM-DD`; unparsable values
-  such as template tokens are not emitted as task metadata.
+  such as template tokens are consumed but not emitted in the rich task formats. Plain mode keeps
+  those continuation lines verbatim.
 - **[D1]** **LOGBOOK** has no Obsidian target; with `logbook: 'drop'` (default) it is removed cleanly,
-  with `logbook: 'keep'` the `:LOGBOOK:`/`CLOCK:` lines are preserved verbatim.
+  with `logbook: 'keep'` the `:LOGBOOK:`/`CLOCK:` lines are preserved verbatim. The drop pass applies
+  to drawers on non-task blocks as well as tasks.
 
 ---
 
 ## E. Journals & dates
 
-Journals have two distinct format ends, neither hard-coded:
+Journals have two distinct source patterns:
 
-- **Source filename** — `journals/2024_08_30.md` style. `journalFilenameToISO` parses
-  `YYYY[_-]M[_-]D` to ISO `YYYY-MM-DD`.
+- **Source filename** — `journals/2024_08_30.md` style. `journalFilenameToISO` parses the built-in
+  `YYYY[_-]M[_-]D` pattern to ISO `YYYY-MM-DD`. Other source filename formats are not read from
+  `logseq/config.edn`; an unrecognized journal basename is retained.
 - **Source date links** — `[[Aug 30th, 2024]]` style. `convertJournalDateLinks` parses the
-  `MMM do, yyyy` family to `[[2024-08-30]]`.
+  English-month `MMM do, yyyy` family to `[[2024-08-30]]`. Custom source page-title formats are not
+  read from `config.edn`.
 
 **Target.** The journal filename is produced from the ISO date via moment using
 `journalDateFormat`. When `useDailyNotes` is on, the folder and format come from the **Daily Notes**
 core plugin (`app.internalPlugins.getPluginById('daily-notes')`), falling back to `Journals` /
-`YYYY-MM-DD`. When off, the user's `journalFolder` / `journalDateFormat` are used.
+`YYYY-MM-DD` in the settings UI. When off, the user's `journalFolder` / `journalDateFormat` are
+used. Periodic Notes settings are not read.
 
-**[E1]** If the target format differs from ISO, pass 2 reformats every in-content `[[YYYY-MM-DD]]` link to
-the target format so links keep matching the filenames.
+**[E1]** If the target format differs from ISO, pass 2 reformats every in-content
+`[[YYYY-MM-DD]]` link, including links with a `#^anchor`, so links keep matching the filenames.
 
 ---
 
@@ -281,8 +293,10 @@ the target format so links keep matching the filenames.
   keeping the folder hierarchy.
 - The **canonical name** (the namespace/date path without `.md`) is what block references and
   wikilinks target.
-- `whiteboards/` files are reported as unsupported and skipped. The scan only includes `pages/`
-  and `journals/`.
+- The scan is recursive, but output planning uses each source file's basename; physical
+  subdirectories under `pages/` or `journals/` are not preserved unless encoded in the basename.
+- The importer does not scan the graph-level `whiteboards/` directory. A Markdown path containing
+  `whiteboards/` below a scanned note directory is reported as unsupported and skipped.
 ---
 
 ## G. Links, references & embeds
@@ -305,7 +319,8 @@ display text). **Self-aliases** (where the alias matches the canonical page name
 avoid redundant `[[Name|Name]]` rewrites. Alias rewriting also skips inline-code spans.
 The alias values still go into the note's `aliases:` frontmatter so Obsidian autocomplete works.
 **Ambiguous aliases** (the same alias claimed by multiple pages) are dropped from the map and left
-unrewritten.
+unrewritten. If a page defines both `alias::` and `aliases::`, both contribute to frontmatter, but
+`alias::` takes precedence when building the cross-file rewrite index.
 
 **[G1] Block IDs.** Logseq UUIDs (e.g. `64ab9aa4-459a-41b1-8c21-dbb38dc0c79b`) are shortened to a stable
 6-char anchor (`^64ab9a`) when `shortenBlockIds` is on (default), or kept full when off. Short-id
@@ -323,6 +338,9 @@ is context-aware:
   with no blank-line gap, for the same reason.
 - After retained block properties: the anchor lands on the **last non-blank line** (including kept
   property lines), not the content line before them.
+
+If the same full UUID is defined in more than one file, the later pass-1 definition replaces the
+earlier entry in the graph-wide index.
 
 **[G1] Block references inside code blocks.** `resolveBlockRefs` converts `((uuid))` and
 `{{embed ((uuid))}}` references **everywhere**, including inside fenced code blocks. The guard is
@@ -354,7 +372,8 @@ opening bracket/paren (`([`). For each tag, in order:
 3. **Convert to link?** Only if `convertTagsToLinks` is on:
    - If `convertTagsOnlyExistingPages` is on (default), the tag becomes `[[tag]]` **only when a
      page with that name exists** in the graph; otherwise it stays a `#tag`. This is the "smart"
-     conversion: real pages become links, ad-hoc tags stay tags.
+     conversion: real pages become links, ad-hoc tags stay tags. Matching is case-insensitive against
+     the page's full canonical name; the bare basename of a namespaced page is not added separately.
    - If `convertTagsOnlyExistingPages` is off, every tag becomes `[[tag]]`.
 4. **Keep as tag (default).** Multi-word `#[[multi word]]` is sanitized to `#multi-word`; simple
    tags are left as-is.
@@ -374,7 +393,7 @@ Tags listed in `dropTags` are also removed from frontmatter `tags:` (section I).
 - `tags` → a `tags:` list (`#` and `[[…]]` stripped; comma- and space-separated values both
   handled; values in `dropTags` removed; if all are removed, no `tags:` key is emitted).
 - `title` → registered as an additional alias (so the page is findable by title in Obsidian);
-  removed from YAML as a standalone key. Also kept in `raw` for the filename / reporting.
+  removed from YAML as a standalone key. It does not replace the filename.
 - Keys listed in `dropPageProperties` → dropped. Default: `public`, `exclude-from-graph-view`,
   `icon`. (`icon` carries a Logseq private-use glyph that renders as □ in Obsidian.)
 - **Always dropped** (Logseq-internal, never meaningful in Obsidian — not user-overridable):
@@ -391,10 +410,11 @@ Tags listed in `dropTags` are also removed from frontmatter `tags:` (section I).
   boolean words, integers, floats, or reserved YAML tokens) are double-quoted. Wikilink-valued
   scalars are also quoted (`project: "[[Big Project]]"`); multiple wikilink values become a quoted
   list.
-- **[I1]** **Date extraction:** values wrapped in `[[…]]` that parse as dates are unwrapped and emitted as
-  bare ISO dates (not quoted). Template tokens like `{{date}}` are left as-is.
-- **[I1]** **List splitting:** comma-separated values are split with bracket-awareness (respects `[[…]]`
-  and `(…)` boundaries so `[[a, b]]` is not split mid-link).
+- **[I1]** **Date extraction:** `created` and `updated` values containing a plain
+  `[[YYYY-MM-DD]]` are unwrapped and emitted as bare ISO dates. Other property keys and date
+  formats follow the normal scalar/list rules.
+- **[I1]** **List splitting:** comma-separated values are split with wikilink-bracket awareness so
+  `[[a, b]]` is not split mid-link.
 - **[I1]** **Duplicate keys:** when the same key appears multiple times, last value wins; insertion order
   of first occurrence is preserved in the YAML output.
 - **[I1]** Empty-valued properties (key with no value) are silently dropped.
@@ -426,7 +446,7 @@ handled by the `blockProperties` option:
   indentation and any trailing `^anchor` (which stays outside the brackets). The label is hidden in
   reading view while the value stays queryable. Values containing a stray `]`/`[` (outside a
   `[[wikilink]]`) fall back to `keep` so the inline-field syntax isn't broken; property-like lines
-  inside fenced code blocks are never touched.
+  inside standard fenced code blocks are never touched.
 - `drop` — the line is removed entirely.
 
 The always-dropped set and `dropBlockProperties` keys win in every mode.
@@ -452,7 +472,7 @@ The always-dropped set and `dropBlockProperties` keys win in every mode.
 | `#+BEGIN_NOTE/TIP/WARNING/IMPORTANT/CAUTION/EXAMPLE` | `> [!type]` callout | **[J1]** first `**bold**` line becomes the callout title |
 | `- #+BEGIN_TIP` (bullet-prefixed) | `- > [!tip]` callout under bullet | **[J1]** |
 | `#+BEGIN_COMMENT` | `%% … %%` | |
-| `#+BEGIN_QUERY` … `#+END_QUERY` | `` ```query `` … `` ``` `` | **[J1]** preserves query DSL verbatim in a fenced block |
+| `#+BEGIN_QUERY` … `#+END_QUERY` | `` ```query `` … `` ``` `` | **[J1]** preserves query DSL in a fenced block; this happens before the `queries` keep/drop option |
 | other `#+BEGIN_*` (CENTER/VERSE/PINNED/…) | `> [!note]` fallback | nesting supported |
 | `#+BEGIN_*` inside a fenced code block | left unchanged | **[J1]** fence-aware: org markers in code are inert |
 | numbered list (bullet + `logseq.order-list-type:: number`) | `1.` `2.` `3.` | **[J1]** counter resets on level change / non-numbered sibling |
@@ -477,27 +497,37 @@ The always-dropped set and `dropBlockProperties` keys win in every mode.
 
 **[K1]** Only links whose path contains `assets/` are treated as local assets; URLs (`http:`, `https:`,
 `data:`) and other paths are left alone. Asset links inside fenced code blocks **and inline code
-spans** are not converted. Assets are de-duplicated by filename when copied; the byte copy resolves
-the source relative to the note's directory (tolerant of `../` prefixes).
+spans** are not converted. The byte copy resolves the source relative to the note's directory
+(tolerant of `../` prefixes) and flattens assets into `<output>/assets/`. If that destination
+filename already exists—whether from the vault or an earlier planned asset—it is retained and the
+later asset is not copied. Asset basename collisions are therefore not renamed or reported. If a
+rewritten source path cannot be resolved on disk, no asset is planned and the rewritten link remains
+without a corresponding copy.
 
 ---
 
 ## L. Logseq-only content
 
-Each Logseq-only feature has an independent keep/drop choice. "Keep" preserves the text verbatim
-(and reports it via `ctx.reportSkipped` so the user can revisit it); "drop" removes it cleanly.
+The importer exposes independent controls for simple queries, flashcard syntax, and LOGBOOK
+drawers. Their exact behavior reflects pipeline ordering and the separate tag controls:
 
 | Feature | Syntax | Option | Default | If kept | If dropped |
 |---|---|---|---|---|---|
-| Queries | `{{query …}}`, `#+BEGIN_QUERY … #+END_QUERY` | `queries` | `keep` | left verbatim + reported | block removed, no residue |
-| Flashcards | `#card`, `{{cloze …}}` | `flashcards` | `keep` | left verbatim + reported | `{{cloze X}}` → `X`, `#card` removed |
-| Time tracking | `:LOGBOOK:` / `CLOCK:` on tasks | `logbook` | `drop` | lines kept on the task | lines removed cleanly |
+| Simple queries | `{{query …}}` | `queries` | `keep` | left verbatim and a report entry is added | matching macro removed |
+| Advanced queries | `#+BEGIN_QUERY … #+END_QUERY` | none after normalization | retained | converted to a fenced `query` block | same as keep; conversion happens before `applyLogseqOnly` sees it |
+| Flashcards | `#card`, `{{cloze …}}` | `flashcards` | `keep` | cloze wrapper retained and a report entry is added; `#card` continues through tag handling | `{{cloze X}}` → `X`, `#card` removed |
+| Time tracking | `:LOGBOOK:` / `CLOCK:` drawers | `logbook` | `drop` | drawer lines kept | drawer lines removed |
 
-Whiteboards (`whiteboards/*.edn`) are always skipped and reported (not migratable).
+Because only Markdown under `pages/` and `journals/` is scanned, graph-level whiteboard `.edn`
+files are outside the import rather than individually reported.
+
+`dropTags` is applied after the flashcard keep/drop pass. With the defaults, `card` is in
+`dropTags`, so choosing `flashcards: 'keep'` preserves `{{cloze}}` wrappers but still removes
+`#card`. Remove `card` from `dropTags` to preserve the marker too.
 
 **Template-field macros are out of scope.** Dynamic template placeholders such as `{{date:…}}`,
 `{{sunday:…}}`, `{{monday:…}}` and similar are left as literal text; converting them to Obsidian
-Templater/QuickAdd syntax is not attempted. They typically appear only on `template::` pages.
+Templater/QuickAdd syntax is not attempted.
 
 ---
 
@@ -512,6 +542,8 @@ The importer handles this natively, with no flattening:
 
 - **Output-path collisions** (two sources mapping to the *exact same* path) are detected during
   planning. The first writer wins; later colliders are reported and skipped — no silent overwrite.
+- A note that already exists in the vault at a planned output path is replaced via
+  `vault.modify`; collision detection only covers sources within the current import plan.
 - **[M1] Ambiguous bare links.** A `basename → [paths]` index is built from all plans. In pass 2,
   `disambiguateBasenameLinks` rewrites any bare `[[name]]` whose basename maps to 2+ notes into
   `[[full/path|name]]` (using the first path as canonical, and preserving any explicit display
@@ -519,5 +551,5 @@ The importer handles this natively, with no flattening:
   left as-is — it already resolves unambiguously in Obsidian's shortest-path resolution. Links that
   already contain a `/` (namespace-style) or a `#` (block/heading ref) are also left untouched.
 
-This mirrors exactly how Obsidian itself disambiguates same-named notes, so the output stays
-idiomatic and no data is lost.
+This uses Obsidian's full-path link syntax so same-named notes can remain in their namespaces
+without global renaming.

--- a/docs/logseq-importer-transformations.md
+++ b/docs/logseq-importer-transformations.md
@@ -160,7 +160,9 @@ dynamic UI; both are always-visible switches). `deOutline` (`de-outline.ts`) par
 and re-serializes it as idiomatic markdown using these heuristics:
 
 - A bullet whose content is a **heading** (`# …`) de-nests to a real heading; its children become
-  the body under it. Multiline heading continuations get a blank line separator (F6).
+  the body under it. Multiline heading continuations get a blank line separator (F6), **except**
+  when the only continuation is a `^anchor` — in that case the anchor lands directly on the next
+  line with no gap (required for Obsidian block-reference resolution).
 - A subtree that is a **genuine list** (2+ siblings where all are list-compatible — leaves, tasks,
   or recursively list-compatible nodes with their own children) stays a list, re-indented from
   depth 0.
@@ -282,18 +284,20 @@ is context-aware:
 
 - On a closing code fence (`` ``` ``): the anchor goes on a **new line after** the fence (appending
   to the fence would break CommonMark).
-- On a heading line: the anchor goes on its own line **below** the heading (Obsidian renders anchors
-  on heading lines as literal text).
+- On a **bullet-heading** line (`- ## Title`): the anchor goes on the **next line, indented** to
+  content level (so it stays part of the block in outline mode). When the heading is later
+  de-outlined to `## Title`, the anchor appears directly below with no blank-line gap — enabling
+  both `[[Page#^anchor]]` and `[[Page#Title]]` reference styles.
+- On a plain heading line (`## Title`, rare outside de-outline): the anchor goes on the next line
+  with no blank-line gap, for the same reason.
 - After retained block properties: the anchor lands on the **last non-blank line** (including kept
   property lines), not the content line before them.
 
-**Orphan block references.** A `((uuid))` whose target was never defined in the graph is left
-untouched by default (the raw text survives). With `removeOrphanBlockRefs` on, such unresolved
-`((uuid))` references and `{{embed ((uuid))}}` embeds are removed cleanly (including lines that
-become empty). This runs *after* `resolveBlockRefs`, so only genuine orphans remain to remove.
-
-**Code protection.** Block reference resolution (`resolveBlockRefs`) skips both fenced code blocks
-and inline-code spans — `((uuid))` appearing inside code is not rewritten.
+**Block references inside code blocks.** `resolveBlockRefs` converts `((uuid))` and
+`{{embed ((uuid))}}` references **everywhere**, including inside fenced code blocks. The guard is
+that the UUID must exist in the block index — unrecognised UUIDs are left as-is. This means
+copy-pasteable code examples that include Logseq embed syntax are updated to the equivalent Obsidian
+form. Inline-code spans (single backticks) are still protected and never rewritten.
 
 ---
 

--- a/docs/logseq-importer-transformations.md
+++ b/docs/logseq-importer-transformations.md
@@ -151,8 +151,15 @@ All options live in `src/formats/logseq/options.ts` (`LogseqImportOptions`). Def
 
 | Option | Type | Default | Effect |
 |---|---|---|---|
-| `dropPageProperties` | string[] | `['public', 'exclude-from-graph-view']` | Page-level property keys excluded from frontmatter. |
+| `dropPageProperties` | string[] | `['public', 'exclude-from-graph-view', 'icon']` | Page-level property keys excluded from frontmatter. `icon` is dropped by default because it carries a Logseq private-use glyph that renders as a tofu box (□) in Obsidian. |
 | `dropBlockProperties` | string[] | `[]` | **Additional** inline block-property keys to strip (beyond the always-dropped set). |
+| `blockProperties` | `keep` \| `wrap` \| `drop` | `wrap` | How retained (unknown) inline block properties are emitted. `keep` leaves the raw `key:: value` line; `wrap` rewrites it to a Dataview inline field `[key:: value]` (label hidden in reading view, value stays queryable); `drop` removes the line. The always-dropped set and `dropBlockProperties` keys win in every mode. |
+
+### Cleanup
+
+| Option | Type | Default | Effect |
+|---|---|---|---|
+| `normalizeWhitespace` | boolean | `true` | Trim trailing whitespace, remove lone empty bullets (`- `), and convert non-breaking spaces (U+00A0) to regular spaces. Fenced code blocks and intentional blank lines are left untouched; empty bullets that carry a `^anchor` are kept. |
 
 ---
 
@@ -197,8 +204,13 @@ Preserve is the default.
 Logseq tasks are bullets whose text starts with a workflow keyword. Recognized keywords:
 `TODO, DOING, DONE, LATER, NOW, WAITING, WAIT, IN-PROGRESS, CANCELLED, CANCELED`.
 
+A colon may follow the keyword (`- TODO: do the thing`); it is recognized as a task and the colon is
+dropped from the emitted text.
+
 The task line plus its indented continuation lines (`SCHEDULED:`, `DEADLINE:`, `:LOGBOOK:`, and
-`created/completed/done/cancelled` properties) are parsed as one unit and re-emitted.
+`created/completed/done/cancelled` properties) are parsed as one unit and re-emitted. A Logseq
+set-literal date value (`completed:: #{"Mar 3rd, 2025"}`) is unwrapped to its quoted date; a
+malformed set literal emits no completion date.
 
 ### Checkbox state mapping
 
@@ -355,7 +367,14 @@ The leading block of unindented `key:: value` lines becomes YAML frontmatter
   handled; values in `dropTags` removed; if all are removed, no `tags:` key is emitted).
 - `title` → registered as an additional alias (so the page is findable by title in Obsidian);
   removed from YAML as a standalone key. Also kept in `raw` for the filename / reporting.
-- Keys listed in `dropPageProperties` → dropped. Default: `public`, `exclude-from-graph-view`.
+- Keys listed in `dropPageProperties` → dropped. Default: `public`, `exclude-from-graph-view`,
+  `icon`. (`icon` carries a Logseq private-use glyph that renders as □ in Obsidian.)
+- **Tag-style values → links (pass-2):** a scalar value that is a single tag (`status:: #IN-PROGRESS`,
+  `area:: #[[Page One]]`) is emitted as quoted text (`status: "#IN-PROGRESS"`) by default. When tag
+  conversion is enabled (`convertTagsToLinks`), the value is linkified to a wikilink
+  (`status: "[[IN-PROGRESS]]"`) using the vault-wide page set, respecting
+  `convertTagsOnlyExistingPages`. With tag conversion off (the default) these values stay quoted text,
+  so default output is unchanged. `tags:` / `aliases:` lists are never affected.
 - **YAML quoting:** values that are YAML-unsafe (contain `: `, `#`, start with `[`, `{`, are
   boolean words, integers, floats, or reserved YAML tokens) are double-quoted. Wikilink-valued
   scalars are also quoted (`project: "[[Big Project]]"`); multiple wikilink values become a quoted
@@ -381,8 +400,20 @@ Both standard indented form (`  key:: value`) and bullet form (`- key:: value`) 
 `query-table`, `query-properties`, `query-sort-by`, `query-sort-desc`, `query-flag`, plus **any key
 starting with `logseq.`**, **`query-`**, **`hl-`**, or **`ls-`** (highlight/annotation-related).
 
-**Additionally dropped:** any key the user lists in `dropBlockProperties` (default empty). Unknown
-user block properties (e.g. `rating:: 5`) are **kept** by default.
+**Additionally dropped:** any key the user lists in `dropBlockProperties` (default empty).
+
+**Retained (unknown) block properties** (e.g. `rating:: 5`, `participants:: [[Alice]], [[Bob]]`) are
+handled by the `blockProperties` option:
+
+- `keep` — the raw `key:: value` line is left as-is.
+- `wrap` (default) — rewritten to a Dataview inline field `[key:: value]`, preserving leading
+  indentation and any trailing `^anchor` (which stays outside the brackets). The label is hidden in
+  reading view while the value stays queryable. Values containing a stray `]`/`[` (outside a
+  `[[wikilink]]`) fall back to `keep` so the inline-field syntax isn't broken; property-like lines
+  inside fenced code blocks are never touched.
+- `drop` — the line is removed entirely.
+
+The always-dropped set and `dropBlockProperties` keys win in every mode.
 
 ### Special property conversions
 
@@ -447,6 +478,10 @@ Each Logseq-only feature has an independent keep/drop choice. "Keep" preserves t
 | Time tracking | `:LOGBOOK:` / `CLOCK:` on tasks | `logbook` | `drop` | lines kept on the task | lines removed cleanly |
 
 Whiteboards (`whiteboards/*.edn`) are always skipped and reported (not migratable).
+
+**Template-field macros are out of scope.** Dynamic template placeholders such as `{{date:…}}`,
+`{{sunday:…}}`, `{{monday:…}}` and similar are left as literal text; converting them to Obsidian
+Templater/QuickAdd syntax is not attempted. They typically appear only on `template::` pages.
 
 ---
 

--- a/docs/logseq-importer-transformations.md
+++ b/docs/logseq-importer-transformations.md
@@ -34,11 +34,15 @@ The import runs in **two passes** so that cross-file references can be resolved 
 vault-wide index that only exists once every file has been planned and locally converted.
 
 **Planning.** Files under `pages/` and `journals/` are enumerated. Each is assigned a canonical
-name and an output path (section 6). Output-path collisions are detected here: the first writer
-wins; later colliders are reported via `ctx.reportSkipped` and skipped. From the plans we build:
+name and an output path (section 6). During planning, files are skipped when:
 
-- a **basename disambiguation index** (`basename → [full path, …]`, section 13),
-- a **known-pages set** (`canonicalName` lower-cased, used for page-aware tag conversion).
+- The path matches `whiteboards/` — not supported.
+- Two sources would map to the *same output path* — the first wins; later colliders are reported
+  and skipped (no silent overwrite).
+
+From the surviving plans we build:
+
+- a **basename disambiguation index** (`basename → [full path, …]`, section 13).
 
 **Pass 1 — per-file local conversion** (`convertLocal` in `pipeline.ts`). Everything that can be
 done on a single file without the vault index. In order:
@@ -59,12 +63,16 @@ done on a single file without the vault index. In order:
 14. `removeLeftoverBlockProperties` — strip remaining internal/user-listed block properties.
 
 While iterating, pass 1 also builds the **block-id index** (`uuid → {page, shortId}`), the
-**alias index** (`alias → canonical page`, ambiguous aliases removed afterward), and the
-**asset plan** (absolute source → filename). Logseq-only content (queries, flashcards) is applied
-here too (`applyLogseqOnly`).
+**alias index** (`alias → canonical page`, including `title::` — ambiguous aliases removed
+afterward), and the **asset plan** (absolute source → filename). Logseq-only content (queries,
+flashcards) is applied here too (`applyLogseqOnly`).
+
+After pass 1, the **known-pages set** is built from intermediates whose YAML or body is non-empty.
+Pages that are blank after pass-1 transforms are excluded so that tag conversion doesn't create
+links to pages that will never be written.
 
 > Tag conversion is **deliberately deferred to pass 2** because the `onlyExistingPages` option
-> needs the complete known-pages set, which is only available after planning.
+> needs the complete known-pages set, which is only available after pass 1 is complete.
 
 **Pass 2 — cross-file resolution + write** (in `logseq.ts`). For each file, in order:
 
@@ -76,7 +84,9 @@ here too (`applyLogseqOnly`).
 5. `convertTags` — keep / sanitize / link / drop tags (section 8).
 6. ISO date-link reformat — `[[YYYY-MM-DD]]` → target Daily-Notes format if it differs.
 7. `deOutline` — *(option)* flatten the outline for journals and/or pages.
-8. Write the note (`yaml + body`), then copy assets.
+8. **Empty-page check** — if the resulting body is blank and there is no YAML frontmatter, the page
+   is skipped (reported via `ctx.reportSkipped`) rather than written as an empty file.
+9. Write the note (`yaml + body`), then copy assets.
 
 ---
 
@@ -135,6 +145,7 @@ All options live in `src/formats/logseq/options.ts` (`LogseqImportOptions`). Def
 |---|---|---|---|
 | `shortenBlockIds` | boolean | `true` | Shorten Logseq UUID block IDs to short Obsidian-style anchors. |
 | `removeOrphanBlockRefs` | boolean | `false` | Remove `((uuid))` references that could not be resolved to a known block. |
+| `alwaysEmbedBlockRefs` | boolean | `false` | Convert bare `((uuid))` block references to embeds (`![[…]]`) instead of plain links (`[[…]]`). |
 
 ### Properties
 
@@ -252,7 +263,6 @@ the target format so links keep matching the filenames.
   wikilinks target.
 - `whiteboards/` files are reported as unsupported and skipped. The scan only includes `pages/`
   and `journals/`.
-
 ---
 
 ## 7. Links, references & embeds

--- a/src/formats/logseq.ts
+++ b/src/formats/logseq.ts
@@ -1,0 +1,400 @@
+import { moment, Notice, Platform, Setting, TFile } from 'obsidian';
+import { FormatImporter } from '../format-importer';
+// Type-only: `main.ts` imports this file, so a value import here would be a
+// circular dependency and the imported binding would be undefined at init().
+import type { ImportContext } from '../main';
+import { NodePickedFile, PickedFile, parseFilePath, fs, fsPromises, path, nodeBufferToArrayBuffer } from '../filesystem';
+import { sanitizeFileNameKeepPath } from './roam/utils';
+import { DEFAULT_LOGSEQ_OPTIONS, LogseqImportOptions, TaskFormat, KeepOrDrop } from './logseq/options';
+import { convertLocal } from './logseq/pipeline';
+import { resolveBlockRefs, BlockRefTarget } from './logseq/block-ids';
+import { rewriteAliasReferences } from './logseq/links';
+import { journalFilenameToISO } from './logseq/journals';
+import { namespaceToPath } from './logseq/paths';
+
+const ISO_FORMAT = 'YYYY-MM-DD';
+// Note directories under a Logseq graph root (relative paths).
+const GRAPH_NOTE_DIRS = ['pages', 'journals'] as const;
+
+interface PagePlan {
+	file: PickedFile;
+	kind: 'page' | 'journal';
+	/** Canonical wikilink name used as the target for block references. */
+	canonicalName: string;
+	/** Vault-relative output path including `.md`. */
+	outputPath: string;
+	/** Absolute directory of the source file (for resolving relative assets). */
+	sourceDir: string;
+}
+
+interface Intermediate extends PagePlan {
+	yaml: string;
+	body: string;
+}
+
+export class LogseqImporter extends FormatImporter {
+	// Initialized in init(), not as a field initializer: FormatImporter's
+	// constructor calls init() before subclass fields are assigned.
+	options!: LogseqImportOptions;
+	/** Absolute path to the selected Logseq graph root. */
+	graphRoot: string | null = null;
+
+	init() {
+		this.options = { ...DEFAULT_LOGSEQ_OPTIONS };
+		const dn = this.getDailyNotesConfig();
+		this.options.journalDateFormat = dn.format;
+		this.options.journalFolder = dn.folder || 'Journals';
+
+		const graphSetting = new Setting(this.modal.contentEl)
+			.setName('Graph folder')
+			.setDesc('Pick the root of your Logseq graph (the folder containing pages/, journals/ and assets/).');
+
+		if (!Platform.isDesktopApp) {
+			graphSetting.setDesc('Logseq import requires the desktop app to select a graph folder.');
+			this.notAvailable = true;
+			return;
+		}
+
+		graphSetting.addButton(button => button
+			.setButtonText('Choose graph folder')
+			.onClick(async () => {
+				const picked = window.electron.remote.dialog.showOpenDialogSync({
+					title: 'Pick Logseq graph folder',
+					properties: ['openDirectory', 'dontAddToRecent'],
+				});
+				if (!picked?.[0]) return;
+
+				const graphRoot = picked[0];
+				this.graphRoot = graphRoot;
+				const notes = collectGraphNotes(graphRoot);
+				this.files = notes;
+
+				const pages = notes.filter(f => relPathFromGraph(graphRoot, this.absPath(f)).startsWith('pages/')).length;
+				const journals = notes.length - pages;
+				graphSetting.setDesc(
+					`Graph: ${graphRoot}\n`
+					+ `${notes.length} note(s) to import (${pages} page(s), ${journals} journal(s)).`
+				);
+			}));
+
+		this.addOutputLocationSetting('Logseq');
+
+		new Setting(this.modal.contentEl).setName('Conversion').setHeading();
+
+		new Setting(this.modal.contentEl)
+			.setName('Task format')
+			.setDesc('How rich Logseq tasks (TODO/DOING/SCHEDULED/priority...) are written in Obsidian.')
+			.addDropdown(d => d
+				.addOption('tasks-emoji', 'Tasks plugin — emoji')
+				.addOption('tasks-dataview', 'Tasks plugin — Dataview fields')
+				.addOption('plain', 'Plain checkboxes')
+				.setValue(this.options.taskFormat)
+				.onChange(v => this.options.taskFormat = v as TaskFormat));
+
+		new Setting(this.modal.contentEl)
+			.setName('Journal folder')
+			.setDesc('Vault folder (relative to output) for imported journals/daily notes.')
+			.addText(t => t
+				.setValue(this.options.journalFolder)
+				.onChange(v => this.options.journalFolder = v));
+
+		new Setting(this.modal.contentEl)
+			.setName('Journal date format')
+			.setDesc('moment.js format for daily-note filenames. Prefilled from your Daily Notes settings.')
+			.addText(t => t
+				.setValue(this.options.journalDateFormat)
+				.onChange(v => this.options.journalDateFormat = v || ISO_FORMAT));
+
+		new Setting(this.modal.contentEl)
+			.setName('Time tracking (LOGBOOK)')
+			.setDesc('Logseq LOGBOOK/CLOCK entries have no Obsidian equivalent in this format.')
+			.addDropdown(d => d
+				.addOption('drop', 'Drop')
+				.addOption('keep', 'Keep verbatim')
+				.setValue(this.options.logbook)
+				.onChange(v => this.options.logbook = v as KeepOrDrop));
+
+		new Setting(this.modal.contentEl)
+			.setName('Logseq-only content')
+			.setDesc('Queries, flashcards and macros that do not translate to Obsidian.')
+			.addDropdown(d => d
+				.addOption('keep', 'Keep verbatim')
+				.addOption('drop', 'Drop')
+				.setValue(this.options.logseqOnlyContent)
+				.onChange(v => this.options.logseqOnlyContent = v as KeepOrDrop));
+
+		new Setting(this.modal.contentEl)
+			.setName('Shorten block IDs')
+			.setDesc('Convert Logseq UUID block ids to short Obsidian-style anchors.')
+			.addToggle(t => t
+				.setValue(this.options.shortenBlockIds)
+				.onChange(v => this.options.shortenBlockIds = v));
+
+		new Setting(this.modal.contentEl)
+			.setName('Convert tags to links')
+			.setDesc('Turn #tags into [[wikilinks]] instead of keeping them as tags.')
+			.addToggle(t => t
+				.setValue(this.options.convertTagsToLinks)
+				.onChange(v => this.options.convertTagsToLinks = v));
+
+		new Setting(this.modal.contentEl)
+			.setName('Keep image alt text')
+			.setDesc('Preserve image alt text as the embed display text.')
+			.addToggle(t => t
+				.setValue(this.options.keepAssetAltText)
+				.onChange(v => this.options.keepAssetAltText = v));
+	}
+
+	private getDailyNotesConfig(): { format: string; folder: string } {
+		try {
+			// @ts-expect-error : internalPlugins is not in the public API
+			const instance = this.app.internalPlugins.getPluginById('daily-notes')?.instance;
+			return {
+				format: instance?.options?.format || ISO_FORMAT,
+				folder: instance?.options?.folder || '',
+			};
+		}
+		catch {
+			return { format: ISO_FORMAT, folder: '' };
+		}
+	}
+
+	async import(ctx: ImportContext): Promise<void> {
+		if (!this.graphRoot || !fs || !path) {
+			new Notice('Please pick a Logseq graph folder to import.');
+			return;
+		}
+
+		const notes = collectGraphNotes(this.graphRoot);
+		if (notes.length === 0) {
+			const hasPages = fs.existsSync(path.join(this.graphRoot, 'pages'));
+			const hasJournals = fs.existsSync(path.join(this.graphRoot, 'journals'));
+			if (!hasPages && !hasJournals) {
+				new Notice('The selected folder does not look like a Logseq graph (missing pages/ and journals/).');
+			}
+			else {
+				new Notice('No markdown notes found under pages/ or journals/.');
+			}
+			return;
+		}
+
+		const { options } = this;
+
+		const outputFolder = await this.getOutputFolder();
+		if (!outputFolder) {
+			new Notice('Please select a location to export to.');
+			return;
+		}
+
+		const journalDir = options.journalFolder.trim()
+			? `${outputFolder.path}/${options.journalFolder.trim()}`
+			: outputFolder.path;
+
+		// Plan output paths from pages/ and journals/ only.
+		const plans: PagePlan[] = [];
+		for (const file of notes) {
+			const rel = relPathFromGraph(this.graphRoot, this.absPath(file));
+			if (/\/whiteboards\//i.test(rel)) {
+				ctx.reportSkipped(file.name, 'Whiteboards are not supported');
+				continue;
+			}
+			plans.push(this.planFor(file, rel, outputFolder.path, journalDir));
+		}
+
+		if (plans.length === 0) {
+			new Notice('No Logseq pages or journals found in the selected folder.');
+			return;
+		}
+
+		// PASS 1: per-file local conversion + index building.
+		const intermediates: Intermediate[] = [];
+		const blockIndex = new Map<string, BlockRefTarget>();
+		const aliasMap = new Map<string, string>();
+		const ambiguousAliases = new Set<string>();
+		const assetPlan = new Map<string, string>(); // absolute source -> filename
+
+		for (const plan of plans) {
+			if (ctx.isCancelled()) return;
+			ctx.status(`Reading ${plan.file.name}`);
+			try {
+				const content = await plan.file.readText();
+				const local = convertLocal(content, options);
+
+				this.indexAliases(local.raw, plan.canonicalName, aliasMap, ambiguousAliases);
+				for (const id of local.ids) {
+					blockIndex.set(id.uuid, { page: plan.canonicalName, shortId: id.shortId });
+				}
+				for (const asset of local.assets) {
+					const abs = this.resolveAsset(plan.sourceDir, asset.sourcePath);
+					if (abs) assetPlan.set(abs, asset.filename);
+				}
+
+				let body = this.applyLogseqOnly(local.body, plan.file.name, ctx);
+				intermediates.push({ ...plan, yaml: local.yaml, body });
+			}
+			catch (e) {
+				ctx.reportFailed(plan.file.name, e);
+			}
+		}
+
+		for (const alias of ambiguousAliases) aliasMap.delete(alias);
+
+		// PASS 2: cross-file resolution + write.
+		let index = 0;
+		for (const inter of intermediates) {
+			if (ctx.isCancelled()) return;
+			index++;
+			try {
+				let body = resolveBlockRefs(inter.body, blockIndex);
+				body = rewriteAliasReferences(body, { aliasMap });
+				if (options.journalDateFormat !== ISO_FORMAT) {
+					body = this.reformatIsoDateLinks(body, options.journalDateFormat);
+				}
+				const final = inter.yaml ? `${inter.yaml}\n\n${body}\n` : `${body}\n`;
+				await this.writeNote(inter.outputPath, final);
+				ctx.reportNoteSuccess(inter.outputPath);
+				ctx.reportProgress(index, intermediates.length);
+			}
+			catch (e) {
+				ctx.reportFailed(inter.outputPath, e);
+			}
+		}
+
+		await this.copyAssets(assetPlan, outputFolder.path, ctx);
+	}
+
+	private planFor(file: PickedFile, relPath: string, outputBase: string, journalDir: string): PagePlan {
+		const sourceDir = path ? parseFilePath(this.absPath(file)).parent : '';
+		const isJournal = relPath.startsWith('journals/');
+
+		if (isJournal) {
+			const iso = journalFilenameToISO(file.basename);
+			const name = iso ? moment(iso, ISO_FORMAT).format(this.options.journalDateFormat) : file.basename;
+			const safe = sanitizeFileNameKeepPath(name);
+			return { file, kind: 'journal', canonicalName: safe, outputPath: `${journalDir}/${safe}.md`, sourceDir };
+		}
+
+		const rel = sanitizeFileNameKeepPath(namespaceToPath(file.basename));
+		return { file, kind: 'page', canonicalName: rel, outputPath: `${outputBase}/${rel}.md`, sourceDir };
+	}
+
+	private absPath(file: PickedFile): string {
+		return (file as NodePickedFile).filepath ?? file.name;
+	}
+
+	private indexAliases(
+		raw: Record<string, string>,
+		canonical: string,
+		aliasMap: Map<string, string>,
+		ambiguous: Set<string>
+	): void {
+		const value = raw.alias ?? raw.aliases;
+		if (!value) return;
+		for (const item of value.split(',')) {
+			const name = item.trim().replace(/^\[\[(.*)\]\]$/, '$1').trim();
+			if (!name) continue;
+			const key = name.toLowerCase();
+			const existing = aliasMap.get(key);
+			if (existing !== undefined && existing !== canonical) ambiguous.add(key);
+			else aliasMap.set(key, canonical);
+		}
+	}
+
+	private applyLogseqOnly(body: string, name: string, ctx: ImportContext): string {
+		const hasQuery = /\{\{query|#\+BEGIN_QUERY/i.test(body);
+		const hasCard = /#card\b|\{\{cloze/i.test(body);
+		if (this.options.logseqOnlyContent === 'keep') {
+			if (hasQuery || hasCard) ctx.reportSkipped(name, 'Logseq-only content kept verbatim');
+			return body;
+		}
+		// drop, cleanly
+		body = body.replace(/^[ \t]*#\+BEGIN_QUERY[\s\S]*?#\+END_QUERY[ \t]*$/gim, '');
+		body = body.replace(/\{\{query[\s\S]*?\}\}/gi, '');
+		body = body.replace(/\{\{cloze\s+([\s\S]*?)\}\}/gi, '$1');
+		body = body.replace(/(^|\s)#card\b/gi, '$1');
+		return body;
+	}
+
+	private resolveAsset(sourceDir: string, sourcePath: string): string | null {
+		if (!fs || !path || !sourceDir) return null;
+		const candidates = [
+			path.resolve(sourceDir, sourcePath),
+			path.resolve(sourceDir, sourcePath.replace(/^(\.\.\/)+/, '')),
+		];
+		for (const candidate of candidates) {
+			try {
+				if (fs.existsSync(candidate)) return candidate;
+			}
+			catch {
+				// ignore
+			}
+		}
+		return null;
+	}
+
+	private reformatIsoDateLinks(content: string, format: string): string {
+		return content.replace(/\[\[(\d{4}-\d{2}-\d{2})\]\]/g, (whole, iso) => {
+			const d = moment(iso, ISO_FORMAT, true);
+			return d.isValid() ? `[[${d.format(format)}]]` : whole;
+		});
+	}
+
+	private async writeNote(outputPath: string, content: string): Promise<void> {
+		const { parent } = parseFilePath(outputPath);
+		if (parent) await this.createFolders(parent);
+		const existing = this.vault.getAbstractFileByPath(outputPath);
+		if (existing instanceof TFile) {
+			await this.vault.modify(existing, content);
+		}
+		else {
+			await this.vault.create(outputPath, content);
+		}
+	}
+
+	private async copyAssets(assetPlan: Map<string, string>, outputBase: string, ctx: ImportContext): Promise<void> {
+		if (!fs || assetPlan.size === 0) return;
+		const assetDir = `${outputBase}/assets`;
+		await this.createFolders(assetDir);
+		for (const [source, filename] of assetPlan) {
+			if (ctx.isCancelled()) return;
+			const dest = `${assetDir}/${filename}`;
+			if (this.vault.getAbstractFileByPath(dest)) continue; // de-dupe by name
+			try {
+				const buffer = await fsPromises.readFile(source);
+				await this.vault.createBinary(dest, nodeBufferToArrayBuffer(buffer));
+				ctx.reportAttachmentSuccess(filename);
+			}
+			catch (e) {
+				ctx.reportFailed(filename, e);
+			}
+		}
+	}
+}
+
+/** Collect markdown notes from pages/ and journals/ under a graph root. */
+function collectGraphNotes(graphRoot: string): NodePickedFile[] {
+	if (!fs || !path) return [];
+	const results: NodePickedFile[] = [];
+	for (const dir of GRAPH_NOTE_DIRS) {
+		const fullDir = path.join(graphRoot, dir);
+		if (!fs.existsSync(fullDir)) continue;
+		walkNotes(fullDir, results);
+	}
+	return results;
+}
+
+function walkNotes(dir: string, out: NodePickedFile[]): void {
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path!.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			walkNotes(full, out);
+		}
+		else if (entry.isFile() && entry.name.endsWith('.md')) {
+			out.push(new NodePickedFile(full));
+		}
+	}
+}
+
+function relPathFromGraph(graphRoot: string, absPath: string): string {
+	return path!.relative(graphRoot, absPath).replace(/\\/g, '/');
+}

--- a/src/formats/logseq.ts
+++ b/src/formats/logseq.ts
@@ -9,7 +9,7 @@ import { DEFAULT_LOGSEQ_OPTIONS, LogseqImportOptions, TaskFormat, KeepOrDrop } f
 import { convertLocal } from './logseq/pipeline';
 import { resolveBlockRefs, BlockRefTarget, removeOrphanBlockRefs } from './logseq/block-ids';
 import { rewriteAliasReferences, convertTags, disambiguateBasenameLinks, BasenameIndex } from './logseq/links';
-import { journalFilenameToISO } from './logseq/journals';
+import { journalFilenameToISO, reformatDateLinks } from './logseq/journals';
 import { namespaceToPath } from './logseq/paths';
 import { deOutline } from './logseq/de-outline';
 
@@ -531,9 +531,9 @@ export class LogseqImporter extends FormatImporter {
 	}
 
 	private reformatIsoDateLinks(content: string, format: string): string {
-		return content.replace(/\[\[(\d{4}-\d{2}-\d{2})\]\]/g, (whole, iso) => {
+		return reformatDateLinks(content, iso => {
 			const d = moment(iso, ISO_FORMAT, true);
-			return d.isValid() ? `[[${d.format(format)}]]` : whole;
+			return d.isValid() ? d.format(format) : null;
 		});
 	}
 

--- a/src/formats/logseq.ts
+++ b/src/formats/logseq.ts
@@ -10,6 +10,7 @@ import { convertLocal, indexPageAliases, isBodyEmpty } from './logseq/pipeline';
 import { resolveBlockRefs, BlockRefTarget, removeOrphanBlockRefs } from './logseq/block-ids';
 import { rewriteAliasReferences, convertTags, disambiguateBasenameLinks, BasenameIndex } from './logseq/links';
 import { journalFilenameToISO, reformatDateLinks } from './logseq/journals';
+import { linkifyTagValuesInFrontmatter } from './logseq/properties';
 import { namespaceToPath } from './logseq/paths';
 import { deOutline } from './logseq/de-outline';
 
@@ -282,6 +283,27 @@ export class LogseqImporter extends FormatImporter {
 				.onChange(v => {
 					this.options.dropBlockProperties = v.split(',').map(s => s.trim()).filter(s => s.length > 0);
 				}));
+
+		new Setting(this.modal.contentEl)
+			.setName('Block properties')
+			.setDesc('How to handle retained inline block properties: keep the raw "key:: value" line, wrap it as a Dataview inline field "[key:: value]", or drop it.')
+			.addDropdown(d => d
+				.addOption('keep', 'Keep raw')
+				.addOption('wrap', 'Wrap as inline field')
+				.addOption('drop', 'Drop')
+				.setValue(this.options.blockProperties)
+				.onChange(v => this.options.blockProperties = v as 'keep' | 'wrap' | 'drop'));
+
+		// ── Cleanup ─────────────────────────────────────────────────────────────────
+
+		new Setting(this.modal.contentEl).setName('Cleanup').setHeading();
+
+		new Setting(this.modal.contentEl)
+			.setName('Normalize whitespace')
+			.setDesc('Trim trailing whitespace, remove empty bullets, and convert non-breaking spaces to regular spaces.')
+			.addToggle(t => t
+				.setValue(this.options.normalizeWhitespace)
+				.onChange(v => this.options.normalizeWhitespace = v));
 	}
 
 	private getDailyNotesConfig(): { format: string, folder: string } {
@@ -436,6 +458,13 @@ export class LogseqImporter extends FormatImporter {
 					dropTags,
 				});
 
+				// Linkify tag-style frontmatter values using the same knownPages set.
+				const yaml = linkifyTagValuesInFrontmatter(inter.yaml, {
+					knownPages,
+					toLinks: options.convertTagsToLinks,
+					onlyExistingPages: options.convertTagsOnlyExistingPages,
+				});
+
 				if (options.journalDateFormat !== ISO_FORMAT) {
 					body = this.reformatIsoDateLinks(body, options.journalDateFormat);
 				}
@@ -447,13 +476,13 @@ export class LogseqImporter extends FormatImporter {
 				}
 
 				// Skip pages with no meaningful content after all transforms.
-				if (isBodyEmpty(inter.yaml, body)) {
+				if (isBodyEmpty(yaml, body)) {
 					ctx.reportSkipped(inter.outputPath, 'Empty page skipped');
 					ctx.reportProgress(index, intermediates.length);
 					continue;
 				}
 
-				const final = inter.yaml ? `${inter.yaml}\n\n${body}\n` : `${body}\n`;
+				const final = yaml ? `${yaml}\n\n${body}\n` : `${body}\n`;
 				await this.writeNote(inter.outputPath, final);
 				ctx.reportNoteSuccess(inter.outputPath);
 				ctx.reportProgress(index, intermediates.length);

--- a/src/formats/logseq.ts
+++ b/src/formats/logseq.ts
@@ -294,6 +294,20 @@ export class LogseqImporter extends FormatImporter {
 				.setValue(this.options.blockProperties)
 				.onChange(v => this.options.blockProperties = v as 'keep' | 'wrap' | 'drop'));
 
+		new Setting(this.modal.contentEl)
+			.setName('Snake_case page properties')
+			.setDesc('Convert kebab-case page-property keys to snake_case (e.g. "test-hyphen" → "test_hyphen"). Hyphens can break Bases/Dataview query syntax.')
+			.addToggle(t => t
+				.setValue(this.options.snakeCasePageProperties)
+				.onChange(v => this.options.snakeCasePageProperties = v));
+
+		new Setting(this.modal.contentEl)
+			.setName('Snake_case block properties')
+			.setDesc('Convert kebab-case inline block-property keys to snake_case, same as above but for retained block properties.')
+			.addToggle(t => t
+				.setValue(this.options.snakeCaseBlockProperties)
+				.onChange(v => this.options.snakeCaseBlockProperties = v));
+
 		// ── Cleanup ─────────────────────────────────────────────────────────────────
 
 		new Setting(this.modal.contentEl).setName('Cleanup').setHeading();

--- a/src/formats/logseq.ts
+++ b/src/formats/logseq.ts
@@ -6,7 +6,7 @@ import type { ImportContext } from '../main';
 import { NodePickedFile, PickedFile, parseFilePath, fs, fsPromises, path, nodeBufferToArrayBuffer } from '../filesystem';
 import { sanitizeFileNameKeepPath } from './roam/utils';
 import { DEFAULT_LOGSEQ_OPTIONS, LogseqImportOptions, TaskFormat, KeepOrDrop } from './logseq/options';
-import { convertLocal } from './logseq/pipeline';
+import { convertLocal, indexPageAliases, isBodyEmpty } from './logseq/pipeline';
 import { resolveBlockRefs, BlockRefTarget, removeOrphanBlockRefs } from './logseq/block-ids';
 import { rewriteAliasReferences, convertTags, disambiguateBasenameLinks, BasenameIndex } from './logseq/links';
 import { journalFilenameToISO, reformatDateLinks } from './logseq/journals';
@@ -369,9 +369,6 @@ export class LogseqImporter extends FormatImporter {
 		}
 		const basenameIndex: BasenameIndex = { basenameMap };
 
-		// Build vault-wide page set for tag→link page-existence check (lower-cased).
-		const knownPages = new Set(plans.map(p => p.canonicalName.toLowerCase()));
-
 		// PASS 1: per-file local conversion + index building.
 		const intermediates: Intermediate[] = [];
 		const blockIndex = new Map<string, BlockRefTarget>();
@@ -404,6 +401,15 @@ export class LogseqImporter extends FormatImporter {
 		}
 
 		for (const alias of ambiguousAliases) aliasMap.delete(alias);
+
+		// Build vault-wide page set for tag→link page-existence check (lower-cased).
+		// Built after pass-1 so we can exclude pages already empty at that stage.
+		// Pages that become empty only after pass-2 transforms are skipped at write-time.
+		const knownPages = new Set(
+			intermediates
+				.filter(inter => !isBodyEmpty(inter.yaml, inter.body))
+				.map(inter => inter.canonicalName.toLowerCase())
+		);
 
 		const dropTags = new Set(options.dropTags);
 
@@ -440,6 +446,13 @@ export class LogseqImporter extends FormatImporter {
 					body = deOutline(body);
 				}
 
+				// Skip pages with no meaningful content after all transforms.
+				if (isBodyEmpty(inter.yaml, body)) {
+					ctx.reportSkipped(inter.outputPath, 'Empty page skipped');
+					ctx.reportProgress(index, intermediates.length);
+					continue;
+				}
+
 				const final = inter.yaml ? `${inter.yaml}\n\n${body}\n` : `${body}\n`;
 				await this.writeNote(inter.outputPath, final);
 				ctx.reportNoteSuccess(inter.outputPath);
@@ -472,23 +485,18 @@ export class LogseqImporter extends FormatImporter {
 		return (file as NodePickedFile).filepath ?? file.name;
 	}
 
-	private indexAliases(
-		raw: Record<string, string>,
-		canonical: string,
-		aliasMap: Map<string, string>,
-		ambiguous: Set<string>
-	): void {
-		const value = raw.alias ?? raw.aliases;
-		if (!value) return;
-		for (const item of value.split(',')) {
-			const name = item.trim().replace(/^\[\[(.*)\]\]$/, '$1').trim();
-			if (!name) continue;
-			const key = name.toLowerCase();
-			const existing = aliasMap.get(key);
-			if (existing !== undefined && existing !== canonical) ambiguous.add(key);
-			else aliasMap.set(key, canonical);
-		}
-	}
+/**
+ * Register all aliases (and the title, if present) for a page in the shared alias map.
+ * Delegates to the exported `indexPageAliases` from pipeline.ts.
+ */
+private indexAliases(
+	raw: Record<string, string>,
+	canonical: string,
+	aliasMap: Map<string, string>,
+	ambiguous: Set<string>
+): void {
+	indexPageAliases(raw, canonical, aliasMap, ambiguous);
+}
 
 	private applyLogseqOnly(body: string, name: string, ctx: ImportContext): string {
 		const { options } = this;

--- a/src/formats/logseq.ts
+++ b/src/formats/logseq.ts
@@ -254,6 +254,13 @@ export class LogseqImporter extends FormatImporter {
 				.setValue(this.options.removeOrphanBlockRefs)
 				.onChange(v => this.options.removeOrphanBlockRefs = v));
 
+		new Setting(this.modal.contentEl)
+			.setName('Always embed block references')
+			.setDesc('Convert bare ((uuid)) block references to embeds (![[Page#^id]]) instead of plain links ([[Page#^id]]). Block embeds ({{embed ((uuid))}}) are always converted to embeds regardless.')
+			.addToggle(t => t
+				.setValue(this.options.alwaysEmbedBlockRefs)
+				.onChange(v => this.options.alwaysEmbedBlockRefs = v));
+
 		// ── Properties ────────────────────────────────────────────────────────────
 
 		new Setting(this.modal.contentEl).setName('Properties').setHeading();

--- a/src/formats/logseq.ts
+++ b/src/formats/logseq.ts
@@ -11,6 +11,7 @@ import { resolveBlockRefs, BlockRefTarget } from './logseq/block-ids';
 import { rewriteAliasReferences } from './logseq/links';
 import { journalFilenameToISO } from './logseq/journals';
 import { namespaceToPath } from './logseq/paths';
+import { deOutline } from './logseq/de-outline';
 
 const ISO_FORMAT = 'YYYY-MM-DD';
 // Note directories under a Logseq graph root (relative paths).
@@ -92,6 +93,29 @@ export class LogseqImporter extends FormatImporter {
 				.onChange(v => this.options.taskFormat = v as TaskFormat));
 
 		new Setting(this.modal.contentEl)
+			.setName('Document structure')
+			.setDesc('How to handle Logseq\'s outline (everything-is-a-bullet) model.')
+			.addDropdown(d => d
+				.addOption('preserve', 'Preserve outline (bullets) — recommended')
+				.addOption('flatten', 'Flatten to paragraphs and headings (experimental)')
+				.setValue(this.options.outlineMode)
+				.onChange(v => {
+					this.options.outlineMode = v as 'preserve' | 'flatten';
+					flattenScopeSetting.settingEl.style.display = v === 'flatten' ? '' : 'none';
+				}));
+
+		const flattenScopeSetting = new Setting(this.modal.contentEl)
+			.setName('Flatten scope')
+			.setDesc('Which note types to de-outline.')
+			.addDropdown(d => d
+				.addOption('pages', 'Pages only — keep journals as outlines')
+				.addOption('journals', 'Journals only')
+				.addOption('both', 'Pages and journals')
+				.setValue(this.options.flattenScope)
+				.onChange(v => this.options.flattenScope = v as 'pages' | 'journals' | 'both'));
+		flattenScopeSetting.settingEl.style.display = this.options.outlineMode === 'flatten' ? '' : 'none';
+
+		new Setting(this.modal.contentEl)
 			.setName('Journal folder')
 			.setDesc('Vault folder (relative to output) for imported journals/daily notes.')
 			.addText(t => t
@@ -145,7 +169,7 @@ export class LogseqImporter extends FormatImporter {
 				.onChange(v => this.options.keepAssetAltText = v));
 	}
 
-	private getDailyNotesConfig(): { format: string; folder: string } {
+	private getDailyNotesConfig(): { format: string, folder: string } {
 		try {
 			// @ts-expect-error : internalPlugins is not in the public API
 			const instance = this.app.internalPlugins.getPluginById('daily-notes')?.instance;
@@ -250,6 +274,17 @@ export class LogseqImporter extends FormatImporter {
 				if (options.journalDateFormat !== ISO_FORMAT) {
 					body = this.reformatIsoDateLinks(body, options.journalDateFormat);
 				}
+
+				// De-outline: flatten outline to paragraphs/headings when configured
+				if (options.outlineMode === 'flatten') {
+					const shouldFlatten = options.flattenScope === 'both'
+						|| (options.flattenScope === 'pages' && inter.kind === 'page')
+						|| (options.flattenScope === 'journals' && inter.kind === 'journal');
+					if (shouldFlatten) {
+						body = deOutline(body);
+					}
+				}
+
 				const final = inter.yaml ? `${inter.yaml}\n\n${body}\n` : `${body}\n`;
 				await this.writeNote(inter.outputPath, final);
 				ctx.reportNoteSuccess(inter.outputPath);

--- a/src/formats/logseq.ts
+++ b/src/formats/logseq.ts
@@ -406,7 +406,7 @@ export class LogseqImporter extends FormatImporter {
 			if (ctx.isCancelled()) return;
 			index++;
 			try {
-				let body = resolveBlockRefs(inter.body, blockIndex);
+				let body = resolveBlockRefs(inter.body, blockIndex, { alwaysEmbedBlockRefs: options.alwaysEmbedBlockRefs });
 
 				if (options.removeOrphanBlockRefs) {
 					body = removeOrphanBlockRefs(body);

--- a/src/formats/logseq.ts
+++ b/src/formats/logseq.ts
@@ -1,4 +1,4 @@
-import { moment, Notice, Platform, Setting, TFile } from 'obsidian';
+import { moment, Notice, Platform, Setting, TFile, TextComponent } from 'obsidian';
 import { FormatImporter } from '../format-importer';
 // Type-only: `main.ts` imports this file, so a value import here would be a
 // circular dependency and the imported binding would be undefined at init().
@@ -7,8 +7,8 @@ import { NodePickedFile, PickedFile, parseFilePath, fs, fsPromises, path, nodeBu
 import { sanitizeFileNameKeepPath } from './roam/utils';
 import { DEFAULT_LOGSEQ_OPTIONS, LogseqImportOptions, TaskFormat, KeepOrDrop } from './logseq/options';
 import { convertLocal } from './logseq/pipeline';
-import { resolveBlockRefs, BlockRefTarget } from './logseq/block-ids';
-import { rewriteAliasReferences } from './logseq/links';
+import { resolveBlockRefs, BlockRefTarget, removeOrphanBlockRefs } from './logseq/block-ids';
+import { rewriteAliasReferences, convertTags, disambiguateBasenameLinks, BasenameIndex } from './logseq/links';
 import { journalFilenameToISO } from './logseq/journals';
 import { namespaceToPath } from './logseq/paths';
 import { deOutline } from './logseq/de-outline';
@@ -80,11 +80,13 @@ export class LogseqImporter extends FormatImporter {
 
 		this.addOutputLocationSetting('Logseq');
 
-		new Setting(this.modal.contentEl).setName('Conversion').setHeading();
+		// ── Tasks ────────────────────────────────────────────────────────────────
+
+		new Setting(this.modal.contentEl).setName('Tasks').setHeading();
 
 		new Setting(this.modal.contentEl)
 			.setName('Task format')
-			.setDesc('How rich Logseq tasks (TODO/DOING/SCHEDULED/priority...) are written in Obsidian.')
+			.setDesc('How rich Logseq tasks (TODO/DOING/SCHEDULED/priority…) are written in Obsidian.')
 			.addDropdown(d => d
 				.addOption('tasks-emoji', 'Tasks plugin — emoji')
 				.addOption('tasks-dataview', 'Tasks plugin — Dataview fields')
@@ -92,67 +94,82 @@ export class LogseqImporter extends FormatImporter {
 				.setValue(this.options.taskFormat)
 				.onChange(v => this.options.taskFormat = v as TaskFormat));
 
-		new Setting(this.modal.contentEl)
-			.setName('Document structure')
-			.setDesc('How to handle Logseq\'s outline (everything-is-a-bullet) model.')
-			.addDropdown(d => d
-				.addOption('preserve', 'Preserve outline (bullets) — recommended')
-				.addOption('flatten', 'Flatten to paragraphs and headings (experimental)')
-				.setValue(this.options.outlineMode)
-				.onChange(v => {
-					this.options.outlineMode = v as 'preserve' | 'flatten';
-					flattenScopeSetting.settingEl.style.display = v === 'flatten' ? '' : 'none';
-				}));
+		// ── Journals ──────────────────────────────────────────────────────────────
 
-		const flattenScopeSetting = new Setting(this.modal.contentEl)
-			.setName('Flatten scope')
-			.setDesc('Which note types to de-outline.')
-			.addDropdown(d => d
-				.addOption('pages', 'Pages only — keep journals as outlines')
-				.addOption('journals', 'Journals only')
-				.addOption('both', 'Pages and journals')
-				.setValue(this.options.flattenScope)
-				.onChange(v => this.options.flattenScope = v as 'pages' | 'journals' | 'both'));
-		flattenScopeSetting.settingEl.style.display = this.options.outlineMode === 'flatten' ? '' : 'none';
+		new Setting(this.modal.contentEl).setName('Journals').setHeading();
+
+		const dn2 = this.getDailyNotesConfig();
+		const dnFolder = dn2.folder || 'Journals';
+		const dnFormat = dn2.format;
+
+		let journalFolderText: TextComponent;
+		let journalFormatText: TextComponent;
+
+		new Setting(this.modal.contentEl)
+			.setName('Use Daily Notes settings')
+			.setDesc(`Migrate journals directly into your Daily Notes folder (${dnFolder}) using the configured date format (${dnFormat}).`)
+			.addToggle(t => t
+				.setValue(this.options.useDailyNotes)
+				.onChange(v => {
+					this.options.useDailyNotes = v;
+					journalFolderText.setDisabled(v);
+					journalFormatText.setDisabled(v);
+					if (v) {
+						this.options.journalFolder = dnFolder;
+						this.options.journalDateFormat = dnFormat;
+						journalFolderText.setValue(dnFolder);
+						journalFormatText.setValue(dnFormat);
+					}
+				}));
 
 		new Setting(this.modal.contentEl)
 			.setName('Journal folder')
-			.setDesc('Vault folder (relative to output) for imported journals/daily notes.')
-			.addText(t => t
-				.setValue(this.options.journalFolder)
-				.onChange(v => this.options.journalFolder = v));
+			.setDesc('Vault folder (relative to output) for imported journals.')
+			.addText(t => {
+				journalFolderText = t;
+				t.setValue(this.options.journalFolder)
+					.setDisabled(this.options.useDailyNotes)
+					.onChange(v => this.options.journalFolder = v);
+			});
 
 		new Setting(this.modal.contentEl)
 			.setName('Journal date format')
 			.setDesc('moment.js format for daily-note filenames. Prefilled from your Daily Notes settings.')
-			.addText(t => t
-				.setValue(this.options.journalDateFormat)
-				.onChange(v => this.options.journalDateFormat = v || ISO_FORMAT));
+			.addText(t => {
+				journalFormatText = t;
+				t.setValue(this.options.journalDateFormat)
+					.setDisabled(this.options.useDailyNotes)
+					.onChange(v => this.options.journalDateFormat = v || ISO_FORMAT);
+			});
 
 		new Setting(this.modal.contentEl)
-			.setName('Time tracking (LOGBOOK)')
-			.setDesc('Logseq LOGBOOK/CLOCK entries have no Obsidian equivalent in this format.')
-			.addDropdown(d => d
-				.addOption('drop', 'Drop')
-				.addOption('keep', 'Keep verbatim')
-				.setValue(this.options.logbook)
-				.onChange(v => this.options.logbook = v as KeepOrDrop));
-
-		new Setting(this.modal.contentEl)
-			.setName('Logseq-only content')
-			.setDesc('Queries, flashcards and macros that do not translate to Obsidian.')
-			.addDropdown(d => d
-				.addOption('keep', 'Keep verbatim')
-				.addOption('drop', 'Drop')
-				.setValue(this.options.logseqOnlyContent)
-				.onChange(v => this.options.logseqOnlyContent = v as KeepOrDrop));
-
-		new Setting(this.modal.contentEl)
-			.setName('Shorten block IDs')
-			.setDesc('Convert Logseq UUID block ids to short Obsidian-style anchors.')
+			.setName('De-outline journals')
+			.setDesc('Flatten journal outlines to paragraphs and headings (experimental).')
 			.addToggle(t => t
-				.setValue(this.options.shortenBlockIds)
-				.onChange(v => this.options.shortenBlockIds = v));
+				.setValue(this.options.deOutlineJournals)
+				.onChange(v => this.options.deOutlineJournals = v));
+
+		// ── Pages ─────────────────────────────────────────────────────────────────
+
+		new Setting(this.modal.contentEl).setName('Pages').setHeading();
+
+		new Setting(this.modal.contentEl)
+			.setName('Pages folder')
+			.setDesc('Vault folder (relative to output) for imported pages. Leave empty to place pages in the output root.')
+			.addText(t => t
+				.setValue(this.options.pagesFolder)
+				.onChange(v => this.options.pagesFolder = v));
+
+		new Setting(this.modal.contentEl)
+			.setName('De-outline pages')
+			.setDesc('Flatten page outlines to paragraphs and headings (experimental).')
+			.addToggle(t => t
+				.setValue(this.options.deOutlinePages)
+				.onChange(v => this.options.deOutlinePages = v));
+
+		// ── Links & tags ──────────────────────────────────────────────────────────
+
+		new Setting(this.modal.contentEl).setName('Links & tags').setHeading();
 
 		new Setting(this.modal.contentEl)
 			.setName('Convert tags to links')
@@ -162,11 +179,102 @@ export class LogseqImporter extends FormatImporter {
 				.onChange(v => this.options.convertTagsToLinks = v));
 
 		new Setting(this.modal.contentEl)
+			.setName('Only convert tags with a matching page')
+			.setDesc('When converting tags to links, keep tags as #tags if no corresponding page exists in the graph.')
+			.addToggle(t => t
+				.setValue(this.options.convertTagsOnlyExistingPages)
+				.onChange(v => this.options.convertTagsOnlyExistingPages = v));
+
+		new Setting(this.modal.contentEl)
+			.setName('Drop tags')
+			.setDesc('Comma-separated list of tags to remove entirely (e.g. "card, public").')
+			.addText(t => t
+				.setValue(this.options.dropTags.join(', '))
+				.onChange(v => {
+					this.options.dropTags = v.split(',').map(s => s.trim()).filter(s => s.length > 0);
+				}));
+
+		// ── Logseq-only content ───────────────────────────────────────────────────
+
+		new Setting(this.modal.contentEl).setName('Logseq-only content').setHeading();
+
+		new Setting(this.modal.contentEl)
+			.setName('Queries')
+			.setDesc('{{query}} and #+BEGIN_QUERY blocks have no Obsidian equivalent.')
+			.addDropdown(d => d
+				.addOption('keep', 'Keep verbatim')
+				.addOption('drop', 'Drop')
+				.setValue(this.options.queries)
+				.onChange(v => this.options.queries = v as KeepOrDrop));
+
+		new Setting(this.modal.contentEl)
+			.setName('Flashcards')
+			.setDesc('#card markers and {{cloze}} wrappers.')
+			.addDropdown(d => d
+				.addOption('keep', 'Keep verbatim')
+				.addOption('drop', 'Drop (unwrap cloze to plain text)')
+				.setValue(this.options.flashcards)
+				.onChange(v => this.options.flashcards = v as KeepOrDrop));
+
+		new Setting(this.modal.contentEl)
+			.setName('Time tracking (LOGBOOK)')
+			.setDesc('Logseq LOGBOOK/CLOCK entries have no Obsidian equivalent.')
+			.addDropdown(d => d
+				.addOption('drop', 'Drop')
+				.addOption('keep', 'Keep verbatim')
+				.setValue(this.options.logbook)
+				.onChange(v => this.options.logbook = v as KeepOrDrop));
+
+		// ── Assets ────────────────────────────────────────────────────────────────
+
+		new Setting(this.modal.contentEl).setName('Assets').setHeading();
+
+		new Setting(this.modal.contentEl)
 			.setName('Keep image alt text')
 			.setDesc('Preserve image alt text as the embed display text.')
 			.addToggle(t => t
 				.setValue(this.options.keepAssetAltText)
 				.onChange(v => this.options.keepAssetAltText = v));
+
+		// ── Block references ──────────────────────────────────────────────────────
+
+		new Setting(this.modal.contentEl).setName('Block references').setHeading();
+
+		new Setting(this.modal.contentEl)
+			.setName('Shorten block IDs')
+			.setDesc('Convert Logseq UUID block IDs to short Obsidian-style anchors.')
+			.addToggle(t => t
+				.setValue(this.options.shortenBlockIds)
+				.onChange(v => this.options.shortenBlockIds = v));
+
+		new Setting(this.modal.contentEl)
+			.setName('Remove orphan block references')
+			.setDesc('Remove ((uuid)) references that could not be resolved to a known block in the graph.')
+			.addToggle(t => t
+				.setValue(this.options.removeOrphanBlockRefs)
+				.onChange(v => this.options.removeOrphanBlockRefs = v));
+
+		// ── Properties ────────────────────────────────────────────────────────────
+
+		new Setting(this.modal.contentEl).setName('Properties').setHeading();
+
+		new Setting(this.modal.contentEl)
+			.setName('Drop page properties')
+			.setDesc('Comma-separated list of page-level property keys to exclude from frontmatter (e.g. "public, exclude-from-graph-view").')
+			.addText(t => t
+				.setValue(this.options.dropPageProperties.join(', '))
+				.onChange(v => {
+					this.options.dropPageProperties = v.split(',').map(s => s.trim()).filter(s => s.length > 0);
+				}));
+
+		new Setting(this.modal.contentEl)
+			.setName('Drop block properties')
+			.setDesc('Comma-separated list of additional inline block property keys to strip (Logseq-internal keys like collapsed, background-color are always stripped).')
+			.addText(t => t
+				.setValue(this.options.dropBlockProperties.join(', '))
+				.onChange(v => {
+					this.options.dropBlockProperties = v.split(',').map(s => s.trim()).filter(s => s.length > 0);
+				}));
 	}
 
 	private getDailyNotesConfig(): { format: string, folder: string } {
@@ -214,7 +322,13 @@ export class LogseqImporter extends FormatImporter {
 			? `${outputFolder.path}/${options.journalFolder.trim()}`
 			: outputFolder.path;
 
+		const pagesDir = options.pagesFolder.trim()
+			? `${outputFolder.path}/${options.pagesFolder.trim()}`
+			: outputFolder.path;
+
 		// Plan output paths from pages/ and journals/ only.
+		// Use a Set to detect output-path collisions (two sources → same path).
+		const claimedPaths = new Set<string>();
 		const plans: PagePlan[] = [];
 		for (const file of notes) {
 			const rel = relPathFromGraph(this.graphRoot, this.absPath(file));
@@ -222,13 +336,34 @@ export class LogseqImporter extends FormatImporter {
 				ctx.reportSkipped(file.name, 'Whiteboards are not supported');
 				continue;
 			}
-			plans.push(this.planFor(file, rel, outputFolder.path, journalDir));
+			const plan = this.planFor(file, rel, pagesDir, journalDir);
+			if (claimedPaths.has(plan.outputPath)) {
+				ctx.reportSkipped(file.name, `Output path collision: ${plan.outputPath} already claimed by another note`);
+				continue;
+			}
+			claimedPaths.add(plan.outputPath);
+			plans.push(plan);
 		}
 
 		if (plans.length === 0) {
 			new Notice('No Logseq pages or journals found in the selected folder.');
 			return;
 		}
+
+		// Build basename disambiguation index: basename (lower-cased) -> [fullPath, ...]
+		// A "basename" here is the last path component of the canonical name without .md.
+		const basenameMap = new Map<string, string[]>();
+		for (const plan of plans) {
+			const name = plan.canonicalName;
+			const base = name.includes('/') ? name.slice(name.lastIndexOf('/') + 1).toLowerCase() : name.toLowerCase();
+			const existing = basenameMap.get(base);
+			if (existing) existing.push(name);
+			else basenameMap.set(base, [name]);
+		}
+		const basenameIndex: BasenameIndex = { basenameMap };
+
+		// Build vault-wide page set for tag→link page-existence check (lower-cased).
+		const knownPages = new Set(plans.map(p => p.canonicalName.toLowerCase()));
 
 		// PASS 1: per-file local conversion + index building.
 		const intermediates: Intermediate[] = [];
@@ -263,6 +398,8 @@ export class LogseqImporter extends FormatImporter {
 
 		for (const alias of ambiguousAliases) aliasMap.delete(alias);
 
+		const dropTags = new Set(options.dropTags);
+
 		// PASS 2: cross-file resolution + write.
 		let index = 0;
 		for (const inter of intermediates) {
@@ -270,19 +407,30 @@ export class LogseqImporter extends FormatImporter {
 			index++;
 			try {
 				let body = resolveBlockRefs(inter.body, blockIndex);
+
+				if (options.removeOrphanBlockRefs) {
+					body = removeOrphanBlockRefs(body);
+				}
+
 				body = rewriteAliasReferences(body, { aliasMap });
+				body = disambiguateBasenameLinks(body, basenameIndex);
+
+				// Tag conversion deferred to pass-2 so we have the full knownPages set.
+				body = convertTags(body, {
+					toLinks: options.convertTagsToLinks,
+					onlyExistingPages: options.convertTagsOnlyExistingPages,
+					knownPages,
+					dropTags,
+				});
+
 				if (options.journalDateFormat !== ISO_FORMAT) {
 					body = this.reformatIsoDateLinks(body, options.journalDateFormat);
 				}
 
 				// De-outline: flatten outline to paragraphs/headings when configured
-				if (options.outlineMode === 'flatten') {
-					const shouldFlatten = options.flattenScope === 'both'
-						|| (options.flattenScope === 'pages' && inter.kind === 'page')
-						|| (options.flattenScope === 'journals' && inter.kind === 'journal');
-					if (shouldFlatten) {
-						body = deOutline(body);
-					}
+				const shouldDeOutline = inter.kind === 'journal' ? options.deOutlineJournals : options.deOutlinePages;
+				if (shouldDeOutline) {
+					body = deOutline(body);
 				}
 
 				const final = inter.yaml ? `${inter.yaml}\n\n${body}\n` : `${body}\n`;
@@ -298,7 +446,7 @@ export class LogseqImporter extends FormatImporter {
 		await this.copyAssets(assetPlan, outputFolder.path, ctx);
 	}
 
-	private planFor(file: PickedFile, relPath: string, outputBase: string, journalDir: string): PagePlan {
+	private planFor(file: PickedFile, relPath: string, pagesDir: string, journalDir: string): PagePlan {
 		const sourceDir = path ? parseFilePath(this.absPath(file)).parent : '';
 		const isJournal = relPath.startsWith('journals/');
 
@@ -310,7 +458,7 @@ export class LogseqImporter extends FormatImporter {
 		}
 
 		const rel = sanitizeFileNameKeepPath(namespaceToPath(file.basename));
-		return { file, kind: 'page', canonicalName: rel, outputPath: `${outputBase}/${rel}.md`, sourceDir };
+		return { file, kind: 'page', canonicalName: rel, outputPath: `${pagesDir}/${rel}.md`, sourceDir };
 	}
 
 	private absPath(file: PickedFile): string {
@@ -336,17 +484,32 @@ export class LogseqImporter extends FormatImporter {
 	}
 
 	private applyLogseqOnly(body: string, name: string, ctx: ImportContext): string {
+		const { options } = this;
+
+		// Queries
 		const hasQuery = /\{\{query|#\+BEGIN_QUERY/i.test(body);
-		const hasCard = /#card\b|\{\{cloze/i.test(body);
-		if (this.options.logseqOnlyContent === 'keep') {
-			if (hasQuery || hasCard) ctx.reportSkipped(name, 'Logseq-only content kept verbatim');
-			return body;
+		if (hasQuery) {
+			if (options.queries === 'keep') {
+				ctx.reportSkipped(name, 'Logseq queries kept verbatim');
+			}
+			else {
+				body = body.replace(/^[ \t]*#\+BEGIN_QUERY[\s\S]*?#\+END_QUERY[ \t]*$/gim, '');
+				body = body.replace(/\{\{query[\s\S]*?\}\}/gi, '');
+			}
 		}
-		// drop, cleanly
-		body = body.replace(/^[ \t]*#\+BEGIN_QUERY[\s\S]*?#\+END_QUERY[ \t]*$/gim, '');
-		body = body.replace(/\{\{query[\s\S]*?\}\}/gi, '');
-		body = body.replace(/\{\{cloze\s+([\s\S]*?)\}\}/gi, '$1');
-		body = body.replace(/(^|\s)#card\b/gi, '$1');
+
+		// Flashcards
+		const hasCard = /#card\b|\{\{cloze/i.test(body);
+		if (hasCard) {
+			if (options.flashcards === 'keep') {
+				ctx.reportSkipped(name, 'Logseq flashcard content kept verbatim');
+			}
+			else {
+				body = body.replace(/\{\{cloze\s+([\s\S]*?)\}\}/gi, '$1');
+				body = body.replace(/(^|\s)#card\b/gi, '$1');
+			}
+		}
+
 		return body;
 	}
 

--- a/src/formats/logseq/assets.ts
+++ b/src/formats/logseq/assets.ts
@@ -1,0 +1,76 @@
+// Converts Logseq's relative markdown asset links (`![alt](../assets/x.png)`)
+// into Obsidian wiki-embeds (`![[x.png]]`). Pure functions only — no filesystem
+// access, no 'obsidian' import — so it can be unit-tested in isolation.
+
+export interface AssetRef {
+	/** The path exactly as written in the original link, e.g. `../assets/image.png`. */
+	sourcePath: string;
+	/** The basename of the asset, e.g. `image.png`. */
+	filename: string;
+}
+
+// `![alt](path)` optionally followed by a Logseq dimension suffix `{: ... }`.
+const assetLinkRegex = /!\[([^\]]*)\]\(([^)]+)\)(\{:[^}]*\})?/g;
+// Triple-backtick fenced code blocks, which must be left untouched.
+const fencedCodeRegex = /```[\s\S]*?```/g;
+
+function isUrl(path: string): boolean {
+	return /^(https?:|data:)/i.test(path.trim());
+}
+
+function basename(path: string): string {
+	const parts = path.split('/');
+	return parts[parts.length - 1];
+}
+
+/** Builds the Obsidian `|size` display from a Logseq `{:height H, :width W}` suffix. */
+function dimensionDisplay(suffix: string | undefined): string | null {
+	if (!suffix) return null;
+	const width = suffix.match(/:width\s+(\d+)/)?.[1];
+	const height = suffix.match(/:height\s+(\d+)/)?.[1];
+	if (width && height) return `${width}x${height}`;
+	if (width) return width;
+	if (height) return height;
+	return null;
+}
+
+export function convertAssetLinks(
+	content: string,
+	options: { keepAltText: boolean }
+): { content: string; assets: AssetRef[] } {
+	const assets: AssetRef[] = [];
+	const seen = new Set<string>();
+
+	function transformSegment(segment: string): string {
+		return segment.replace(assetLinkRegex, (match, alt: string, path: string, dimSuffix?: string) => {
+			if (isUrl(path) || !path.includes('assets/')) return match;
+
+			const filename = basename(path);
+			if (!seen.has(path)) {
+				seen.add(path);
+				assets.push({ sourcePath: path, filename });
+			}
+
+			const dims = dimensionDisplay(dimSuffix);
+			let display: string | null = dims;
+			if (display === null && options.keepAltText && alt.trim().length > 0) {
+				display = alt;
+			}
+
+			return display !== null ? `![[${filename}|${display}]]` : `![[${filename}]]`;
+		});
+	}
+
+	let result = '';
+	let lastIndex = 0;
+	let fence: RegExpExecArray | null;
+	fencedCodeRegex.lastIndex = 0;
+	while ((fence = fencedCodeRegex.exec(content)) !== null) {
+		result += transformSegment(content.slice(lastIndex, fence.index));
+		result += fence[0];
+		lastIndex = fence.index + fence[0].length;
+	}
+	result += transformSegment(content.slice(lastIndex));
+
+	return { content: result, assets };
+}

--- a/src/formats/logseq/assets.ts
+++ b/src/formats/logseq/assets.ts
@@ -37,7 +37,7 @@ function dimensionDisplay(suffix: string | undefined): string | null {
 export function convertAssetLinks(
 	content: string,
 	options: { keepAltText: boolean }
-): { content: string; assets: AssetRef[] } {
+): { content: string, assets: AssetRef[] } {
 	const assets: AssetRef[] = [];
 	const seen = new Set<string>();
 

--- a/src/formats/logseq/assets.ts
+++ b/src/formats/logseq/assets.ts
@@ -9,10 +9,14 @@ export interface AssetRef {
 	filename: string;
 }
 
-// `![alt](path)` optionally followed by a Logseq dimension suffix `{: ... }`.
-const assetLinkRegex = /!\[([^\]]*)\]\(([^)]+)\)(\{:[^}]*\})?/g;
+// `[alt](path)` or `![alt](path)` optionally followed by `{: ... }`.
+// H1: path allows balanced parens (e.g. filename with `(...)`).
+// H2: leading `!` is optional so plain links are also converted.
+const assetLinkRegex = /(!?)\[([^\]]*)\]\(([^()]*(?:\([^()]*\)[^()]*)*)\)(\{:[^}]*\})?/g;
 // Triple-backtick fenced code blocks, which must be left untouched.
 const fencedCodeRegex = /```[\s\S]*?```/g;
+// Inline-code spans that must not be rewritten (M1).
+const inlineCodeRe = /`[^`]*`/g;
 
 function isUrl(path: string): boolean {
 	return /^(https?:|data:)/i.test(path.trim());
@@ -42,7 +46,23 @@ export function convertAssetLinks(
 	const seen = new Set<string>();
 
 	function transformSegment(segment: string): string {
-		return segment.replace(assetLinkRegex, (match, alt: string, path: string, dimSuffix?: string) => {
+		// M1: protect inline-code spans — only rewrite content outside them.
+		let result = '';
+		let last = 0;
+		let icm: RegExpExecArray | null;
+		inlineCodeRe.lastIndex = 0;
+		while ((icm = inlineCodeRe.exec(segment)) !== null) {
+			result += rewriteAssets(segment.slice(last, icm.index));
+			result += icm[0];
+			last = icm.index + icm[0].length;
+		}
+		result += rewriteAssets(segment.slice(last));
+		return result;
+	}
+
+	function rewriteAssets(text: string): string {
+		assetLinkRegex.lastIndex = 0;
+		return text.replace(assetLinkRegex, (match, bang: string, alt: string, path: string, dimSuffix?: string) => {
 			if (isUrl(path) || !path.includes('assets/')) return match;
 
 			const filename = basename(path);
@@ -57,7 +77,8 @@ export function convertAssetLinks(
 				display = alt;
 			}
 
-			return display !== null ? `![[${filename}|${display}]]` : `![[${filename}]]`;
+			const embed = bang === '!' ? '!' : '';
+			return display !== null ? `${embed}[[${filename}|${display}]]` : `${embed}[[${filename}]]`;
 		});
 	}
 

--- a/src/formats/logseq/assets.ts
+++ b/src/formats/logseq/assets.ts
@@ -12,7 +12,8 @@ export interface AssetRef {
 // `[alt](path)` or `![alt](path)` optionally followed by `{: ... }`.
 // H1: path allows balanced parens (e.g. filename with `(...)`).
 // H2: leading `!` is optional so plain links are also converted.
-const assetLinkRegex = /(!?)\[([^\]]*)\]\(([^()]*(?:\([^()]*\)[^()]*)*)\)(\{:[^}]*\})?/g;
+// H2b: label allows one level of nested brackets (e.g. `[Fw_ [Nested] _ desc]`).
+const assetLinkRegex = /(!?)\[([^\[\]]*(?:\[[^\]]*\][^\[\]]*)*)\]\(([^()]*(?:\([^()]*\)[^()]*)*)\)(\{:[^}]*\})?/g;
 // Triple-backtick fenced code blocks, which must be left untouched.
 const fencedCodeRegex = /```[\s\S]*?```/g;
 // Inline-code spans that must not be rewritten (M1).

--- a/src/formats/logseq/assets.ts
+++ b/src/formats/logseq/assets.ts
@@ -10,13 +10,13 @@ export interface AssetRef {
 }
 
 // `[alt](path)` or `![alt](path)` optionally followed by `{: ... }`.
-// H1: path allows balanced parens (e.g. filename with `(...)`).
-// H2: leading `!` is optional so plain links are also converted.
-// H2b: label allows one level of nested brackets (e.g. `[Fw_ [Nested] _ desc]`).
+// K1: path allows balanced parens (e.g. filename with `(...)`).
+// K1: leading `!` is optional so plain links are also converted.
+// K1: label allows one level of nested brackets (e.g. `[Fw_ [Nested] _ desc]`).
 const assetLinkRegex = /(!?)\[([^\[\]]*(?:\[[^\]]*\][^\[\]]*)*)\]\(([^()]*(?:\([^()]*\)[^()]*)*)\)(\{:[^}]*\})?/g;
 // Triple-backtick fenced code blocks, which must be left untouched.
 const fencedCodeRegex = /```[\s\S]*?```/g;
-// Inline-code spans that must not be rewritten (M1).
+// Inline-code spans that must not be rewritten.
 const inlineCodeRe = /`[^`]*`/g;
 
 function isUrl(path: string): boolean {
@@ -47,7 +47,7 @@ export function convertAssetLinks(
 	const seen = new Set<string>();
 
 	function transformSegment(segment: string): string {
-		// M1: protect inline-code spans — only rewrite content outside them.
+		// K1: protect inline-code spans — only rewrite content outside them.
 		let result = '';
 		let last = 0;
 		let icm: RegExpExecArray | null;

--- a/src/formats/logseq/block-ids.ts
+++ b/src/formats/logseq/block-ids.ts
@@ -47,15 +47,31 @@ export function attachBlockIds(content: string, shorten: boolean): { content: st
 		const m = line.match(ID_LINE);
 		if (m && lastContentIndex >= 0) {
 			const uuid = m[2];
+			const indent = m[1];
 			const shortId = makeUnique(shorten ? shortenId(uuid) : uuid);
 			ids.push({ uuid, shortId });
-			if (!new RegExp(`\\^${shortId}\\s*$`).test(out[lastContentIndex])) {
-				out[lastContentIndex] = out[lastContentIndex].replace(/\s*$/, '') + ` ^${shortId}`;
+			const target = out[lastContentIndex];
+			if (!new RegExp(`\\^${shortId}\\s*$`).test(target)) {
+				// BR-2: anchor after a closing fence (appending breaks CommonMark)
+				if (/^[ \t]*```[ \t]*$/.test(target)) {
+					out.push(indent + `^${shortId}`);
+					lastContentIndex = out.length - 1;
+				}
+				// BR-3: anchor on its own line below a heading
+				else if (/^#{1,6} /.test(target.trimStart())) {
+					out.push('');
+					out.push(`^${shortId}`);
+					lastContentIndex = out.length - 1;
+				}
+				else {
+					out[lastContentIndex] = target.replace(/\s*$/, '') + ` ^${shortId}`;
+				}
 			}
 			continue; // drop the id:: line
 		}
-		// Track the nearest preceding content line (non-blank, not a property).
-		if (line.trim() !== '' && !/^\s*[A-Za-z0-9_.\-]+:: /.test(line)) {
+		// BR-4: track the nearest preceding non-blank line as anchor target
+		// (including retained property lines).
+		if (line.trim() !== '') {
 			lastContentIndex = out.length;
 		}
 		out.push(line);
@@ -65,19 +81,48 @@ export function attachBlockIds(content: string, shorten: boolean): { content: st
 }
 
 export function resolveBlockRefs(content: string, index: Map<string, BlockRefTarget>): string {
+	// BR-1: process line-by-line, skipping fenced code blocks and inline-code spans.
+	const lines = content.split('\n');
+	let inFence = false;
+	const resolved = lines.map(line => {
+		if (/^\s*```/.test(line)) {
+			inFence = !inFence;
+			return line;
+		}
+		if (inFence) return line;
+		// Protect inline-code spans within the line.
+		return resolveOutsideInlineCode(line, index);
+	});
+	return resolved.join('\n');
+}
+
+function resolveOutsideInlineCode(line: string, index: Map<string, BlockRefTarget>): string {
+	const inlineRe = /`[^`]*`/g;
+	let result = '';
+	let last = 0;
+	let m: RegExpExecArray | null;
+	while ((m = inlineRe.exec(line)) !== null) {
+		result += resolveSegment(line.slice(last, m.index), index);
+		result += m[0];
+		last = m.index + m[0].length;
+	}
+	return result + resolveSegment(line.slice(last), index);
+}
+
+function resolveSegment(text: string, index: Map<string, BlockRefTarget>): string {
 	// Block embeds: {{embed ((uuid))}} -> ![[Page#^shortId]]
-	content = content.replace(/\{\{embed\s+\(\(([^()]+?)\)\)\}\}/g, (whole, uuid) => {
+	text = text.replace(/\{\{embed\s+\(\(([^()]+?)\)\)\}\}/g, (whole, uuid) => {
 		const target = index.get(uuid.trim());
 		return target ? `![[${target.page}#^${target.shortId}]]` : whole;
 	});
 	// Page embeds: {{embed [[Page]]}} -> ![[Page]]
-	content = content.replace(/\{\{embed\s+\[\[([^\]]+?)\]\]\}\}/g, (_, page) => `![[${page}]]`);
+	text = text.replace(/\{\{embed\s+\[\[([^\]]+?)\]\]\}\}/g, (_, page) => `![[${page}]]`);
 	// Bare block references: ((uuid)) -> [[Page#^shortId]]
-	content = content.replace(/\(\(([^()]+?)\)\)/g, (whole, uuid) => {
+	text = text.replace(/\(\(([^()]+?)\)\)/g, (whole, uuid) => {
 		const target = index.get(uuid.trim());
 		return target ? `[[${target.page}#^${target.shortId}]]` : whole;
 	});
-	return content;
+	return text;
 }
 
 /**

--- a/src/formats/logseq/block-ids.ts
+++ b/src/formats/logseq/block-ids.ts
@@ -52,12 +52,12 @@ export function attachBlockIds(content: string, shorten: boolean): { content: st
 			ids.push({ uuid, shortId });
 			const target = out[lastContentIndex];
 			if (!new RegExp(`\\^${shortId}\\s*$`).test(target)) {
-				// BR-2: anchor after a closing fence (appending breaks CommonMark)
+				// G1: anchor after a closing fence (appending breaks CommonMark)
 				if (/^[ \t]*```[ \t]*$/.test(target)) {
 					out.push(indent + `^${shortId}`);
 					lastContentIndex = out.length - 1;
 				}
-				// BR-3: anchor on its own line below a heading. Strip optional bullet
+				// G1: anchor on its own line below a heading. Strip optional bullet
 				// prefix before testing for heading syntax (Logseq headings are bullets).
 				else if (/^#{1,6} /.test(target.trimStart().replace(/^-\s+/, ''))) {
 					const isBulletHeading = /^\s*-\s+#{1,6} /.test(target);
@@ -76,7 +76,7 @@ export function attachBlockIds(content: string, shorten: boolean): { content: st
 			}
 			continue; // drop the id:: line
 		}
-		// BR-4: track the nearest preceding non-blank line as anchor target
+		// G1: track the nearest preceding non-blank line as anchor target
 		// (including retained property lines).
 		if (line.trim() !== '') {
 			lastContentIndex = out.length;

--- a/src/formats/logseq/block-ids.ts
+++ b/src/formats/logseq/block-ids.ts
@@ -24,7 +24,7 @@ export function shortenId(uuid: string): string {
 	return base.length > 0 ? base : 'ref';
 }
 
-export function attachBlockIds(content: string, shorten: boolean): { content: string; ids: DefinedId[] } {
+export function attachBlockIds(content: string, shorten: boolean): { content: string, ids: DefinedId[] } {
 	const lines = content.split('\n');
 	const out: string[] = [];
 	const ids: DefinedId[] = [];

--- a/src/formats/logseq/block-ids.ts
+++ b/src/formats/logseq/block-ids.ts
@@ -87,29 +87,34 @@ export function attachBlockIds(content: string, shorten: boolean): { content: st
 	return { content: out.join('\n'), ids };
 }
 
-export function resolveBlockRefs(content: string, index: Map<string, BlockRefTarget>): string {
+export function resolveBlockRefs(
+	content: string,
+	index: Map<string, BlockRefTarget>,
+	opts: { alwaysEmbedBlockRefs?: boolean } = {},
+): string {
 	// Logseq ref/embed syntax ({{embed ((uuid))}}, ((uuid))) is unambiguous enough
 	// that we convert even inside code fences — the resolved Obsidian syntax is more
 	// useful than stale UUIDs (e.g. in copy-pasteable examples). The only guard is
 	// that the UUID must exist in the index, which resolveSegment already enforces.
 	// Inline-code spans within a line are still protected.
-	return content.split('\n').map(line => resolveOutsideInlineCode(line, index)).join('\n');
+	const alwaysEmbed = opts.alwaysEmbedBlockRefs ?? false;
+	return content.split('\n').map(line => resolveOutsideInlineCode(line, index, alwaysEmbed)).join('\n');
 }
 
-function resolveOutsideInlineCode(line: string, index: Map<string, BlockRefTarget>): string {
+function resolveOutsideInlineCode(line: string, index: Map<string, BlockRefTarget>, alwaysEmbed: boolean): string {
 	const inlineRe = /`[^`]*`/g;
 	let result = '';
 	let last = 0;
 	let m: RegExpExecArray | null;
 	while ((m = inlineRe.exec(line)) !== null) {
-		result += resolveSegment(line.slice(last, m.index), index);
+		result += resolveSegment(line.slice(last, m.index), index, alwaysEmbed);
 		result += m[0];
 		last = m.index + m[0].length;
 	}
-	return result + resolveSegment(line.slice(last), index);
+	return result + resolveSegment(line.slice(last), index, alwaysEmbed);
 }
 
-function resolveSegment(text: string, index: Map<string, BlockRefTarget>): string {
+function resolveSegment(text: string, index: Map<string, BlockRefTarget>, alwaysEmbed: boolean): string {
 	// Block embeds: {{embed ((uuid))}} -> ![[Page#^shortId]]
 	text = text.replace(/\{\{embed\s+\(\(([^()]+?)\)\)\}\}/g, (whole, uuid) => {
 		const target = index.get(uuid.trim());
@@ -117,10 +122,13 @@ function resolveSegment(text: string, index: Map<string, BlockRefTarget>): strin
 	});
 	// Page embeds: {{embed [[Page]]}} -> ![[Page]]
 	text = text.replace(/\{\{embed\s+\[\[([^\]]+?)\]\]\}\}/g, (_, page) => `![[${page}]]`);
-	// Bare block references: ((uuid)) -> [[Page#^shortId]]
+	// Bare block references: ((uuid)) -> [[Page#^shortId]] or ![[...]] when alwaysEmbed
 	text = text.replace(/\(\(([^()]+?)\)\)/g, (whole, uuid) => {
 		const target = index.get(uuid.trim());
-		return target ? `[[${target.page}#^${target.shortId}]]` : whole;
+		if (!target) return whole;
+		return alwaysEmbed
+			? `![[${target.page}#^${target.shortId}]]`
+			: `[[${target.page}#^${target.shortId}]]`;
 	});
 	return text;
 }

--- a/src/formats/logseq/block-ids.ts
+++ b/src/formats/logseq/block-ids.ts
@@ -1,0 +1,81 @@
+// Block identifiers and references.
+//
+// Logseq marks a block with `id:: <uuid>` and references it with `((uuid))`.
+// Obsidian uses a short `^anchor` on the block line and `[[Page#^anchor]]` to
+// reference it. We shorten the UUID to an idiomatic short anchor and keep a
+// uuid -> {page, shortId} index so references across files resolve.
+
+export interface DefinedId {
+	uuid: string;
+	shortId: string;
+}
+
+export interface BlockRefTarget {
+	page: string;
+	shortId: string;
+}
+
+// `id::` as an indented block property, or flattened onto its own bullet.
+const ID_LINE = /^(\s*)(?:- )?id:: ?([0-9a-fA-F-]{6,})\s*$/;
+
+/** Derive a short, Obsidian-legal anchor (letters/numbers/dashes) from a UUID. */
+export function shortenId(uuid: string): string {
+	const base = uuid.replace(/[^A-Za-z0-9]/g, '').slice(0, 6);
+	return base.length > 0 ? base : 'ref';
+}
+
+export function attachBlockIds(content: string, shorten: boolean): { content: string; ids: DefinedId[] } {
+	const lines = content.split('\n');
+	const out: string[] = [];
+	const ids: DefinedId[] = [];
+	const used = new Set<string>();
+	let lastContentIndex = -1;
+
+	const makeUnique = (candidate: string): string => {
+		if (!used.has(candidate)) {
+			used.add(candidate);
+			return candidate;
+		}
+		let i = 1;
+		while (used.has(`${candidate}-${i}`)) i++;
+		const result = `${candidate}-${i}`;
+		used.add(result);
+		return result;
+	};
+
+	for (const line of lines) {
+		const m = line.match(ID_LINE);
+		if (m && lastContentIndex >= 0) {
+			const uuid = m[2];
+			const shortId = makeUnique(shorten ? shortenId(uuid) : uuid);
+			ids.push({ uuid, shortId });
+			if (!new RegExp(`\\^${shortId}\\s*$`).test(out[lastContentIndex])) {
+				out[lastContentIndex] = out[lastContentIndex].replace(/\s*$/, '') + ` ^${shortId}`;
+			}
+			continue; // drop the id:: line
+		}
+		// Track the nearest preceding content line (non-blank, not a property).
+		if (line.trim() !== '' && !/^\s*[A-Za-z0-9_.\-]+:: /.test(line)) {
+			lastContentIndex = out.length;
+		}
+		out.push(line);
+	}
+
+	return { content: out.join('\n'), ids };
+}
+
+export function resolveBlockRefs(content: string, index: Map<string, BlockRefTarget>): string {
+	// Block embeds: {{embed ((uuid))}} -> ![[Page#^shortId]]
+	content = content.replace(/\{\{embed\s+\(\(([^()]+?)\)\)\}\}/g, (whole, uuid) => {
+		const target = index.get(uuid.trim());
+		return target ? `![[${target.page}#^${target.shortId}]]` : whole;
+	});
+	// Page embeds: {{embed [[Page]]}} -> ![[Page]]
+	content = content.replace(/\{\{embed\s+\[\[([^\]]+?)\]\]\}\}/g, (_, page) => `![[${page}]]`);
+	// Bare block references: ((uuid)) -> [[Page#^shortId]]
+	content = content.replace(/\(\(([^()]+?)\)\)/g, (whole, uuid) => {
+		const target = index.get(uuid.trim());
+		return target ? `[[${target.page}#^${target.shortId}]]` : whole;
+	});
+	return content;
+}

--- a/src/formats/logseq/block-ids.ts
+++ b/src/formats/logseq/block-ids.ts
@@ -79,3 +79,22 @@ export function resolveBlockRefs(content: string, index: Map<string, BlockRefTar
 	});
 	return content;
 }
+
+/**
+ * Remove block references and block embeds that could not be resolved (i.e. the uuid
+ * does not appear in the block index). Resolved references are already rewritten to
+ * `[[Page#^id]]` form by resolveBlockRefs, so by the time this runs only raw
+ * `((uuid))` / `{{embed ((uuid))}}` patterns remain as orphans.
+ */
+export function removeOrphanBlockRefs(content: string): string {
+	// Orphan block embeds
+	content = content.replace(/\{\{embed\s+\(\([^()]+?\)\)\}\}/g, '');
+	// Orphan bare block references
+	content = content.replace(/\(\([^()]+?\)\)/g, '');
+	// Clean up lines that became empty or whitespace-only due to removal
+	return content
+		.split('\n')
+		.map(line => (/^\s*[-*+]?\s*$/.test(line) ? '' : line))
+		.join('\n')
+		.replace(/\n{3,}/g, '\n\n');
+}

--- a/src/formats/logseq/block-ids.ts
+++ b/src/formats/logseq/block-ids.ts
@@ -57,10 +57,17 @@ export function attachBlockIds(content: string, shorten: boolean): { content: st
 					out.push(indent + `^${shortId}`);
 					lastContentIndex = out.length - 1;
 				}
-				// BR-3: anchor on its own line below a heading
-				else if (/^#{1,6} /.test(target.trimStart())) {
-					out.push('');
-					out.push(`^${shortId}`);
+				// BR-3: anchor on its own line below a heading. Strip optional bullet
+				// prefix before testing for heading syntax (Logseq headings are bullets).
+				else if (/^#{1,6} /.test(target.trimStart().replace(/^-\s+/, ''))) {
+					const isBulletHeading = /^\s*-\s+#{1,6} /.test(target);
+					if (isBulletHeading) {
+						// Outline mode: indent anchor at content level (id:: line's indent).
+						out.push(indent + `^${shortId}`);
+					} else {
+						// Plain heading (rare): anchor directly below, no blank line.
+						out.push(`^${shortId}`);
+					}
 					lastContentIndex = out.length - 1;
 				}
 				else {
@@ -81,19 +88,12 @@ export function attachBlockIds(content: string, shorten: boolean): { content: st
 }
 
 export function resolveBlockRefs(content: string, index: Map<string, BlockRefTarget>): string {
-	// BR-1: process line-by-line, skipping fenced code blocks and inline-code spans.
-	const lines = content.split('\n');
-	let inFence = false;
-	const resolved = lines.map(line => {
-		if (/^\s*```/.test(line)) {
-			inFence = !inFence;
-			return line;
-		}
-		if (inFence) return line;
-		// Protect inline-code spans within the line.
-		return resolveOutsideInlineCode(line, index);
-	});
-	return resolved.join('\n');
+	// Logseq ref/embed syntax ({{embed ((uuid))}}, ((uuid))) is unambiguous enough
+	// that we convert even inside code fences — the resolved Obsidian syntax is more
+	// useful than stale UUIDs (e.g. in copy-pasteable examples). The only guard is
+	// that the UUID must exist in the index, which resolveSegment already enforces.
+	// Inline-code spans within a line are still protected.
+	return content.split('\n').map(line => resolveOutsideInlineCode(line, index)).join('\n');
 }
 
 function resolveOutsideInlineCode(line: string, index: Map<string, BlockRefTarget>): string {

--- a/src/formats/logseq/blocks.ts
+++ b/src/formats/logseq/blocks.ts
@@ -72,7 +72,8 @@ export function convertNumberedLists(content: string): string {
 			const count = (counters.get(indentLen) ?? 0) + 1;
 			counters.set(indentLen, count);
 			out.push(`${indent}${count}. ${item}`);
-		} else {
+		}
+		else {
 			counters.set(indentLen, 0); // non-numbered sibling resets the counter
 			out.push(line);
 		}

--- a/src/formats/logseq/blocks.ts
+++ b/src/formats/logseq/blocks.ts
@@ -1,0 +1,238 @@
+// Pure, side-effect-free text transforms for the Logseq -> Obsidian importer.
+// Each function takes the full multi-line file content and returns it transformed.
+
+const HIGHLIGHT_RE = /\^\^(.+?)\^\^/g;
+
+/** Replace Logseq highlights `^^text^^` with Obsidian `==text==`, skipping code. */
+export function convertHighlights(content: string): string {
+	const fenceRe = /^\s*```/;
+	let inFence = false;
+	return content
+		.split('\n')
+		.map(line => {
+			if (fenceRe.test(line)) {
+				inFence = !inFence;
+				return line;
+			}
+			if (inFence) return line;
+			return replaceHighlightsOutsideInlineCode(line);
+		})
+		.join('\n');
+}
+
+function replaceHighlightsOutsideInlineCode(line: string): string {
+	const inlineCodeRe = /`[^`]*`/g;
+	let result = '';
+	let last = 0;
+	let m: RegExpExecArray | null;
+	while ((m = inlineCodeRe.exec(line)) !== null) {
+		result += line.slice(last, m.index).replace(HIGHLIGHT_RE, '==$1==');
+		result += m[0];
+		last = inlineCodeRe.lastIndex;
+	}
+	result += line.slice(last).replace(HIGHLIGHT_RE, '==$1==');
+	return result;
+}
+
+/** Convert Logseq `logseq.order-list-type:: number` bullets into `1.`, `2.`, ... */
+export function convertNumberedLists(content: string): string {
+	const lines = content.split('\n');
+	const bulletRe = /^(\s*)-\s+(.*)$/;
+	const propRe = /^(\s*)logseq\.order-list-type::\s*number\s*$/;
+	const out: string[] = [];
+	const counters = new Map<number, number>();
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
+		if (propRe.test(line)) continue; // drop the hidden property line
+
+		const m = bulletRe.exec(line);
+		if (!m) {
+			out.push(line);
+			continue;
+		}
+
+		const indent = m[1];
+		const indentLen = indent.length;
+		const item = m[2];
+
+		// Moving to a (new) bullet at this level resets any deeper-level counters.
+		for (const level of Array.from(counters.keys())) {
+			if (level > indentLen) counters.delete(level);
+		}
+
+		const next = lines[i + 1];
+		const numbered =
+			next !== undefined && (() => {
+				const pm = propRe.exec(next);
+				return pm !== null && pm[1].length > indentLen;
+			})();
+
+		if (numbered) {
+			const count = (counters.get(indentLen) ?? 0) + 1;
+			counters.set(indentLen, count);
+			out.push(`${indent}${count}. ${item}`);
+		} else {
+			counters.set(indentLen, 0); // non-numbered sibling resets the counter
+			out.push(line);
+		}
+	}
+
+	return out.join('\n');
+}
+
+// Named Obsidian callouts. Other org types (CENTER/VERSE/PINNED, etc.) fall back to [!note].
+const CALLOUT_TYPES = new Set(['NOTE', 'TIP', 'WARNING', 'IMPORTANT', 'CAUTION', 'EXAMPLE']);
+
+/** Convert Logseq org-mode `#+BEGIN_*`/`#+END_*` blocks into Obsidian syntax. */
+export function convertOrgBlocks(content: string): string {
+	return processOrgLines(content.split('\n')).join('\n');
+}
+
+const BEGIN_RE = /^(\s*)#\+BEGIN_(\w+)/i;
+const END_RE = /^\s*#\+END_\w+/i;
+
+function processOrgLines(lines: string[]): string[] {
+	const out: string[] = [];
+	let i = 0;
+	while (i < lines.length) {
+		const begin = BEGIN_RE.exec(lines[i]);
+		if (!begin) {
+			out.push(lines[i]);
+			i++;
+			continue;
+		}
+
+		// Find the matching #+END, accounting for nested blocks.
+		let depth = 1;
+		let end = -1;
+		for (let j = i + 1; j < lines.length; j++) {
+			if (BEGIN_RE.test(lines[j])) depth++;
+			else if (END_RE.test(lines[j])) {
+				depth--;
+				if (depth === 0) {
+					end = j;
+					break;
+				}
+			}
+		}
+
+		if (end === -1) {
+			// No matching end: leave the line unchanged and continue.
+			out.push(lines[i]);
+			i++;
+			continue;
+		}
+
+		const indent = begin[1];
+		const type = begin[2].toUpperCase();
+		const inner = processOrgLines(lines.slice(i + 1, end));
+		out.push(...renderOrgBlock(type, indent, inner));
+		i = end + 1;
+	}
+	return out;
+}
+
+function renderOrgBlock(type: string, indent: string, inner: string[]): string[] {
+	const stripped = inner.map(line => stripIndent(line, indent.length));
+
+	if (type === 'COMMENT') {
+		return [`${indent}%%`, ...stripped.map(line => indent + line), `${indent}%%`];
+	}
+
+	if (type === 'QUOTE') {
+		return stripped.map(line => quoteLine(indent, line));
+	}
+
+	// Named callouts keep their type; everything else (incl. fallback types) is a note.
+	const calloutType = CALLOUT_TYPES.has(type) ? type.toLowerCase() : 'note';
+
+	let body = stripped;
+	let title = '';
+	const titleMatch = body.length > 0 ? /^\*\*(.+)\*\*\s*$/.exec(body[0]) : null;
+	if (titleMatch) {
+		title = titleMatch[1];
+		body = body.slice(1);
+	}
+
+	const header = title
+		? `${indent}> [!${calloutType}] ${title}`
+		: `${indent}> [!${calloutType}]`;
+	return [header, ...body.map(line => quoteLine(indent, line))];
+}
+
+function quoteLine(indent: string, line: string): string {
+	return line === '' ? `${indent}>` : `${indent}> ${line}`;
+}
+
+function stripIndent(line: string, n: number): string {
+	let i = 0;
+	while (i < n && i < line.length && (line[i] === ' ' || line[i] === '\t')) i++;
+	return line.slice(i);
+}
+
+/**
+ * A bare Markdown heading at column 0 that is immediately followed by an
+ * indented list reads as a "child list" in Logseq's outline. Obsidian would
+ * render the indented bullets oddly, so prefix the heading with `- ` to make
+ * the heading own the nested list.
+ */
+export function fixHeadingChildLists(content: string): string {
+	const lines = content.split('\n');
+	const headingRe = /^#{1,6}\s+\S/;
+	const indentedListRe = /^[\t ]+[-*+]\s/;
+	return lines
+		.map((line, i) => {
+			if (headingRe.test(line) && indentedListRe.test(lines[i + 1] ?? '')) {
+				return `- ${line}`;
+			}
+			return line;
+		})
+		.join('\n');
+}
+
+/**
+ * Convert Logseq media embeds `{{video URL}}`, `{{youtube URL}}`, `{{tweet URL}}`
+ * into Obsidian's markdown image/embed syntax `![](URL)`.
+ */
+export function convertMediaEmbeds(content: string): string {
+	const fenceRe = /^\s*```/;
+	let inFence = false;
+	return content
+		.split('\n')
+		.map(line => {
+			if (fenceRe.test(line)) {
+				inFence = !inFence;
+				return line;
+			}
+			if (inFence) return line;
+			return line.replace(/\{\{(?:video|youtube|tweet)\s+([^}]+?)\s*\}\}/g, '![]($1)');
+		})
+		.join('\n');
+}
+
+/** Align a list-nested fenced code block's closing fence with its opening fence. */
+export function fixCodeBlocksInLists(content: string): string {
+	const lines = content.split('\n');
+	const openRe = /^(?:\s*(?:[-*+]\s+)?)```/;
+	const closeRe = /^[ \t]*```[ \t]*$/;
+	let inFence = false;
+	let fenceColumn = 0;
+
+	return lines
+		.map(line => {
+			if (!inFence) {
+				if (openRe.test(line)) {
+					inFence = true;
+					fenceColumn = line.indexOf('```');
+				}
+				return line;
+			}
+			if (closeRe.test(line)) {
+				inFence = false;
+				return fenceColumn > 0 ? ' '.repeat(fenceColumn) + '```' : line;
+			}
+			return line;
+		})
+		.join('\n');
+}

--- a/src/formats/logseq/blocks.ts
+++ b/src/formats/logseq/blocks.ts
@@ -5,7 +5,8 @@ const HIGHLIGHT_RE = /\^\^(.+?)\^\^/g;
 
 /** Replace Logseq highlights `^^text^^` with Obsidian `==text==`, skipping code. */
 export function convertHighlights(content: string): string {
-	const fenceRe = /^\s*```/;
+	// Issue 5: also match bullet-opened fences `- ``` `
+	const fenceRe = /^(?:\s*- )?\s*```/;
 	let inFence = false;
 	return content
 		.split('\n')
@@ -90,16 +91,62 @@ export function convertOrgBlocks(content: string): string {
 	return processOrgLines(content.split('\n')).join('\n');
 }
 
-const BEGIN_RE = /^(\s*)#\+BEGIN_(\w+)/i;
-const END_RE = /^\s*#\+END_\w+/i;
+const BEGIN_RE = /^(\s*)(?:- )?#\+BEGIN_(\w+)/i;
+const END_RE = /^(\s*)(?:- )?#\+END_\w+/i;
 
 function processOrgLines(lines: string[]): string[] {
 	const out: string[] = [];
 	let i = 0;
+	let inFence = false;
 	while (i < lines.length) {
-		const begin = BEGIN_RE.exec(lines[i]);
+		const line = lines[i];
+
+		// Issue 3: skip begin/end markers inside fenced code blocks.
+		if (/^\s*```/.test(line) || /^\s*- ```/.test(line)) {
+			inFence = !inFence;
+			out.push(line);
+			i++;
+			continue;
+		}
+		if (inFence) {
+			out.push(line);
+			i++;
+			continue;
+		}
+
+		const begin = BEGIN_RE.exec(line);
 		if (!begin) {
-			out.push(lines[i]);
+			out.push(line);
+			i++;
+			continue;
+		}
+
+		const type = begin[2].toUpperCase();
+		const hasBullet = /^\s*- /.test(line);
+
+		// Issue 4: #+BEGIN_QUERY → fenced ```query block (lossless).
+		if (type === 'QUERY') {
+			let qend = -1;
+			for (let j = i + 1; j < lines.length; j++) {
+				if (END_RE.test(lines[j])) { qend = j; break; }
+			}
+			if (qend >= 0) {
+				const indent = begin[1];
+				const inner = lines.slice(i + 1, qend);
+				if (hasBullet) {
+					out.push(`${indent}- \`\`\`query`);
+					out.push(...inner.map(l => `${indent}  ${l.replace(/^\s*/, '')}`));
+					out.push(`${indent}  \`\`\``);
+				}
+				else {
+					out.push(`${indent}\`\`\`query`);
+					out.push(...inner.map(l => stripIndent(l, indent.length)));
+					out.push(`${indent}\`\`\``);
+				}
+				i = qend + 1;
+				continue;
+			}
+			out.push(line);
 			i++;
 			continue;
 		}
@@ -120,28 +167,37 @@ function processOrgLines(lines: string[]): string[] {
 
 		if (end === -1) {
 			// No matching end: leave the line unchanged and continue.
-			out.push(lines[i]);
+			out.push(line);
 			i++;
 			continue;
 		}
 
 		const indent = begin[1];
-		const type = begin[2].toUpperCase();
 		const inner = processOrgLines(lines.slice(i + 1, end));
-		out.push(...renderOrgBlock(type, indent, inner));
+		out.push(...renderOrgBlock(type, indent, inner, hasBullet));
 		i = end + 1;
 	}
 	return out;
 }
 
-function renderOrgBlock(type: string, indent: string, inner: string[]): string[] {
-	const stripped = inner.map(line => stripIndent(line, indent.length));
+function renderOrgBlock(type: string, indent: string, inner: string[], hasBullet: boolean): string[] {
+	// Issue 1: when bullet-prefixed, content is indented `indent + '  '` under the bullet.
+	const stripN = hasBullet ? indent.length + 2 : indent.length;
+	const stripped = inner.map(line => stripIndent(line, stripN));
 
 	if (type === 'COMMENT') {
 		return [`${indent}%%`, ...stripped.map(line => indent + line), `${indent}%%`];
 	}
 
 	if (type === 'QUOTE') {
+		if (hasBullet) {
+			// Issue 1: bullet-opened QUOTE — first line uses `- > `, rest use `  > `.
+			if (stripped.length === 0) return [`${indent}- >`];
+			return [
+				`${indent}- > ${stripped[0]}`,
+				...stripped.slice(1).map(line => line === '' ? `${indent}  >` : `${indent}  > ${line}`),
+			];
+		}
 		return stripped.map(line => quoteLine(indent, line));
 	}
 
@@ -156,6 +212,13 @@ function renderOrgBlock(type: string, indent: string, inner: string[]): string[]
 		body = body.slice(1);
 	}
 
+	if (hasBullet) {
+		// Issue 1: bullet-opened callout — keep the bullet, render callout as child content.
+		const header = title
+			? `${indent}- > [!${calloutType}] ${title}`
+			: `${indent}- > [!${calloutType}]`;
+		return [header, ...body.map(line => line === '' ? `${indent}  >` : `${indent}  > ${line}`)];
+	}
 	const header = title
 		? `${indent}> [!${calloutType}] ${title}`
 		: `${indent}> [!${calloutType}]`;
@@ -197,7 +260,8 @@ export function fixHeadingChildLists(content: string): string {
  * into Obsidian's markdown image/embed syntax `![](URL)`.
  */
 export function convertMediaEmbeds(content: string): string {
-	const fenceRe = /^\s*```/;
+	// Issue 5: also match bullet-opened fences `- ``` `
+	const fenceRe = /^(?:\s*- )?\s*```/;
 	let inFence = false;
 	return content
 		.split('\n')
@@ -215,23 +279,29 @@ export function convertMediaEmbeds(content: string): string {
 /** Align a list-nested fenced code block's closing fence with its opening fence. */
 export function fixCodeBlocksInLists(content: string): string {
 	const lines = content.split('\n');
-	const openRe = /^(?:\s*(?:[-*+]\s+)?)```/;
+	// Issue 2: capture prefix + bullet separately to compute content indent (tab-safe).
+	const openRe = /^([ \t]*)([-*+]\s+)?```/;
 	const closeRe = /^[ \t]*```[ \t]*$/;
 	let inFence = false;
-	let fenceColumn = 0;
+	let fenceIndent = '';
 
 	return lines
 		.map(line => {
 			if (!inFence) {
-				if (openRe.test(line)) {
+				const m = openRe.exec(line);
+				if (m) {
 					inFence = true;
-					fenceColumn = line.indexOf('```');
+					const prefix = m[1]; // whitespace before the bullet (or fence)
+					const bullet = m[2]; // e.g. '- ' or undefined
+					// Content (and closing fence) indent = prefix + bullet-width spaces.
+					fenceIndent = bullet ? prefix + ' '.repeat(bullet.length) : prefix;
 				}
 				return line;
 			}
 			if (closeRe.test(line)) {
 				inFence = false;
-				return fenceColumn > 0 ? ' '.repeat(fenceColumn) + '```' : line;
+				// Only correct if there's a meaningful indent; leave top-level fences unchanged.
+				return fenceIndent ? fenceIndent + '```' : line;
 			}
 			return line;
 		})

--- a/src/formats/logseq/blocks.ts
+++ b/src/formats/logseq/blocks.ts
@@ -5,7 +5,7 @@ const HIGHLIGHT_RE = /\^\^(.+?)\^\^/g;
 
 /** Replace Logseq highlights `^^text^^` with Obsidian `==text==`, skipping code. */
 export function convertHighlights(content: string): string {
-	// Issue 5: also match bullet-opened fences `- ``` `
+	// J1: also match bullet-opened fences `- ``` `
 	const fenceRe = /^(?:\s*- )?\s*```/;
 	let inFence = false;
 	return content
@@ -101,7 +101,7 @@ function processOrgLines(lines: string[]): string[] {
 	while (i < lines.length) {
 		const line = lines[i];
 
-		// Issue 3: skip begin/end markers inside fenced code blocks.
+		// J1: skip begin/end markers inside fenced code blocks.
 		if (/^\s*```/.test(line) || /^\s*- ```/.test(line)) {
 			inFence = !inFence;
 			out.push(line);
@@ -124,7 +124,7 @@ function processOrgLines(lines: string[]): string[] {
 		const type = begin[2].toUpperCase();
 		const hasBullet = /^\s*- /.test(line);
 
-		// Issue 4: #+BEGIN_QUERY → fenced ```query block (lossless).
+		// J1: #+BEGIN_QUERY → fenced ```query block (lossless).
 		if (type === 'QUERY') {
 			let qend = -1;
 			for (let j = i + 1; j < lines.length; j++) {
@@ -181,7 +181,7 @@ function processOrgLines(lines: string[]): string[] {
 }
 
 function renderOrgBlock(type: string, indent: string, inner: string[], hasBullet: boolean): string[] {
-	// Issue 1: when bullet-prefixed, content is indented `indent + '  '` under the bullet.
+	// J1: when bullet-prefixed, content is indented `indent + '  '` under the bullet.
 	const stripN = hasBullet ? indent.length + 2 : indent.length;
 	const stripped = inner.map(line => stripIndent(line, stripN));
 
@@ -191,7 +191,7 @@ function renderOrgBlock(type: string, indent: string, inner: string[], hasBullet
 
 	if (type === 'QUOTE') {
 		if (hasBullet) {
-			// Issue 1: bullet-opened QUOTE — first line uses `- > `, rest use `  > `.
+			// J1: bullet-opened QUOTE — first line uses `- > `, rest use `  > `.
 			if (stripped.length === 0) return [`${indent}- >`];
 			return [
 				`${indent}- > ${stripped[0]}`,
@@ -213,7 +213,7 @@ function renderOrgBlock(type: string, indent: string, inner: string[], hasBullet
 	}
 
 	if (hasBullet) {
-		// Issue 1: bullet-opened callout — keep the bullet, render callout as child content.
+		// J1: bullet-opened callout — keep the bullet, render callout as child content.
 		const header = title
 			? `${indent}- > [!${calloutType}] ${title}`
 			: `${indent}- > [!${calloutType}]`;
@@ -260,7 +260,7 @@ export function fixHeadingChildLists(content: string): string {
  * into Obsidian's markdown image/embed syntax `![](URL)`.
  */
 export function convertMediaEmbeds(content: string): string {
-	// Issue 5: also match bullet-opened fences `- ``` `
+	// J1: also match bullet-opened fences `- ``` `
 	const fenceRe = /^(?:\s*- )?\s*```/;
 	let inFence = false;
 	return content
@@ -279,7 +279,7 @@ export function convertMediaEmbeds(content: string): string {
 /** Align a list-nested fenced code block's closing fence with its opening fence. */
 export function fixCodeBlocksInLists(content: string): string {
 	const lines = content.split('\n');
-	// Issue 2: capture prefix + bullet separately to compute content indent (tab-safe).
+	// J1: capture prefix + bullet separately to compute content indent (tab-safe).
 	const openRe = /^([ \t]*)([-*+]\s+)?```/;
 	const closeRe = /^[ \t]*```[ \t]*$/;
 	let inFence = false;

--- a/src/formats/logseq/de-outline.ts
+++ b/src/formats/logseq/de-outline.ts
@@ -53,7 +53,8 @@ function parseOutline(content: string): OutlineNode[] {
 				// Inside code block: keep consuming until closing fence at same level
 				rawLines.push(nextLine);
 				const stripped = nextLine.replace(/^\s*/, '');
-				if (stripped.match(/^```\s*$/)) {
+				// F1: closing fence may have a trailing ^anchor
+				if (stripped.match(/^```\s*(\^\S+)?\s*$/)) {
 					inCodeBlock = false;
 				}
 				j++;
@@ -81,12 +82,36 @@ function parseOutline(content: string): OutlineNode[] {
 
 		// Build content: first line content + any continuation lines (stripped of indent)
 		let fullContent = firstLineContent;
+		// F2: compute the actual whitespace prefix to strip from continuations.
+		// In Logseq, continuations are indented with the bullet's indent + "  " (or a tab).
+		// We detect the indent from the first continuation line if available.
+		let continuationPrefix = '';
+		if (rawLines.length > 1) {
+			const firstCont = rawLines[1];
+			const ws = firstCont.match(/^(\s*)/)?.[1] ?? '';
+			// The continuation prefix is all leading whitespace (it should align with
+			// content after "- "). Use actual indent rather than char-count arithmetic.
+			continuationPrefix = ws.length >= continuationIndent ? ws.slice(0, Math.max(ws.length, continuationIndent)) : ws;
+			// If the whitespace is longer than continuationIndent, check if first non-ws
+			// would be content (not a deeper indent); use the full ws as prefix.
+			if (firstCont.trim() !== '') {
+				continuationPrefix = ws;
+			}
+		}
 		for (let k = 1; k < rawLines.length; k++) {
 			const rawLine = rawLines[k];
-			// Strip the continuation indent
-			const stripped = rawLine.length > continuationIndent
-				? rawLine.slice(continuationIndent)
-				: rawLine.trim() === '' ? '' : rawLine.replace(new RegExp(`^\\s{0,${continuationIndent}}`), '');
+			let stripped: string;
+			if (rawLine.trim() === '') {
+				stripped = '';
+			}
+			else if (continuationPrefix && rawLine.startsWith(continuationPrefix)) {
+				stripped = rawLine.slice(continuationPrefix.length);
+			}
+			else {
+				// Fallback: strip up to continuationIndent chars of whitespace
+				const leadingWs = rawLine.match(/^(\s*)/)?.[1] ?? '';
+				stripped = rawLine.slice(Math.min(leadingWs.length, continuationIndent));
+			}
 			fullContent += '\n' + stripped;
 		}
 
@@ -125,30 +150,37 @@ function isTask(content: string): boolean {
  */
 function isGenuineList(nodes: OutlineNode[]): boolean {
 	if (nodes.length < 2) return false;
-	return nodes.every(node => {
-		// Tasks are always list items
-		if (isTask(node.content)) return true;
-		// A leaf or near-leaf: has 0 or 1 children, and those children are also leaves
-		if (node.children.length === 0) return true;
-		// If it has children that form a genuine list, it's a list parent
-		if (node.children.length >= 2 && isGenuineList(node.children)) return true;
-		// Single child that is a leaf is OK (collapses)
-		if (node.children.length === 1 && node.children[0].children.length === 0) return true;
-		return false;
-	});
+	return nodes.every(node => isListCompatible(node));
+}
+
+/** Check recursively whether a node can participate in a list rendering. */
+function isListCompatible(node: OutlineNode): boolean {
+	// Tasks are always list items
+	if (isTask(node.content)) return true;
+	// A leaf node is list-compatible
+	if (node.children.length === 0) return true;
+	// If it has children that form a genuine list, it's a list parent
+	if (node.children.length >= 2 && isGenuineList(node.children)) return true;
+	// F3: a single child that is itself list-compatible (recursively) is OK
+	if (node.children.length === 1 && isListCompatible(node.children[0])) return true;
+	return false;
 }
 
 /**
  * Check if a node represents a single-child chain that should collapse:
  * one parent with one child (not a list, not a heading, just prose).
+ * F5: don't collapse if the single child has children that are NOT themselves
+ * a simple collapse chain (i.e. the subtree has branching or tasks).
  */
 function shouldCollapseChain(node: OutlineNode): boolean {
-	return (
-		node.children.length === 1 &&
-		!isHeading(node.children[0].content) &&
-		!isTask(node.children[0].content) &&
-		!isGenuineList(node.children)
-	);
+	if (node.children.length !== 1) return false;
+	const child = node.children[0];
+	if (isHeading(child.content) || isTask(child.content)) return false;
+	if (isGenuineList(node.children)) return false;
+	// If the child has no children, it's a simple 2-node collapse
+	if (child.children.length === 0) return true;
+	// If the child has exactly one child that is also collapsible, allow deep chains
+	return shouldCollapseChain(child);
 }
 
 /** Serialize nodes as a markdown list with proper indentation */
@@ -187,7 +219,14 @@ function serializeTopLevel(nodes: OutlineNode[]): string[] {
 			if (output.length > 0 && output[output.length - 1] !== '') {
 				output.push('');
 			}
-			output.push(content);
+			// F6: if the heading has multiline content (continuation body), split and
+			// insert a blank line between heading and body.
+			const headingLines = content.split('\n');
+			output.push(headingLines[0]);
+			if (headingLines.length > 1) {
+				output.push('');
+				output.push(...headingLines.slice(1));
+			}
 			if (node.children.length > 0) {
 				output.push('');
 				output.push(...serializeBodyUnderHeading(node.children));
@@ -292,7 +331,13 @@ function serializeBodyUnderHeading(nodes: OutlineNode[]): string[] {
 			if (output.length > 0 && output[output.length - 1] !== '') {
 				output.push('');
 			}
-			output.push(content);
+			// F6: split multiline heading content
+			const headingLines = content.split('\n');
+			output.push(headingLines[0]);
+			if (headingLines.length > 1) {
+				output.push('');
+				output.push(...headingLines.slice(1));
+			}
 			if (node.children.length > 0) {
 				output.push('');
 				output.push(...serializeBodyUnderHeading(node.children));

--- a/src/formats/logseq/de-outline.ts
+++ b/src/formats/logseq/de-outline.ts
@@ -53,7 +53,7 @@ function parseOutline(content: string): OutlineNode[] {
 				// Inside code block: keep consuming until closing fence at same level
 				rawLines.push(nextLine);
 				const stripped = nextLine.replace(/^\s*/, '');
-				// F1: closing fence may have a trailing ^anchor
+				// C1: closing fence may have a trailing ^anchor
 				if (stripped.match(/^```\s*(\^\S+)?\s*$/)) {
 					inCodeBlock = false;
 				}
@@ -82,7 +82,7 @@ function parseOutline(content: string): OutlineNode[] {
 
 		// Build content: first line content + any continuation lines (stripped of indent)
 		let fullContent = firstLineContent;
-		// F2: compute the actual whitespace prefix to strip from continuations.
+		// C1: compute the actual whitespace prefix to strip from continuations.
 		// In Logseq, continuations are indented with the bullet's indent + "  " (or a tab).
 		// We detect the indent from the first continuation line if available.
 		let continuationPrefix = '';
@@ -156,7 +156,7 @@ function isGenuineList(nodes: OutlineNode[]): boolean {
 /** Check recursively whether a node can participate in a list rendering. */
 function isListCompatible(node: OutlineNode): boolean {
 	// Headings must not participate in list rendering — they should always be
-	// promoted to real headings via serializeBodyUnderHeading (H-E4).
+	// promoted to real headings via serializeBodyUnderHeading (C1).
 	if (isHeading(node.content)) return false;
 	// Tasks are always list items
 	if (isTask(node.content)) return true;
@@ -164,7 +164,7 @@ function isListCompatible(node: OutlineNode): boolean {
 	if (node.children.length === 0) return true;
 	// If it has children that form a genuine list, it's a list parent
 	if (node.children.length >= 2 && isGenuineList(node.children)) return true;
-	// F3: a single child that is itself list-compatible (recursively) is OK
+	// C1: a single child that is itself list-compatible (recursively) is OK
 	if (node.children.length === 1 && isListCompatible(node.children[0])) return true;
 	return false;
 }
@@ -172,7 +172,7 @@ function isListCompatible(node: OutlineNode): boolean {
 /**
  * Check if a node represents a single-child chain that should collapse:
  * one parent with one child (not a list, not a heading, just prose).
- * F5: don't collapse if the single child has children that are NOT themselves
+ * C1: don't collapse if the single child has children that are NOT themselves
  * a simple collapse chain (i.e. the subtree has branching or tasks).
  */
 function shouldCollapseChain(node: OutlineNode): boolean {
@@ -222,7 +222,7 @@ function serializeTopLevel(nodes: OutlineNode[]): string[] {
 			if (output.length > 0 && output[output.length - 1] !== '') {
 				output.push('');
 			}
-			// F6: if the heading has multiline content (continuation body), split and
+			// C1: if the heading has multiline content (continuation body), split and
 			// insert a blank line between heading and body — but NOT before a lone
 			// ^anchor, which must stay adjacent to the heading for Obsidian block refs.
 			const headingLines = content.split('\n');
@@ -338,7 +338,7 @@ function serializeBodyUnderHeading(nodes: OutlineNode[]): string[] {
 			if (output.length > 0 && output[output.length - 1] !== '') {
 				output.push('');
 			}
-			// F6: split multiline heading content
+			// C1: split multiline heading content
 			const headingLines = content.split('\n');
 			output.push(headingLines[0]);
 			if (headingLines.length > 1) {

--- a/src/formats/logseq/de-outline.ts
+++ b/src/formats/logseq/de-outline.ts
@@ -1,0 +1,369 @@
+// De-outline: converts Logseq's everything-is-a-bullet outline structure back
+// into idiomatic flat markdown (paragraphs, headings, lists). This is the
+// inverse of the "outline" function. Pure, side-effect-free.
+
+interface OutlineNode {
+	content: string;
+	children: OutlineNode[];
+	rawLines: string[]; // for multiline content (code blocks spanning lines)
+}
+
+/**
+ * Parse indented bullet lines into a tree of OutlineNodes.
+ * Handles code blocks that span multiple indented lines.
+ */
+function parseOutline(content: string): OutlineNode[] {
+	const lines = content.split('\n');
+	const root: OutlineNode[] = [];
+	const stack: { indent: number, node: OutlineNode, children: OutlineNode[] }[] = [
+		{ indent: -1, node: { content: '', children: root, rawLines: [] }, children: root },
+	];
+
+	let i = 0;
+	while (i < lines.length) {
+		const line = lines[i];
+
+		// Match a bullet line: optional indent + "- " + content
+		const bulletMatch = line.match(/^(\s*)- (.*)$/);
+
+		if (!bulletMatch) {
+			// Non-bullet line at top level — could be leftover content; skip it
+			// (shouldn't happen in well-formed Logseq output, but be safe)
+			i++;
+			continue;
+		}
+
+		const indent = bulletMatch[1].length;
+		const firstLineContent = bulletMatch[2];
+
+		// Collect raw lines: the bullet line + any continuation lines
+		// (indented more than the bullet, but not starting with a new bullet)
+		const rawLines = [line];
+		const continuationIndent = indent + 2; // content continuation is indented past "- "
+
+		// Check if this bullet starts a code block
+		let inCodeBlock = firstLineContent.match(/^```/) !== null;
+
+		let j = i + 1;
+		while (j < lines.length) {
+			const nextLine = lines[j];
+			const nextBulletMatch = nextLine.match(/^(\s*)- /);
+
+			if (inCodeBlock) {
+				// Inside code block: keep consuming until closing fence at same level
+				rawLines.push(nextLine);
+				const stripped = nextLine.replace(/^\s*/, '');
+				if (stripped.match(/^```\s*$/)) {
+					inCodeBlock = false;
+				}
+				j++;
+				continue;
+			}
+
+			// If next line is a bullet at any level, stop
+			if (nextBulletMatch) break;
+
+			// If next line is a continuation (indented content under this bullet)
+			// but NOT a child bullet, include as raw
+			const nextIndent = nextLine.match(/^(\s*)/)?.[1].length ?? 0;
+			if (nextLine.trim() === '' || nextIndent >= continuationIndent) {
+				rawLines.push(nextLine);
+				// Check if continuation starts a code block
+				if (nextLine.trim().match(/^```/)) {
+					inCodeBlock = true;
+				}
+				j++;
+			}
+			else {
+				break;
+			}
+		}
+
+		// Build content: first line content + any continuation lines (stripped of indent)
+		let fullContent = firstLineContent;
+		for (let k = 1; k < rawLines.length; k++) {
+			const rawLine = rawLines[k];
+			// Strip the continuation indent
+			const stripped = rawLine.length > continuationIndent
+				? rawLine.slice(continuationIndent)
+				: rawLine.trim() === '' ? '' : rawLine.replace(new RegExp(`^\\s{0,${continuationIndent}}`), '');
+			fullContent += '\n' + stripped;
+		}
+
+		const node: OutlineNode = { content: fullContent, children: [], rawLines };
+
+		// Pop stack until we find the parent (an item with smaller indent)
+		while (stack.length > 1 && stack[stack.length - 1].indent >= indent) {
+			stack.pop();
+		}
+
+		// Add to parent's children
+		stack[stack.length - 1].children.push(node);
+
+		// Push this node onto the stack
+		stack.push({ indent, node, children: node.children });
+
+		i = j;
+	}
+
+	return root;
+}
+
+/** Check if content starts with a markdown heading */
+function isHeading(content: string): boolean {
+	return /^#{1,6}\s+\S/.test(content);
+}
+
+/** Check if a node is a task checkbox */
+function isTask(content: string): boolean {
+	return /^\[.\]\s/.test(content);
+}
+
+/**
+ * A subtree is a "genuine list" if the parent has 2+ children that are all
+ * leaf-ish items (short, no deep sub-documents). Tasks are always list items.
+ */
+function isGenuineList(nodes: OutlineNode[]): boolean {
+	if (nodes.length < 2) return false;
+	return nodes.every(node => {
+		// Tasks are always list items
+		if (isTask(node.content)) return true;
+		// A leaf or near-leaf: has 0 or 1 children, and those children are also leaves
+		if (node.children.length === 0) return true;
+		// If it has children that form a genuine list, it's a list parent
+		if (node.children.length >= 2 && isGenuineList(node.children)) return true;
+		// Single child that is a leaf is OK (collapses)
+		if (node.children.length === 1 && node.children[0].children.length === 0) return true;
+		return false;
+	});
+}
+
+/**
+ * Check if a node represents a single-child chain that should collapse:
+ * one parent with one child (not a list, not a heading, just prose).
+ */
+function shouldCollapseChain(node: OutlineNode): boolean {
+	return (
+		node.children.length === 1 &&
+		!isHeading(node.children[0].content) &&
+		!isTask(node.children[0].content) &&
+		!isGenuineList(node.children)
+	);
+}
+
+/** Serialize nodes as a markdown list with proper indentation */
+function serializeList(nodes: OutlineNode[], depth: number): string[] {
+	const lines: string[] = [];
+	const indent = '  '.repeat(depth);
+
+	for (const node of nodes) {
+		const contentLines = node.content.split('\n');
+		// First line gets the "- " prefix (or "- [ ] " for tasks)
+		lines.push(`${indent}- ${contentLines[0]}`);
+		// Continuation lines get indented
+		for (let i = 1; i < contentLines.length; i++) {
+			const cLine = contentLines[i];
+			lines.push(cLine === '' ? '' : `${indent}  ${cLine}`);
+		}
+
+		if (node.children.length > 0) {
+			lines.push(...serializeList(node.children, depth + 1));
+		}
+	}
+
+	return lines;
+}
+
+/** Serialize top-level nodes into flat markdown */
+function serializeTopLevel(nodes: OutlineNode[]): string[] {
+	const output: string[] = [];
+
+	for (let i = 0; i < nodes.length; i++) {
+		const node = nodes[i];
+		const content = node.content;
+
+		if (isHeading(content)) {
+			// Heading node: emit heading, then serialize children as body
+			if (output.length > 0 && output[output.length - 1] !== '') {
+				output.push('');
+			}
+			output.push(content);
+			if (node.children.length > 0) {
+				output.push('');
+				output.push(...serializeBodyUnderHeading(node.children));
+			}
+		}
+		else if (isTask(content)) {
+			// Task at top level stays as a list item
+			if (output.length > 0 && output[output.length - 1] !== '') {
+				output.push('');
+			}
+			const contentLines = content.split('\n');
+			output.push(`- ${contentLines[0]}`);
+			for (let k = 1; k < contentLines.length; k++) {
+				const cLine = contentLines[k];
+				output.push(cLine === '' ? '' : `  ${cLine}`);
+			}
+			if (node.children.length > 0) {
+				output.push(...serializeList(node.children, 1));
+			}
+		}
+		else if (node.children.length > 0 && isGenuineList(node.children)) {
+			// Prose parent with genuine list children: emit paragraph then list
+			if (output.length > 0 && output[output.length - 1] !== '') {
+				output.push('');
+			}
+			output.push(...content.split('\n'));
+			output.push('');
+			output.push(...serializeList(node.children, 0));
+		}
+		else if (shouldCollapseChain(node)) {
+			// Single-child chain: collapse
+			if (output.length > 0 && output[output.length - 1] !== '') {
+				output.push('');
+			}
+			const collapsed = collapseChain(node);
+			output.push(...collapsed.split('\n'));
+		}
+		else if (node.children.length > 0) {
+			// Has children but not a genuine list — children are sub-documents
+			// Serialize as prose paragraph then children as subsequent paragraphs
+			if (output.length > 0 && output[output.length - 1] !== '') {
+				output.push('');
+			}
+			output.push(...content.split('\n'));
+			output.push('');
+			output.push(...serializeBodyUnderHeading(node.children));
+		}
+		else {
+			// Plain prose: emit as paragraph
+			if (output.length > 0 && output[output.length - 1] !== '') {
+				output.push('');
+			}
+			output.push(...content.split('\n'));
+		}
+	}
+
+	return output;
+}
+
+/** Collapse a single-child chain into one paragraph */
+function collapseChain(node: OutlineNode): string {
+	let result = node.content;
+	let current = node;
+	while (current.children.length === 1 &&
+		!isHeading(current.children[0].content) &&
+		!isTask(current.children[0].content)) {
+		const child = current.children[0];
+		result += '\n' + child.content;
+		current = child;
+	}
+	// If the final node in the chain has children, append them
+	if (current.children.length > 0) {
+		if (isGenuineList(current.children)) {
+			result += '\n\n' + serializeList(current.children, 0).join('\n');
+		}
+		else {
+			result += '\n\n' + serializeBodyUnderHeading(current.children).join('\n');
+		}
+	}
+	return result;
+}
+
+/**
+ * Serialize children under a heading: they may be paragraphs, sub-headings, or lists.
+ * Unlike top-level, heading children are always processed individually (not treated
+ * as a "genuine list" collectively) — except when ALL are tasks.
+ */
+function serializeBodyUnderHeading(nodes: OutlineNode[]): string[] {
+	const output: string[] = [];
+
+	// If all children are tasks, render as a compact list
+	if (nodes.length >= 2 && nodes.every(n => isTask(n.content))) {
+		output.push(...serializeList(nodes, 0));
+		return output;
+	}
+
+	for (let i = 0; i < nodes.length; i++) {
+		const node = nodes[i];
+		const content = node.content;
+
+		if (isHeading(content)) {
+			if (output.length > 0 && output[output.length - 1] !== '') {
+				output.push('');
+			}
+			output.push(content);
+			if (node.children.length > 0) {
+				output.push('');
+				output.push(...serializeBodyUnderHeading(node.children));
+			}
+		}
+		else if (isTask(content)) {
+			// Group consecutive tasks into a compact list
+			const taskGroup: OutlineNode[] = [node];
+			while (i + 1 < nodes.length && isTask(nodes[i + 1].content)) {
+				i++;
+				taskGroup.push(nodes[i]);
+			}
+			if (output.length > 0 && output[output.length - 1] !== '') {
+				output.push('');
+			}
+			output.push(...serializeList(taskGroup, 0));
+		}
+		else if (node.children.length > 0 && isGenuineList(node.children)) {
+			if (output.length > 0 && output[output.length - 1] !== '') {
+				output.push('');
+			}
+			output.push(...content.split('\n'));
+			output.push('');
+			output.push(...serializeList(node.children, 0));
+		}
+		else if (shouldCollapseChain(node)) {
+			if (output.length > 0 && output[output.length - 1] !== '') {
+				output.push('');
+			}
+			output.push(...collapseChain(node).split('\n'));
+		}
+		else if (node.children.length > 0) {
+			if (output.length > 0 && output[output.length - 1] !== '') {
+				output.push('');
+			}
+			output.push(...content.split('\n'));
+			output.push('');
+			output.push(...serializeBodyUnderHeading(node.children));
+		}
+		else {
+			if (output.length > 0 && output[output.length - 1] !== '') {
+				output.push('');
+			}
+			output.push(...content.split('\n'));
+		}
+	}
+
+	return output;
+}
+
+/**
+ * De-outline: converts Logseq's bullet-outline format back into idiomatic
+ * flat markdown with paragraphs, headings, and properly-nested lists.
+ *
+ * Takes content AFTER all other conversions (tasks, properties, highlights, etc.)
+ * have been applied.
+ */
+export function deOutline(content: string): string {
+	if (!content.trim()) return content;
+
+	// If content doesn't look like an outline (no bullet lines), return as-is
+	if (!/^\s*- /m.test(content)) return content;
+
+	const nodes = parseOutline(content);
+	if (nodes.length === 0) return content;
+
+	const lines = serializeTopLevel(nodes);
+
+	// Clean up: remove trailing blank lines, ensure single trailing newline
+	let result = lines.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd();
+	if (content.endsWith('\n')) result += '\n';
+
+	return result;
+}

--- a/src/formats/logseq/de-outline.ts
+++ b/src/formats/logseq/de-outline.ts
@@ -220,11 +220,15 @@ function serializeTopLevel(nodes: OutlineNode[]): string[] {
 				output.push('');
 			}
 			// F6: if the heading has multiline content (continuation body), split and
-			// insert a blank line between heading and body.
+			// insert a blank line between heading and body — but NOT before a lone
+			// ^anchor, which must stay adjacent to the heading for Obsidian block refs.
 			const headingLines = content.split('\n');
 			output.push(headingLines[0]);
 			if (headingLines.length > 1) {
-				output.push('');
+				const nonBlankConts = headingLines.slice(1).filter(l => l.trim() !== '');
+				const isJustAnchors = nonBlankConts.length > 0 &&
+					nonBlankConts.every(l => /^\^[A-Za-z0-9-]+$/.test(l));
+				if (!isJustAnchors) output.push('');
 				output.push(...headingLines.slice(1));
 			}
 			if (node.children.length > 0) {

--- a/src/formats/logseq/de-outline.ts
+++ b/src/formats/logseq/de-outline.ts
@@ -155,6 +155,9 @@ function isGenuineList(nodes: OutlineNode[]): boolean {
 
 /** Check recursively whether a node can participate in a list rendering. */
 function isListCompatible(node: OutlineNode): boolean {
+	// Headings must not participate in list rendering — they should always be
+	// promoted to real headings via serializeBodyUnderHeading (H-E4).
+	if (isHeading(node.content)) return false;
 	// Tasks are always list items
 	if (isTask(node.content)) return true;
 	// A leaf node is list-compatible

--- a/src/formats/logseq/journals.ts
+++ b/src/formats/logseq/journals.ts
@@ -1,0 +1,46 @@
+// Journal date handling (pure parts).
+//
+// Logseq journal files are named with `:journal/file-name-format` (default
+// `yyyy_MM_dd`) and reference dates in content using `:journal/page-title-format`
+// (default `MMM do, yyyy`, e.g. "Aug 30th, 2024"). These helpers normalize both
+// to ISO `YYYY-MM-DD`. The orchestrator reformats ISO into the target Obsidian
+// daily-note format at runtime (using moment), which is not needed here.
+
+const MONTHS: Record<string, number> = {
+	jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6,
+	jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12,
+};
+
+function pad(n: number): string {
+	return n.toString().padStart(2, '0');
+}
+
+function validYMD(y: number, m: number, d: number): boolean {
+	if (m < 1 || m > 12 || d < 1 || d > 31) return false;
+	return true;
+}
+
+export function journalFilenameToISO(basename: string): string | null {
+	const m = basename.match(/^(\d{4})[_-](\d{1,2})[_-](\d{1,2})$/);
+	if (!m) return null;
+	const y = parseInt(m[1], 10);
+	const mo = parseInt(m[2], 10);
+	const d = parseInt(m[3], 10);
+	if (!validYMD(y, mo, d)) return null;
+	return `${y}-${pad(mo)}-${pad(d)}`;
+}
+
+export function isJournalFilename(basename: string): boolean {
+	return journalFilenameToISO(basename) !== null;
+}
+
+const DATE_LINK = /\[\[((?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*)\.? (\d{1,2})(?:st|nd|rd|th)?,? (\d{4})\]\]/g;
+
+export function convertJournalDateLinks(content: string): string {
+	return content.replace(DATE_LINK, (whole, monthName: string, day: string, year: string) => {
+		const mo = MONTHS[monthName.slice(0, 3).toLowerCase()];
+		const d = parseInt(day, 10);
+		if (!mo || !validYMD(parseInt(year, 10), mo, d)) return whole;
+		return `[[${year}-${pad(mo)}-${pad(d)}]]`;
+	});
+}

--- a/src/formats/logseq/journals.ts
+++ b/src/formats/logseq/journals.ts
@@ -34,7 +34,27 @@ export function isJournalFilename(basename: string): boolean {
 	return journalFilenameToISO(basename) !== null;
 }
 
+// Matches the Logseq long-date format inside `[[...]]`, e.g. `[[Feb 13th, 2025]]`.
 const DATE_LINK = /\[\[((?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*)\.? (\d{1,2})(?:st|nd|rd|th)?,? (\d{4})\]\]/g;
+
+// Matches a bare long-date (no brackets), e.g. "Feb 13th, 2025".
+const BARE_DATE = /^((?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*)\.? (\d{1,2})(?:st|nd|rd|th)?,? (\d{4})$/i;
+
+/**
+ * Convert a bare Logseq long-date string (e.g. "Feb 13th, 2025") to ISO
+ * `YYYY-MM-DD`, or return `null` if the input is not a recognizable date.
+ * This is the pure parsing core used by both journal date-link conversion
+ * and task date property normalization.
+ */
+export function logseqDateToISO(text: string): string | null {
+	const m = BARE_DATE.exec(text.trim());
+	if (!m) return null;
+	const mo = MONTHS[m[1].slice(0, 3).toLowerCase()];
+	const d = parseInt(m[2], 10);
+	const y = parseInt(m[3], 10);
+	if (!mo || !validYMD(y, mo, d)) return null;
+	return `${y}-${pad(mo)}-${pad(d)}`;
+}
 
 export function convertJournalDateLinks(content: string): string {
 	return content.replace(DATE_LINK, (whole, monthName: string, day: string, year: string) => {
@@ -42,5 +62,21 @@ export function convertJournalDateLinks(content: string): string {
 		const d = parseInt(day, 10);
 		if (!mo || !validYMD(parseInt(year, 10), mo, d)) return whole;
 		return `[[${year}-${pad(mo)}-${pad(d)}]]`;
+	});
+}
+
+/**
+ * Reformat ISO date wikilinks `[[YYYY-MM-DD]]` into a target date format.
+ * `formatIso` returns the formatted date string, or `null` to leave the link
+ * unchanged. The actual moment-based formatting lives in the orchestrator (which
+ * has the user's daily-note format); this keeps the link-rewriting logic pure and
+ * unit-testable.
+ */
+export function reformatDateLinks(content: string, formatIso: (iso: string) => string | null): string {
+	// Also handles `[[YYYY-MM-DD#^anchor]]` — date part is reformatted, anchor preserved.
+	return content.replace(/\[\[(\d{4}-\d{2}-\d{2})(#\^[^\]]+)?\]\]/g, (whole, iso: string, anchor?: string) => {
+		const formatted = formatIso(iso);
+		if (formatted === null) return whole;
+		return anchor ? `[[${formatted}${anchor}]]` : `[[${formatted}]]`;
 	});
 }

--- a/src/formats/logseq/links.ts
+++ b/src/formats/logseq/links.ts
@@ -1,0 +1,62 @@
+// Wikilink, alias, and tag conversions.
+//
+// Logseq and Obsidian both have `[[wikilinks]]`, but Logseq writes aliased
+// links as `[display]([[Page]])` and, crucially, lets you *reference a page by
+// one of its aliases*. Obsidian links must target the canonical note name, so
+// alias references have to be rewritten to `[[Canonical|Alias]]`.
+
+export interface LinkIndex {
+	/** alias (lower-cased) -> canonical page name. Ambiguous aliases excluded. */
+	aliasMap: Map<string, string>;
+}
+
+/** Run a per-line transform, skipping fenced code blocks. */
+function outsideCode(content: string, fn: (line: string) => string): string {
+	let inFence = false;
+	return content
+		.split('\n')
+		.map(line => {
+			if (/^\s*```/.test(line)) {
+				inFence = !inFence;
+				return line;
+			}
+			return inFence ? line : fn(line);
+		})
+		.join('\n');
+}
+
+export function convertAliasLinks(content: string): string {
+	return outsideCode(content, line =>
+		// [display]([[Target]]) -> [[Target|display]]
+		line.replace(/\[([^\]]+)\]\(\[\[([^\]]+)\]\]\)/g, (_, display, target) => `[[${target}|${display}]]`)
+	);
+}
+
+export function convertTags(content: string, convertToLinks: boolean): string {
+	return outsideCode(content, line => {
+		// #[[multi word tag]]
+		line = line.replace(/(^|\s)#\[\[([^\]]+)\]\]/g, (_, pre, name) =>
+			convertToLinks ? `${pre}[[${name}]]` : `${pre}#${name.replace(/\s+/g, '-')}`
+		);
+		// #simple-tag (letters, digits, /_-), must follow start or whitespace
+		line = line.replace(/(^|\s)#([\w/-]+)/g, (m, pre, name) =>
+			convertToLinks ? `${pre}[[${name}]]` : m
+		);
+		return line;
+	});
+}
+
+export function rewriteAliasReferences(content: string, index: LinkIndex): string {
+	if (index.aliasMap.size === 0) return content;
+	return outsideCode(content, line =>
+		line.replace(/(!?)\[\[([^\]]+)\]\]/g, (whole, bang, inner) => {
+			const pipe = inner.indexOf('|');
+			const target = (pipe >= 0 ? inner.slice(0, pipe) : inner).trim();
+			const display = pipe >= 0 ? inner.slice(pipe + 1) : target;
+			if (target.includes('#')) return whole; // block/heading ref, not a page alias
+			const canonical = index.aliasMap.get(target.toLowerCase());
+			if (!canonical) return whole;
+			return `${bang}[[${canonical}|${display}]]`;
+		})
+	);
+}

--- a/src/formats/logseq/links.ts
+++ b/src/formats/logseq/links.ts
@@ -43,7 +43,7 @@ function outsideInlineCode(fn: (segment: string) => string): (line: string) => s
 
 export function convertAliasLinks(content: string): string {
 	return outsideCode(content, line =>
-		// [display]([[Target]]) -> [[Target|display]]. L2: strip any pre-existing pipe from target.
+		// [display]([[Target]]) -> [[Target|display]]. G1: strip any pre-existing pipe from target.
 		line.replace(/\[([^\]]+)\]\(\[\[([^\]]+)\]\]\)/g, (_, display, target) => `[[${target.split('|')[0]}|${display}]]`)
 	);
 }
@@ -77,7 +77,7 @@ export function convertTags(content: string, options: ConvertTagsOptions): strin
 		});
 		// #simple-tag (letters, digits, /_-), must follow start, whitespace, or `([`
 		line = line.replace(/(^|[\s(\[])#([\w/-]+)/g, (m, pre, name) => {
-			// L5: skip full hex colour tokens like #FF0000 (exactly 6 hex digits)
+			// H1: skip full hex colour tokens like #FF0000 (exactly 6 hex digits)
 			if (/^[0-9A-Fa-f]{6}$/.test(name)) return m;
 			if (dropTags.has(name)) return pre;
 			if (toLinks) {
@@ -100,7 +100,7 @@ export function rewriteAliasReferences(content: string, index: LinkIndex): strin
 			if (target.includes('#')) return whole; // block/heading ref, not a page alias
 			const canonical = index.aliasMap.get(target.toLowerCase());
 			if (!canonical) return whole;
-			// M3: skip if the alias resolves to the same name (would produce [[Name|Name]])
+			// G1: skip if the alias resolves to the same name (would produce [[Name|Name]])
 			if (canonical.toLowerCase() === target.toLowerCase()) return whole;
 			return `${bang}[[${canonical}|${display}]]`;
 		})
@@ -135,7 +135,7 @@ export function disambiguateBasenameLinks(content: string, index: BasenameIndex)
 			const paths = index.basenameMap.get(target.toLowerCase());
 			if (!paths || paths.length < 2) return whole;
 
-			// M4: if one of the paths is an exact top-level match (no namespace), use it as-is.
+			// M1: if one of the paths is an exact top-level match (no namespace), use it as-is.
 			const exact = paths.find(p => !p.includes('/') && p.toLowerCase() === target.toLowerCase());
 			if (exact) return whole;
 

--- a/src/formats/logseq/links.ts
+++ b/src/formats/logseq/links.ts
@@ -25,10 +25,26 @@ function outsideCode(content: string, fn: (line: string) => string): string {
 		.join('\n');
 }
 
+/** Wrap a per-segment transform so that inline-code spans are passed through unchanged. */
+function outsideInlineCode(fn: (segment: string) => string): (line: string) => string {
+	return (line: string) => {
+		const inlineRe = /`[^`]*`/g;
+		let result = '';
+		let last = 0;
+		let m: RegExpExecArray | null;
+		while ((m = inlineRe.exec(line)) !== null) {
+			result += fn(line.slice(last, m.index));
+			result += m[0];
+			last = m.index + m[0].length;
+		}
+		return result + fn(line.slice(last));
+	};
+}
+
 export function convertAliasLinks(content: string): string {
 	return outsideCode(content, line =>
-		// [display]([[Target]]) -> [[Target|display]]
-		line.replace(/\[([^\]]+)\]\(\[\[([^\]]+)\]\]\)/g, (_, display, target) => `[[${target}|${display}]]`)
+		// [display]([[Target]]) -> [[Target|display]]. L2: strip any pre-existing pipe from target.
+		line.replace(/\[([^\]]+)\]\(\[\[([^\]]+)\]\]\)/g, (_, display, target) => `[[${target.split('|')[0]}|${display}]]`)
 	);
 }
 
@@ -51,7 +67,7 @@ export function convertTags(content: string, options: ConvertTagsOptions): strin
 
 	return outsideCode(content, line => {
 		// #[[multi word tag]]
-		line = line.replace(/(^|\s)#\[\[([^\]]+)\]\]/g, (_, pre, name) => {
+		line = line.replace(/(^|[\s(\[])#\[\[([^\]]+)\]\]/g, (_, pre, name) => {
 			if (dropTags.has(name) || dropTags.has(name.replace(/\s+/g, '-'))) return pre;
 			if (toLinks) {
 				if (onlyExistingPages && !knownPages.has(name.toLowerCase())) return `${pre}#${name.replace(/\s+/g, '-')}`;
@@ -59,8 +75,10 @@ export function convertTags(content: string, options: ConvertTagsOptions): strin
 			}
 			return `${pre}#${name.replace(/\s+/g, '-')}`;
 		});
-		// #simple-tag (letters, digits, /_-), must follow start or whitespace
-		line = line.replace(/(^|\s)#([\w/-]+)/g, (m, pre, name) => {
+		// #simple-tag (letters, digits, /_-), must follow start, whitespace, or `([`
+		line = line.replace(/(^|[\s(\[])#([\w/-]+)/g, (m, pre, name) => {
+			// L5: skip full hex colour tokens like #FF0000 (exactly 6 hex digits)
+			if (/^[0-9A-Fa-f]{6}$/.test(name)) return m;
 			if (dropTags.has(name)) return pre;
 			if (toLinks) {
 				if (onlyExistingPages && !knownPages.has(name.toLowerCase())) return m;
@@ -74,17 +92,19 @@ export function convertTags(content: string, options: ConvertTagsOptions): strin
 
 export function rewriteAliasReferences(content: string, index: LinkIndex): string {
 	if (index.aliasMap.size === 0) return content;
-	return outsideCode(content, line =>
-		line.replace(/(!?)\[\[([^\]]+)\]\]/g, (whole, bang, inner) => {
+	return outsideCode(content, outsideInlineCode(segment =>
+		segment.replace(/(!?)\[\[([^\]]+)\]\]/g, (whole, bang, inner) => {
 			const pipe = inner.indexOf('|');
 			const target = (pipe >= 0 ? inner.slice(0, pipe) : inner).trim();
 			const display = pipe >= 0 ? inner.slice(pipe + 1) : target;
 			if (target.includes('#')) return whole; // block/heading ref, not a page alias
 			const canonical = index.aliasMap.get(target.toLowerCase());
 			if (!canonical) return whole;
+			// M3: skip if the alias resolves to the same name (would produce [[Name|Name]])
+			if (canonical.toLowerCase() === target.toLowerCase()) return whole;
 			return `${bang}[[${canonical}|${display}]]`;
 		})
-	);
+	));
 }
 
 export interface BasenameIndex {
@@ -114,6 +134,10 @@ export function disambiguateBasenameLinks(content: string, index: BasenameIndex)
 
 			const paths = index.basenameMap.get(target.toLowerCase());
 			if (!paths || paths.length < 2) return whole;
+
+			// M4: if one of the paths is an exact top-level match (no namespace), use it as-is.
+			const exact = paths.find(p => !p.includes('/') && p.toLowerCase() === target.toLowerCase());
+			if (exact) return whole;
 
 			// Use the first known path as the canonical (same as write order).
 			// The display text is the original target name, or the explicit display if given.

--- a/src/formats/logseq/links.ts
+++ b/src/formats/logseq/links.ts
@@ -32,16 +32,42 @@ export function convertAliasLinks(content: string): string {
 	);
 }
 
-export function convertTags(content: string, convertToLinks: boolean): string {
+export interface ConvertTagsOptions {
+	/** Convert tags to wikilinks. */
+	toLinks: boolean;
+	/**
+	 * When toLinks is true, only convert tags that have a matching page in the graph.
+	 * Tags with no corresponding page are kept as-is.
+	 */
+	onlyExistingPages: boolean;
+	/** Set of known page canonical names (lower-cased) for page-existence checks. */
+	knownPages: Set<string>;
+	/** Tags to drop entirely from body text (applied before the toLinks decision). */
+	dropTags: Set<string>;
+}
+
+export function convertTags(content: string, options: ConvertTagsOptions): string {
+	const { toLinks, onlyExistingPages, knownPages, dropTags } = options;
+
 	return outsideCode(content, line => {
 		// #[[multi word tag]]
-		line = line.replace(/(^|\s)#\[\[([^\]]+)\]\]/g, (_, pre, name) =>
-			convertToLinks ? `${pre}[[${name}]]` : `${pre}#${name.replace(/\s+/g, '-')}`
-		);
+		line = line.replace(/(^|\s)#\[\[([^\]]+)\]\]/g, (_, pre, name) => {
+			if (dropTags.has(name) || dropTags.has(name.replace(/\s+/g, '-'))) return pre;
+			if (toLinks) {
+				if (onlyExistingPages && !knownPages.has(name.toLowerCase())) return `${pre}#${name.replace(/\s+/g, '-')}`;
+				return `${pre}[[${name}]]`;
+			}
+			return `${pre}#${name.replace(/\s+/g, '-')}`;
+		});
 		// #simple-tag (letters, digits, /_-), must follow start or whitespace
-		line = line.replace(/(^|\s)#([\w/-]+)/g, (m, pre, name) =>
-			convertToLinks ? `${pre}[[${name}]]` : m
-		);
+		line = line.replace(/(^|\s)#([\w/-]+)/g, (m, pre, name) => {
+			if (dropTags.has(name)) return pre;
+			if (toLinks) {
+				if (onlyExistingPages && !knownPages.has(name.toLowerCase())) return m;
+				return `${pre}[[${name}]]`;
+			}
+			return m;
+		});
 		return line;
 	});
 }
@@ -57,6 +83,43 @@ export function rewriteAliasReferences(content: string, index: LinkIndex): strin
 			const canonical = index.aliasMap.get(target.toLowerCase());
 			if (!canonical) return whole;
 			return `${bang}[[${canonical}|${display}]]`;
+		})
+	);
+}
+
+export interface BasenameIndex {
+	/**
+	 * basename (lower-cased, without .md) -> full output path(s) without .md.
+	 * Entries with 2+ paths are ambiguous and wikilinks must be disambiguated.
+	 */
+	basenameMap: Map<string, string[]>;
+}
+
+/**
+ * Rewrite wikilinks that are ambiguous due to same-basename pages in different folders.
+ * A bare `[[name]]` that matches two or more notes becomes `[[full/path/to/note|name]]`.
+ * Links that already contain a `/` (namespace-style) are left untouched — they already
+ * point at the correct full path.
+ */
+export function disambiguateBasenameLinks(content: string, index: BasenameIndex): string {
+	if (index.basenameMap.size === 0) return content;
+	return outsideCode(content, line =>
+		line.replace(/(!?)\[\[([^\]]+)\]\]/g, (whole, bang, inner) => {
+			const pipe = inner.indexOf('|');
+			const target = (pipe >= 0 ? inner.slice(0, pipe) : inner).trim();
+			const display = pipe >= 0 ? inner.slice(pipe + 1) : null;
+
+			// Already a path (contains /) or a block ref — leave as-is.
+			if (target.includes('/') || target.includes('#')) return whole;
+
+			const paths = index.basenameMap.get(target.toLowerCase());
+			if (!paths || paths.length < 2) return whole;
+
+			// Use the first known path as the canonical (same as write order).
+			// The display text is the original target name, or the explicit display if given.
+			const canonical = paths[0];
+			const displayText = display ?? target;
+			return `${bang}[[${canonical}|${displayText}]]`;
 		})
 	);
 }

--- a/src/formats/logseq/normalize.ts
+++ b/src/formats/logseq/normalize.ts
@@ -9,11 +9,16 @@ const EMPTY_BULLET = /^\s*-\s*$/;
 // because the anchor may be referenced elsewhere.
 const ANCHOR_BULLET = /^\s*-\s+\^[A-Za-z0-9_-]+\s*$/;
 
+// Matches a fenced code-block delimiter. A fence can be a standard ``` line or a
+// bullet-prefixed one (- ``` or \t- ```) since the Logseq pipeline preserves
+// code blocks nested inside list bullets.
+const FENCE_LINE = /^\s*(?:-\s+)?```/;
+
 export function normalizeWhitespace(content: string): string {
 	const out: string[] = [];
 	let inFence = false;
 	for (const line of content.split('\n')) {
-		if (/^\s*```/.test(line)) {
+		if (FENCE_LINE.test(line)) {
 			inFence = !inFence;
 			out.push(line);
 			continue;

--- a/src/formats/logseq/normalize.ts
+++ b/src/formats/logseq/normalize.ts
@@ -1,0 +1,33 @@
+// Whitespace cleanup for imported Logseq content. Obsidian-free and pure so it
+// stays unit-testable. Source graphs accumulate trailing whitespace, lone empty
+// bullets, and non-breaking spaces (from Confluence/Word paste); this removes
+// them while leaving fenced code blocks and intentional blank lines untouched.
+
+// A lone bullet with nothing but optional whitespace after the dash.
+const EMPTY_BULLET = /^\s*-\s*$/;
+// An empty bullet that still carries a block anchor, e.g. `- ^abc123` — kept
+// because the anchor may be referenced elsewhere.
+const ANCHOR_BULLET = /^\s*-\s+\^[A-Za-z0-9_-]+\s*$/;
+
+export function normalizeWhitespace(content: string): string {
+	const out: string[] = [];
+	let inFence = false;
+	for (const line of content.split('\n')) {
+		if (/^\s*```/.test(line)) {
+			inFence = !inFence;
+			out.push(line);
+			continue;
+		}
+		if (inFence) {
+			out.push(line);
+			continue;
+		}
+		// Drop lone empty bullets, but keep ones that carry a block anchor.
+		if (EMPTY_BULLET.test(line) && !ANCHOR_BULLET.test(line)) {
+			continue;
+		}
+		// Normalize non-breaking spaces, then strip trailing whitespace.
+		out.push(line.replace(/\u00A0/g, ' ').replace(/[ \t]+$/, ''));
+	}
+	return out.join('\n');
+}

--- a/src/formats/logseq/options.ts
+++ b/src/formats/logseq/options.ts
@@ -8,14 +8,6 @@ export type TaskFormat =
 	| 'tasks-dataview'; // Tasks plugin, Dataview inline-field metadata
 // 'tasknotes' (one note per task) is a later phase and intentionally omitted for now.
 
-/** How Logseq's outline (everything-is-a-bullet) structure is serialized. */
-export type OutlineMode =
-	| 'preserve' // keep blocks as bullets (lossless, default)
-	| 'flatten'; // de-outline into paragraphs and headings (experimental)
-
-/** Which note kinds the flatten transform applies to. */
-export type FlattenScope = 'pages' | 'journals' | 'both';
-
 /** Generic keep-or-drop choice for Logseq-only content. */
 export type KeepOrDrop = 'keep' | 'drop';
 
@@ -23,39 +15,107 @@ export interface LogseqImportOptions {
 	/** Task target format. */
 	taskFormat: TaskFormat;
 
-	/** Outline handling. */
-	outlineMode: OutlineMode;
-	/** When outlineMode is 'flatten', which note kinds to flatten. */
-	flattenScope: FlattenScope;
+	// --- Journals ---
 
+	/**
+	 * When true, journal folder and date format are taken from the Daily Notes core plugin
+	 * and the custom fields below are ignored.
+	 */
+	useDailyNotes: boolean;
 	/** Target Obsidian daily-note filename format (moment.js tokens), e.g. 'YYYY-MM-DD'. */
 	journalDateFormat: string;
-	/** Vault-relative folder for imported journals (daily notes). */
+	/** Vault-relative folder (relative to output) for imported journals. */
 	journalFolder: string;
+	/** Flatten the outline for journal notes. */
+	deOutlineJournals: boolean;
 
-	/** Keep or drop LOGBOOK / CLOCK time-tracking blocks. */
+	// --- Pages ---
+
+	/** Vault-relative folder (relative to output) for imported pages. Empty = output root. */
+	pagesFolder: string;
+	/** Flatten the outline for page notes. */
+	deOutlinePages: boolean;
+
+	// --- Logseq-only content (each independently keep or drop) ---
+
+	/** LOGBOOK / CLOCK time-tracking blocks. */
 	logbook: KeepOrDrop;
-	/** Keep (verbatim) or drop Logseq-only content: queries, flashcards, macros, templates. */
-	logseqOnlyContent: KeepOrDrop;
+	/** `{{query}}` / `#+BEGIN_QUERY` blocks. */
+	queries: KeepOrDrop;
+	/** `#card` flashcard markers and `{{cloze}}` wrappers. */
+	flashcards: KeepOrDrop;
 
-	/** Shorten Logseq block UUIDs to Obsidian-style short anchors. */
-	shortenBlockIds: boolean;
+	// --- Properties ---
+
+	/**
+	 * Page-level property keys (frontmatter) to exclude from output.
+	 * Good defaults: Logseq-only keys that don't map to anything in Obsidian.
+	 */
+	dropPageProperties: string[];
+	/**
+	 * Inline block-property keys to strip from the note body.
+	 * Keys that start with `logseq.` or `query-` are always stripped regardless.
+	 */
+	dropBlockProperties: string[];
+
+	// --- Tags ---
 
 	/** Convert `#tag` / `#[[tag]]` to `[[tag]]` wikilinks instead of keeping them as tags. */
 	convertTagsToLinks: boolean;
+	/**
+	 * When converting tags to links, only convert tags that have a corresponding page in the
+	 * graph. Tags with no matching page are kept as tags.
+	 * Only applies when convertTagsToLinks is true.
+	 */
+	convertTagsOnlyExistingPages: boolean;
+	/** Tags to remove entirely (from body text and frontmatter). */
+	dropTags: string[];
+
+	// --- Block references ---
+
+	/** Shorten Logseq block UUIDs to Obsidian-style short anchors. */
+	shortenBlockIds: boolean;
+	/** Remove `((uuid))` block references that could not be resolved to a known block. */
+	removeOrphanBlockRefs: boolean;
+
+	// --- Assets ---
+
 	/** Preserve image alt text as the wikilink display text (`![[x|alt]]`). */
 	keepAssetAltText: boolean;
 }
 
+// Logseq-only page properties that have no Obsidian equivalent and are safe to drop from
+// frontmatter. Users may add their own to dropPageProperties.
+export const DEFAULT_DROP_PAGE_PROPERTIES = ['public', 'exclude-from-graph-view'];
+
+// Additional block properties to strip beyond the always-dropped Logseq-internal set.
+// Users may extend dropBlockProperties with their own graph-specific keys.
+export const DEFAULT_DROP_BLOCK_PROPERTIES: string[] = [];
+
 export const DEFAULT_LOGSEQ_OPTIONS: LogseqImportOptions = {
 	taskFormat: 'tasks-emoji',
-	outlineMode: 'preserve',
-	flattenScope: 'pages',
+
+	useDailyNotes: true,
 	journalDateFormat: 'YYYY-MM-DD',
 	journalFolder: '',
+	deOutlineJournals: false,
+
+	pagesFolder: '',
+	deOutlinePages: false,
+
 	logbook: 'drop',
-	logseqOnlyContent: 'keep',
-	shortenBlockIds: true,
+	queries: 'keep',
+	flashcards: 'keep',
+
+	dropPageProperties: [...DEFAULT_DROP_PAGE_PROPERTIES],
+	dropBlockProperties: [...DEFAULT_DROP_BLOCK_PROPERTIES],
+
 	convertTagsToLinks: false,
+	convertTagsOnlyExistingPages: true,
+	dropTags: ['card'],
+
+	shortenBlockIds: true,
+	removeOrphanBlockRefs: false,
+
 	keepAssetAltText: false,
 };

--- a/src/formats/logseq/options.ts
+++ b/src/formats/logseq/options.ts
@@ -1,0 +1,61 @@
+// User-configurable options for the Logseq importer. See
+// docs/logseq-importer-assessment.md for the rationale behind each one.
+
+/** How rich Logseq tasks are rendered in the Obsidian vault. */
+export type TaskFormat =
+	| 'plain' // native checkboxes only, metadata flattened into text
+	| 'tasks-emoji' // Tasks plugin, emoji-style metadata (default)
+	| 'tasks-dataview'; // Tasks plugin, Dataview inline-field metadata
+// 'tasknotes' (one note per task) is a later phase and intentionally omitted for now.
+
+/** How Logseq's outline (everything-is-a-bullet) structure is serialized. */
+export type OutlineMode =
+	| 'preserve' // keep blocks as bullets (lossless, default)
+	| 'flatten'; // de-outline into paragraphs and headings (experimental)
+
+/** Which note kinds the flatten transform applies to. */
+export type FlattenScope = 'pages' | 'journals' | 'both';
+
+/** Generic keep-or-drop choice for Logseq-only content. */
+export type KeepOrDrop = 'keep' | 'drop';
+
+export interface LogseqImportOptions {
+	/** Task target format. */
+	taskFormat: TaskFormat;
+
+	/** Outline handling. */
+	outlineMode: OutlineMode;
+	/** When outlineMode is 'flatten', which note kinds to flatten. */
+	flattenScope: FlattenScope;
+
+	/** Target Obsidian daily-note filename format (moment.js tokens), e.g. 'YYYY-MM-DD'. */
+	journalDateFormat: string;
+	/** Vault-relative folder for imported journals (daily notes). */
+	journalFolder: string;
+
+	/** Keep or drop LOGBOOK / CLOCK time-tracking blocks. */
+	logbook: KeepOrDrop;
+	/** Keep (verbatim) or drop Logseq-only content: queries, flashcards, macros, templates. */
+	logseqOnlyContent: KeepOrDrop;
+
+	/** Shorten Logseq block UUIDs to Obsidian-style short anchors. */
+	shortenBlockIds: boolean;
+
+	/** Convert `#tag` / `#[[tag]]` to `[[tag]]` wikilinks instead of keeping them as tags. */
+	convertTagsToLinks: boolean;
+	/** Preserve image alt text as the wikilink display text (`![[x|alt]]`). */
+	keepAssetAltText: boolean;
+}
+
+export const DEFAULT_LOGSEQ_OPTIONS: LogseqImportOptions = {
+	taskFormat: 'tasks-emoji',
+	outlineMode: 'preserve',
+	flattenScope: 'pages',
+	journalDateFormat: 'YYYY-MM-DD',
+	journalFolder: '',
+	logbook: 'drop',
+	logseqOnlyContent: 'keep',
+	shortenBlockIds: true,
+	convertTagsToLinks: false,
+	keepAssetAltText: false,
+};

--- a/src/formats/logseq/options.ts
+++ b/src/formats/logseq/options.ts
@@ -77,6 +77,12 @@ export interface LogseqImportOptions {
 	shortenBlockIds: boolean;
 	/** Remove `((uuid))` block references that could not be resolved to a known block. */
 	removeOrphanBlockRefs: boolean;
+	/**
+	 * Convert bare `((uuid))` block references to embeds (`![[Page#^id]]`) instead of
+	 * plain links (`[[Page#^id]]`). Block embeds (`{{embed ((uuid))}}`) are always
+	 * converted to embeds regardless of this setting.
+	 */
+	alwaysEmbedBlockRefs: boolean;
 
 	// --- Assets ---
 
@@ -116,6 +122,7 @@ export const DEFAULT_LOGSEQ_OPTIONS: LogseqImportOptions = {
 
 	shortenBlockIds: true,
 	removeOrphanBlockRefs: false,
+	alwaysEmbedBlockRefs: false,
 
 	keepAssetAltText: false,
 };

--- a/src/formats/logseq/options.ts
+++ b/src/formats/logseq/options.ts
@@ -67,6 +67,14 @@ export interface LogseqImportOptions {
 	 * - `drop`  — remove the line entirely.
 	 */
 	blockProperties: BlockPropertyMode;
+	/**
+	 * Convert kebab-case page-property keys (frontmatter) to snake_case, e.g.
+	 * `test-hyphen` → `test_hyphen`. Hyphens can break Bases/Dataview query syntax
+	 * (`note["test-hyphen"]` vs. `test_underscore`).
+	 */
+	snakeCasePageProperties: boolean;
+	/** Same as `snakeCasePageProperties`, but for inline block-property keys. */
+	snakeCaseBlockProperties: boolean;
 
 	// --- Tags ---
 
@@ -134,6 +142,8 @@ export const DEFAULT_LOGSEQ_OPTIONS: LogseqImportOptions = {
 	dropPageProperties: [...DEFAULT_DROP_PAGE_PROPERTIES],
 	dropBlockProperties: [...DEFAULT_DROP_BLOCK_PROPERTIES],
 	blockProperties: 'wrap',
+	snakeCasePageProperties: false,
+	snakeCaseBlockProperties: false,
 
 	convertTagsToLinks: false,
 	convertTagsOnlyExistingPages: true,

--- a/src/formats/logseq/options.ts
+++ b/src/formats/logseq/options.ts
@@ -11,6 +11,9 @@ export type TaskFormat =
 /** Generic keep-or-drop choice for Logseq-only content. */
 export type KeepOrDrop = 'keep' | 'drop';
 
+/** How retained (unknown) inline block properties are emitted. */
+export type BlockPropertyMode = 'keep' | 'wrap' | 'drop';
+
 export interface LogseqImportOptions {
 	/** Task target format. */
 	taskFormat: TaskFormat;
@@ -57,6 +60,13 @@ export interface LogseqImportOptions {
 	 * Keys that start with `logseq.` or `query-` are always stripped regardless.
 	 */
 	dropBlockProperties: string[];
+	/**
+	 * How to render retained (unknown) inline block properties:
+	 * - `keep`  — leave the raw `key:: value` line.
+	 * - `wrap`  — rewrite to a Dataview inline field `[key:: value]` (default).
+	 * - `drop`  — remove the line entirely.
+	 */
+	blockProperties: BlockPropertyMode;
 
 	// --- Tags ---
 
@@ -88,11 +98,19 @@ export interface LogseqImportOptions {
 
 	/** Preserve image alt text as the wikilink display text (`![[x|alt]]`). */
 	keepAssetAltText: boolean;
+
+	// --- Cleanup ---
+
+	/**
+	 * Trim trailing whitespace, remove lone empty bullets, and normalize
+	 * non-breaking spaces (U+00A0) to regular spaces. Default true.
+	 */
+	normalizeWhitespace: boolean;
 }
 
 // Logseq-only page properties that have no Obsidian equivalent and are safe to drop from
 // frontmatter. Users may add their own to dropPageProperties.
-export const DEFAULT_DROP_PAGE_PROPERTIES = ['public', 'exclude-from-graph-view'];
+export const DEFAULT_DROP_PAGE_PROPERTIES = ['public', 'exclude-from-graph-view', 'icon'];
 
 // Additional block properties to strip beyond the always-dropped Logseq-internal set.
 // Users may extend dropBlockProperties with their own graph-specific keys.
@@ -115,6 +133,7 @@ export const DEFAULT_LOGSEQ_OPTIONS: LogseqImportOptions = {
 
 	dropPageProperties: [...DEFAULT_DROP_PAGE_PROPERTIES],
 	dropBlockProperties: [...DEFAULT_DROP_BLOCK_PROPERTIES],
+	blockProperties: 'wrap',
 
 	convertTagsToLinks: false,
 	convertTagsOnlyExistingPages: true,
@@ -125,4 +144,6 @@ export const DEFAULT_LOGSEQ_OPTIONS: LogseqImportOptions = {
 	alwaysEmbedBlockRefs: false,
 
 	keepAssetAltText: false,
+
+	normalizeWhitespace: true,
 };

--- a/src/formats/logseq/paths.ts
+++ b/src/formats/logseq/paths.ts
@@ -1,0 +1,50 @@
+// Pure helpers for translating Logseq page filenames into vault-relative paths.
+//
+// Logseq stores namespaced pages as flat files whose name encodes the namespace.
+// The default separator for `/` is the triple underscore `___`; some older
+// graphs use the percent-encoded `%2F`. Other special characters in titles may
+// be percent-encoded too (e.g. `%3A` for `:`).
+
+// Matches one or more consecutive valid percent-escapes. Decoding a whole run
+// at once keeps multi-byte UTF-8 sequences (e.g. `%C3%A9`) intact.
+const PERCENT_RUN = /(?:%[0-9A-Fa-f]{2})+/g;
+
+/**
+ * Percent-decode a Logseq filename body tolerantly: valid escapes are decoded,
+ * while malformed sequences (e.g. `%ZZ`, a lone `%2`, a bare `%`) are left
+ * unchanged instead of throwing. The `___` namespace separator is untouched.
+ */
+export function decodeLogseqName(name: string): string {
+	return name.replace(PERCENT_RUN, (run) => {
+		try {
+			return decodeURIComponent(run);
+		} catch {
+			// Valid hex escapes that don't form valid UTF-8: leave as-is.
+			return run;
+		}
+	});
+}
+
+/**
+ * Convert a Logseq page filename body (without `.md`) into a vault-relative
+ * page path (without extension), turning namespace separators into `/`.
+ *
+ * Splits on `%2F` if present, otherwise on `___`. Single `/` and single `_`
+ * are not separators. Each segment is percent-decoded. OS-illegal-character
+ * sanitization is intentionally left to the caller.
+ */
+export function namespaceToPath(filenameBody: string): string {
+	const separator = /%2F/i.test(filenameBody) ? /%2F/i : '___';
+	return filenameBody
+		.split(separator)
+		.map(decodeLogseqName)
+		.join('/');
+}
+
+/**
+ * Alias of {@link namespaceToPath}, named for use by the link rewriter when
+ * mapping a wikilink target to its on-disk page path.
+ */
+export function pageNameToPath(filenameBody: string): string {
+	return namespaceToPath(filenameBody);
+}

--- a/src/formats/logseq/paths.ts
+++ b/src/formats/logseq/paths.ts
@@ -18,7 +18,8 @@ export function decodeLogseqName(name: string): string {
 	return name.replace(PERCENT_RUN, (run) => {
 		try {
 			return decodeURIComponent(run);
-		} catch {
+		}
+		catch {
 			// Valid hex escapes that don't form valid UTF-8: leave as-is.
 			return run;
 		}

--- a/src/formats/logseq/pipeline.ts
+++ b/src/formats/logseq/pipeline.ts
@@ -72,7 +72,7 @@ export function indexPageAliases(
 	aliasMap: Map<string, string>,
 	ambiguous: Set<string>
 ): void {
-	// Collect all alias values: alias/aliases properties plus the title:: value (M3).
+	// Collect all alias values: alias/aliases properties plus the title:: value (G1).
 	const aliasValues: string[] = [];
 	if (raw.alias ?? raw.aliases) aliasValues.push(raw.alias ?? raw.aliases);
 	if (raw.title) aliasValues.push(raw.title);
@@ -95,3 +95,4 @@ export function indexPageAliases(
 export function isBodyEmpty(yaml: string, body: string): boolean {
 	return !yaml && !body.trim();
 }
+

--- a/src/formats/logseq/pipeline.ts
+++ b/src/formats/logseq/pipeline.ts
@@ -1,21 +1,21 @@
 // Pure pass-1 conversion pipeline: everything that can be done on a single file
 // without the vault-wide block/alias index. Kept obsidian-free so it is unit
 // testable. The orchestrator runs the cross-file pass-2 steps (block-ref and
-// alias-reference resolution) afterwards.
+// alias-reference resolution, tag conversion) afterwards.
 
 import { LogseqImportOptions } from './options';
 import { extractPageProperties, convertHeadingProperty, removeLeftoverBlockProperties } from './properties';
 import { convertTasks } from './tasks';
 import { convertNumberedLists, convertOrgBlocks, convertHighlights, convertMediaEmbeds, fixCodeBlocksInLists, fixHeadingChildLists } from './blocks';
 import { convertAssetLinks, AssetRef } from './assets';
-import { convertAliasLinks, convertTags } from './links';
+import { convertAliasLinks } from './links';
 import { convertJournalDateLinks } from './journals';
 import { attachBlockIds, DefinedId } from './block-ids';
 
 export interface LocalResult {
 	/** YAML frontmatter block (with fences) or '' when there are no page properties. */
 	yaml: string;
-	/** Converted body, still containing `((uuid))` refs and alias references for pass 2. */
+	/** Converted body, still containing `((uuid))` refs, alias references, and tags for pass 2. */
 	body: string;
 	/** Raw page properties (e.g. alias/aliases/title) for index building. */
 	raw: Record<string, string>;
@@ -26,7 +26,10 @@ export interface LocalResult {
 }
 
 export function convertLocal(content: string, options: LogseqImportOptions): LocalResult {
-	const { yaml, body: initialBody, raw } = extractPageProperties(content);
+	const { yaml, body: initialBody, raw } = extractPageProperties(content, {
+		dropPageProperties: options.dropPageProperties,
+		dropTags: options.dropTags,
+	});
 
 	let body = initialBody;
 	body = convertHeadingProperty(body);
@@ -42,13 +45,14 @@ export function convertLocal(content: string, options: LogseqImportOptions): Loc
 	body = assetResult.content;
 
 	body = convertAliasLinks(body);
-	body = convertTags(body, options.convertTagsToLinks);
+	// Note: convertTags is intentionally deferred to pass-2 in the orchestrator so it can
+	// use the vault-wide page set for onlyExistingPages logic.
 	body = convertJournalDateLinks(body);
 
 	const idResult = attachBlockIds(body, options.shortenBlockIds);
 	body = idResult.content;
 
-	body = removeLeftoverBlockProperties(body);
+	body = removeLeftoverBlockProperties(body, options.dropBlockProperties);
 
 	return { yaml, body, raw, ids: idResult.ids, assets: assetResult.assets };
 }

--- a/src/formats/logseq/pipeline.ts
+++ b/src/formats/logseq/pipeline.ts
@@ -11,6 +11,7 @@ import { convertAssetLinks, AssetRef } from './assets';
 import { convertAliasLinks } from './links';
 import { convertJournalDateLinks } from './journals';
 import { attachBlockIds, DefinedId } from './block-ids';
+import { normalizeWhitespace } from './normalize';
 
 export interface LocalResult {
 	/** YAML frontmatter block (with fences) or '' when there are no page properties. */
@@ -52,7 +53,11 @@ export function convertLocal(content: string, options: LogseqImportOptions): Loc
 	const idResult = attachBlockIds(body, options.shortenBlockIds);
 	body = idResult.content;
 
-	body = removeLeftoverBlockProperties(body, options.dropBlockProperties);
+	body = removeLeftoverBlockProperties(body, options.dropBlockProperties, options.blockProperties);
+
+	if (options.normalizeWhitespace) {
+		body = normalizeWhitespace(body);
+	}
 
 	return { yaml, body, raw, ids: idResult.ids, assets: assetResult.assets };
 }

--- a/src/formats/logseq/pipeline.ts
+++ b/src/formats/logseq/pipeline.ts
@@ -30,6 +30,7 @@ export function convertLocal(content: string, options: LogseqImportOptions): Loc
 	const { yaml, body: initialBody, raw } = extractPageProperties(content, {
 		dropPageProperties: options.dropPageProperties,
 		dropTags: options.dropTags,
+		snakeCasePageProperties: options.snakeCasePageProperties,
 	});
 
 	let body = initialBody;
@@ -53,7 +54,7 @@ export function convertLocal(content: string, options: LogseqImportOptions): Loc
 	const idResult = attachBlockIds(body, options.shortenBlockIds);
 	body = idResult.content;
 
-	body = removeLeftoverBlockProperties(body, options.dropBlockProperties, options.blockProperties);
+	body = removeLeftoverBlockProperties(body, options.dropBlockProperties, options.blockProperties, options.snakeCaseBlockProperties);
 
 	if (options.normalizeWhitespace) {
 		body = normalizeWhitespace(body);

--- a/src/formats/logseq/pipeline.ts
+++ b/src/formats/logseq/pipeline.ts
@@ -56,3 +56,37 @@ export function convertLocal(content: string, options: LogseqImportOptions): Loc
 
 	return { yaml, body, raw, ids: idResult.ids, assets: assetResult.assets };
 }
+
+/**
+ * Register all aliases (and the title, if present) for a page in the shared alias map.
+ * `raw` is the raw page properties from `convertLocal`.
+ */
+export function indexPageAliases(
+	raw: Record<string, string>,
+	canonical: string,
+	aliasMap: Map<string, string>,
+	ambiguous: Set<string>
+): void {
+	// Collect all alias values: alias/aliases properties plus the title:: value (M3).
+	const aliasValues: string[] = [];
+	if (raw.alias ?? raw.aliases) aliasValues.push(raw.alias ?? raw.aliases);
+	if (raw.title) aliasValues.push(raw.title);
+	for (const value of aliasValues) {
+		for (const item of value.split(',')) {
+			const name = item.trim().replace(/^\[\[(.*)\]\]$/, '$1').trim();
+			if (!name) continue;
+			const key = name.toLowerCase();
+			const existing = aliasMap.get(key);
+			if (existing !== undefined && existing !== canonical) ambiguous.add(key);
+			else aliasMap.set(key, canonical);
+		}
+	}
+}
+
+/**
+ * Returns true when the page has no meaningful content: no YAML frontmatter and
+ * a blank/whitespace-only body. Used to skip writing empty output files.
+ */
+export function isBodyEmpty(yaml: string, body: string): boolean {
+	return !yaml && !body.trim();
+}

--- a/src/formats/logseq/pipeline.ts
+++ b/src/formats/logseq/pipeline.ts
@@ -1,0 +1,54 @@
+// Pure pass-1 conversion pipeline: everything that can be done on a single file
+// without the vault-wide block/alias index. Kept obsidian-free so it is unit
+// testable. The orchestrator runs the cross-file pass-2 steps (block-ref and
+// alias-reference resolution) afterwards.
+
+import { LogseqImportOptions } from './options';
+import { extractPageProperties, convertHeadingProperty, removeLeftoverBlockProperties } from './properties';
+import { convertTasks } from './tasks';
+import { convertNumberedLists, convertOrgBlocks, convertHighlights, convertMediaEmbeds, fixCodeBlocksInLists, fixHeadingChildLists } from './blocks';
+import { convertAssetLinks, AssetRef } from './assets';
+import { convertAliasLinks, convertTags } from './links';
+import { convertJournalDateLinks } from './journals';
+import { attachBlockIds, DefinedId } from './block-ids';
+
+export interface LocalResult {
+	/** YAML frontmatter block (with fences) or '' when there are no page properties. */
+	yaml: string;
+	/** Converted body, still containing `((uuid))` refs and alias references for pass 2. */
+	body: string;
+	/** Raw page properties (e.g. alias/aliases/title) for index building. */
+	raw: Record<string, string>;
+	/** Block ids defined in this file (uuid -> short anchor). */
+	ids: DefinedId[];
+	/** Assets referenced by this file. */
+	assets: AssetRef[];
+}
+
+export function convertLocal(content: string, options: LogseqImportOptions): LocalResult {
+	const { yaml, body: initialBody, raw } = extractPageProperties(content);
+
+	let body = initialBody;
+	body = convertHeadingProperty(body);
+	body = convertTasks(body, options.taskFormat, { logbook: options.logbook });
+	body = convertNumberedLists(body);
+	body = convertOrgBlocks(body);
+	body = convertHighlights(body);
+	body = convertMediaEmbeds(body);
+	body = fixHeadingChildLists(body);
+	body = fixCodeBlocksInLists(body);
+
+	const assetResult = convertAssetLinks(body, { keepAltText: options.keepAssetAltText });
+	body = assetResult.content;
+
+	body = convertAliasLinks(body);
+	body = convertTags(body, options.convertTagsToLinks);
+	body = convertJournalDateLinks(body);
+
+	const idResult = attachBlockIds(body, options.shortenBlockIds);
+	body = idResult.content;
+
+	body = removeLeftoverBlockProperties(body);
+
+	return { yaml, body, raw, ids: idResult.ids, assets: assetResult.assets };
+}

--- a/src/formats/logseq/properties.ts
+++ b/src/formats/logseq/properties.ts
@@ -6,7 +6,10 @@
 
 const PROPERTY_LINE = /^([A-Za-z0-9_.\-]+):: ?(.*)$/;
 // Also matches bullet-form block properties: `- key:: value`
-const BLOCK_PROPERTY_LINE = /^(\s*)(?:- )?([A-Za-z0-9_.\-]+):: ?(.*)$/;
+// Groups: 1=indent, 2=bullet (`- ` or undefined), 3=key, 4=value.
+const BLOCK_PROPERTY_LINE = /^(\s*)(- )?([A-Za-z0-9_.\-]+):: ?(.*)$/;
+// A trailing Logseq block anchor on a property value, e.g. ` ^68dc12`.
+const BLOCK_ANCHOR = /\s+(\^[A-Za-z0-9_-]+)\s*$/;
 
 // Block properties that are always dropped regardless of user config.
 // These are purely Logseq-internal and have no meaning in Obsidian.
@@ -227,19 +230,115 @@ export function extractPageProperties(content: string, opts: ExtractPageProperti
 	return { yaml, body: bodyLines.join('\n'), raw };
 }
 
-export function removeLeftoverBlockProperties(content: string, dropBlockProperties: string[] = []): string {
+/** How retained (unknown) inline block properties are emitted. */
+export type BlockPropertyMode = 'keep' | 'wrap' | 'drop';
+
+function isAlwaysDroppedBlockProp(key: string, userDrop: Set<string>): boolean {
+	if (ALWAYS_DROP_HL_PROPS(key)) return true;
+	if (key.startsWith('logseq.')) return true;
+	if (key.startsWith('query-')) return true;
+	return ALWAYS_DROP_BLOCK_PROPS.has(key) || userDrop.has(key);
+}
+
+/**
+ * Rewrite a retained `key:: value` line into a Dataview inline field
+ * `[key:: value]`, preserving indentation, any bullet prefix, and a trailing
+ * `^anchor`. Falls back to the original line when the value is empty or would
+ * break the inline-field bracket syntax (contains a stray `]`/`[` outside of a
+ * `[[wikilink]]`).
+ */
+function wrapBlockProperty(line: string, m: RegExpMatchArray): string {
+	const indent = m[1];
+	const bullet = m[2] ?? '';
+	const key = m[3];
+	let value = m[4];
+	let anchor = '';
+	const am = value.match(BLOCK_ANCHOR);
+	if (am) {
+		anchor = am[1];
+		value = value.slice(0, am.index);
+	}
+	const core = value.trim();
+	if (core === '') return line;
+	// Dataview inline fields can't contain a stray `]`/`[`; wikilinks are fine.
+	const withoutLinks = core.replace(/\[\[[^\]]*\]\]/g, '');
+	if (withoutLinks.includes(']') || withoutLinks.includes('[')) return line;
+	const wrapped = `${indent}${bullet}[${key}:: ${core}]`;
+	return anchor ? `${wrapped} ${anchor}` : wrapped;
+}
+
+export function removeLeftoverBlockProperties(
+	content: string,
+	dropBlockProperties: string[] = [],
+	mode: BlockPropertyMode = 'keep'
+): string {
 	const userDrop = new Set(dropBlockProperties);
-	return content
+	const out: string[] = [];
+	let inFence = false;
+	for (const line of content.split('\n')) {
+		if (/^\s*```/.test(line)) {
+			inFence = !inFence;
+			out.push(line);
+			continue;
+		}
+		if (inFence) {
+			out.push(line);
+			continue;
+		}
+		const m = line.match(BLOCK_PROPERTY_LINE);
+		if (!m) {
+			out.push(line);
+			continue;
+		}
+		const key = m[3];
+		// The always-drop set wins in every mode.
+		if (isAlwaysDroppedBlockProp(key, userDrop)) continue;
+		// Retained unknown key: apply the configured mode.
+		if (mode === 'drop') continue;
+		if (mode === 'wrap') {
+			out.push(wrapBlockProperty(line, m));
+			continue;
+		}
+		out.push(line); // keep
+	}
+	return out.join('\n');
+}
+
+export interface LinkifyTagValuesOptions {
+	/** Set of known page canonical names (lower-cased) for page-existence checks. */
+	knownPages: Set<string>;
+	/** Convert tag-style values to wikilinks. When false, the yaml is returned unchanged. */
+	toLinks: boolean;
+	/** Only linkify tags that resolve to an existing page. */
+	onlyExistingPages: boolean;
+}
+
+// A frontmatter scalar line whose value is a single, quoted Logseq tag token,
+// e.g. `status: "#IN-PROGRESS"` or `area: "#[[Page One]]"`.
+const TAG_VALUE_LINE = /^(\s*[A-Za-z0-9_.\-]+: )"(#(?:\[\[[^\]]+\]\]|[\w/-]+))"$/;
+
+/**
+ * Rewrite tag-style frontmatter scalar values (`key: "#tag"`) into wikilinks
+ * (`key: "[[tag]]"`) using the vault-wide page set. Must run in pass-2 where
+ * `knownPages` is available. Respects the user's tag-conversion options; when
+ * `toLinks` is off the yaml is returned unchanged (values stay quoted text).
+ * List values (`tags:` / `aliases:`) are untouched — they are multi-line and
+ * never match the single-scalar pattern.
+ */
+export function linkifyTagValuesInFrontmatter(yaml: string, opts: LinkifyTagValuesOptions): string {
+	if (!yaml || !opts.toLinks) return yaml;
+	const { knownPages, onlyExistingPages } = opts;
+	return yaml
 		.split('\n')
-		.filter(line => {
-			const m = line.match(BLOCK_PROPERTY_LINE);
-			if (!m) return true;
-			const key = m[2];
-			// M2: drop PDF-annotation props (hl-* / ls-* prefix).
-			if (ALWAYS_DROP_HL_PROPS(key)) return false;
-			if (key.startsWith('logseq.')) return false;
-			if (key.startsWith('query-')) return false;
-			return !ALWAYS_DROP_BLOCK_PROPS.has(key) && !userDrop.has(key);
+		.map(line => {
+			const m = line.match(TAG_VALUE_LINE);
+			if (!m) return line;
+			const prefix = m[1];
+			const token = m[2];
+			const multi = token.match(/^#\[\[([^\]]+)\]\]$/);
+			const name = multi ? multi[1] : token.slice(1);
+			if (onlyExistingPages && !knownPages.has(name.toLowerCase())) return line;
+			return `${prefix}"[[${name}]]"`;
 		})
 		.join('\n');
 }

--- a/src/formats/logseq/properties.ts
+++ b/src/formats/logseq/properties.ts
@@ -14,6 +14,8 @@ const BLOCK_ANCHOR = /\s+(\^[A-Za-z0-9_-]+)\s*$/;
 // Block properties that are always dropped regardless of user config.
 // These are purely Logseq-internal and have no meaning in Obsidian.
 const ALWAYS_DROP_BLOCK_PROPS = new Set([
+	'alias',
+	'aliases',
 	'collapsed',
 	'background-color',
 	'heading',
@@ -25,11 +27,27 @@ const ALWAYS_DROP_BLOCK_PROPS = new Set([
 	'filters',
 	'public',
 	'exclude-from-graph-view',
+	'template',
+	'template-including-parent',
 ]);
 
-// Logseq PDF-annotation internal properties — always dropped.
-const ALWAYS_DROP_HL_PROPS = (key: string): boolean =>
-	key.startsWith('hl-') || key.startsWith('ls-');
+// Page properties that are always dropped regardless of user config.
+// These are Logseq UI/internal properties with no equivalent in Obsidian.
+const ALWAYS_DROP_PAGE_PROPS = new Set([
+	'collapsed',
+	'filters',
+	'background-color',
+	'heading',
+	'template',
+	'template-including-parent',
+]);
+
+// Prefix-based always-drop rules for both page and block properties.
+const isAlwaysDroppedByPrefix = (key: string): boolean =>
+	key.startsWith('hl-') ||
+	key.startsWith('ls-') ||
+	key.startsWith('logseq.') ||
+	key.startsWith('query-');
 
 export interface PageProperties {
 	/** YAML frontmatter block including `---` fences, or '' when there are none. */
@@ -145,6 +163,8 @@ function emitProperty(key: string, value: string, aliases: string[], dropPagePro
 		if (items.length === 0) return [];
 		return ['tags:', ...items.map(i => `  - ${i}`)];
 	}
+	// Always-drop Logseq-internal keys take precedence over user config.
+	if (isAlwaysDroppedPageProp(key)) return [];
 	if (dropPageProps.has(key)) return [];
 
 	// I1: created/updated wikilink dates → plain ISO.
@@ -234,10 +254,13 @@ export function extractPageProperties(content: string, opts: ExtractPageProperti
 export type BlockPropertyMode = 'keep' | 'wrap' | 'drop';
 
 function isAlwaysDroppedBlockProp(key: string, userDrop: Set<string>): boolean {
-	if (ALWAYS_DROP_HL_PROPS(key)) return true;
-	if (key.startsWith('logseq.')) return true;
-	if (key.startsWith('query-')) return true;
+	if (isAlwaysDroppedByPrefix(key)) return true;
 	return ALWAYS_DROP_BLOCK_PROPS.has(key) || userDrop.has(key);
+}
+
+function isAlwaysDroppedPageProp(key: string): boolean {
+	if (isAlwaysDroppedByPrefix(key)) return true;
+	return ALWAYS_DROP_PAGE_PROPS.has(key);
 }
 
 /**

--- a/src/formats/logseq/properties.ts
+++ b/src/formats/logseq/properties.ts
@@ -7,8 +7,9 @@
 const PROPERTY_LINE = /^([A-Za-z0-9_.\-]+):: ?(.*)$/;
 const BLOCK_PROPERTY_LINE = /^(\s*)([A-Za-z0-9_.\-]+):: ?(.*)$/;
 
-// Logseq-internal block properties that have no meaning in Obsidian.
-const INTERNAL_BLOCK_PROPS = new Set([
+// Block properties that are always dropped regardless of user config.
+// These are purely Logseq-internal and have no meaning in Obsidian.
+const ALWAYS_DROP_BLOCK_PROPS = new Set([
 	'collapsed',
 	'background-color',
 	'heading',
@@ -59,15 +60,17 @@ function tagsFromItem(item: string): string[] {
 	return tokens;
 }
 
-function emitProperty(key: string, value: string, aliases: string[]): string[] {
+function emitProperty(key: string, value: string, aliases: string[], dropPageProps: Set<string>, dropTags: Set<string>): string[] {
 	if (key === 'alias' || key === 'aliases') {
 		for (const item of splitList(value)) aliases.push(stripWikiBrackets(item));
 		return []; // emitted later, after the whole block is parsed
 	}
 	if (key === 'tags') {
-		const items = splitList(value).flatMap(tagsFromItem);
+		const items = splitList(value).flatMap(tagsFromItem).filter(t => !dropTags.has(t));
+		if (items.length === 0) return [];
 		return ['tags:', ...items.map(i => `  - ${i}`)];
 	}
+	if (dropPageProps.has(key)) return [];
 	const parts = splitList(value);
 	const hasWiki = value.includes('[[');
 	if (hasWiki && parts.length > 1) {
@@ -79,7 +82,14 @@ function emitProperty(key: string, value: string, aliases: string[]): string[] {
 	return [`${key}: ${value}`];
 }
 
-export function extractPageProperties(content: string): PageProperties {
+export interface ExtractPagePropertiesOptions {
+	dropPageProperties?: string[];
+	dropTags?: string[];
+}
+
+export function extractPageProperties(content: string, opts: ExtractPagePropertiesOptions = {}): PageProperties {
+	const dropPageProps = new Set(opts.dropPageProperties ?? []);
+	const dropTags = new Set(opts.dropTags ?? []);
 	const lines = content.split('\n');
 	const raw: Record<string, string> = {};
 	const bodyLines: string[] = [];
@@ -95,7 +105,7 @@ export function extractPageProperties(content: string): PageProperties {
 		const value = m[2].trim();
 		raw[key] = value;
 		if (key === 'title') continue; // dropped from YAML, kept in raw
-		propLines.push(...emitProperty(key, value, aliases));
+		propLines.push(...emitProperty(key, value, aliases, dropPageProps, dropTags));
 	}
 
 	// Skip blank lines between the property block and the body.
@@ -114,7 +124,8 @@ export function extractPageProperties(content: string): PageProperties {
 	return { yaml, body: bodyLines.join('\n'), raw };
 }
 
-export function removeLeftoverBlockProperties(content: string): string {
+export function removeLeftoverBlockProperties(content: string, dropBlockProperties: string[] = []): string {
+	const userDrop = new Set(dropBlockProperties);
 	return content
 		.split('\n')
 		.filter(line => {
@@ -122,7 +133,8 @@ export function removeLeftoverBlockProperties(content: string): string {
 			if (!m) return true;
 			const key = m[2];
 			if (key.startsWith('logseq.')) return false;
-			return !INTERNAL_BLOCK_PROPS.has(key);
+			if (key.startsWith('query-')) return false;
+			return !ALWAYS_DROP_BLOCK_PROPS.has(key) && !userDrop.has(key);
 		})
 		.join('\n');
 }

--- a/src/formats/logseq/properties.ts
+++ b/src/formats/logseq/properties.ts
@@ -5,7 +5,8 @@
 // `key:: value` continuation lines; most Logseq-internal ones are dropped.
 
 const PROPERTY_LINE = /^([A-Za-z0-9_.\-]+):: ?(.*)$/;
-const BLOCK_PROPERTY_LINE = /^(\s*)([A-Za-z0-9_.\-]+):: ?(.*)$/;
+// Also matches bullet-form block properties: `- key:: value`
+const BLOCK_PROPERTY_LINE = /^(\s*)(?:- )?([A-Za-z0-9_.\-]+):: ?(.*)$/;
 
 // Block properties that are always dropped regardless of user config.
 // These are purely Logseq-internal and have no meaning in Obsidian.
@@ -23,6 +24,10 @@ const ALWAYS_DROP_BLOCK_PROPS = new Set([
 	'exclude-from-graph-view',
 ]);
 
+// Logseq PDF-annotation internal properties — always dropped.
+const ALWAYS_DROP_HL_PROPS = (key: string): boolean =>
+	key.startsWith('hl-') || key.startsWith('ls-');
+
 export interface PageProperties {
 	/** YAML frontmatter block including `---` fences, or '' when there are none. */
 	yaml: string;
@@ -37,12 +42,76 @@ function stripWikiBrackets(value: string): string {
 	return m ? m[1] : value;
 }
 
+/**
+ * Split a comma-separated property value into items, ignoring commas that
+ * appear inside `[[wikilinks]]`.  H3 fix: a single `[[Jul 18th, 2025]]`
+ * must remain one item, not split into `["[[Jul 18th"`, `"2025]]"]`.
+ */
 function splitList(value: string): string[] {
-	return value.split(',').map(v => v.trim()).filter(v => v.length > 0);
+	const items: string[] = [];
+	let current = '';
+	let depth = 0;
+	for (let i = 0; i < value.length; i++) {
+		const ch = value[i];
+		if (ch === '[' && value[i + 1] === '[') { depth++; current += ch; continue; }
+		if (ch === ']' && value[i - 1] === ']' && depth > 0) { depth--; current += ch; continue; }
+		if (ch === ',' && depth === 0) {
+			const trimmed = current.trim();
+			if (trimmed) items.push(trimmed);
+			current = '';
+		}
+		else {
+			current += ch;
+		}
+	}
+	const trimmed = current.trim();
+	if (trimmed) items.push(trimmed);
+	return items;
 }
 
+/**
+ * Return a YAML-safe double-quoted scalar.
+ * Escapes internal `"` and `\` characters.
+ */
 function quote(value: string): string {
-	return '"' + value.replace(/"/g, '\\"') + '"';
+	return '"' + value.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
+}
+
+/**
+ * Return true when a scalar MUST be quoted to round-trip safely through YAML.
+ * Covers the cases that js-yaml / Obsidian care about:
+ *  - starts with a YAML indicator character: #, [, {, >, |, *, &, !, @, `
+ *  - looks like a YAML boolean: yes/no/true/false/on/off (case-insensitive)
+ *  - looks like a number (int, float, leading-zero, hex, octal)
+ *  - contains ': ' (would be parsed as a mapping key)
+ *  - starts or ends with a quote character
+ *  - contains a wikilink `[[` (already handled upstream, but guard here too)
+ */
+const YAML_BOOL = /^(yes|no|true|false|on|off)$/i;
+const YAML_NUMBER = /^[-+]?(\d+\.?\d*|\.\d+)([eE][-+]?\d+)?$|^0[xXoObB]/;
+const YAML_LEADING_ZERO = /^0\d/;
+
+function needsQuoting(value: string): boolean {
+	if (value.length === 0) return false;
+	const first = value[0];
+	if ('#[{>|*&!@`'.includes(first)) return true;
+	if (first === '"' || first === "'") return true;
+	if (value.endsWith(':') || value.includes(': ')) return true;
+	if (YAML_BOOL.test(value)) return true;
+	if (YAML_NUMBER.test(value) || YAML_LEADING_ZERO.test(value)) return true;
+	return false;
+}
+
+/**
+ * Strip `[[wikilink]]` brackets from an ISO-date property value.
+ * e.g. `[[2024-01-16]]` → `2024-01-16`. Returns `null` if the value
+ * is not a plain ISO date (so template tokens like `{{date:…}}` are dropped).
+ */
+function extractIsoDate(value: string): string | null {
+	const clean = value.replace(/^\[\[|\]\]$/g, '').trim();
+	if (/\{\{/.test(clean)) return null; // template token
+	if (/^\d{4}-\d{2}-\d{2}$/.test(clean)) return clean;
+	return null;
 }
 
 // A single comma-separated tag entry may itself contain multiple tags, e.g.
@@ -61,6 +130,9 @@ function tagsFromItem(item: string): string[] {
 }
 
 function emitProperty(key: string, value: string, aliases: string[], dropPageProps: Set<string>, dropTags: Set<string>): string[] {
+	// L2: drop empty-valued properties.
+	if (value.trim() === '') return [];
+
 	if (key === 'alias' || key === 'aliases') {
 		for (const item of splitList(value)) aliases.push(stripWikiBrackets(item));
 		return []; // emitted later, after the whole block is parsed
@@ -71,12 +143,24 @@ function emitProperty(key: string, value: string, aliases: string[], dropPagePro
 		return ['tags:', ...items.map(i => `  - ${i}`)];
 	}
 	if (dropPageProps.has(key)) return [];
+
+	// L1: created/updated wikilink dates → plain ISO.
+	if ((key === 'created' || key === 'updated') && value.includes('[[')) {
+		const iso = extractIsoDate(value);
+		if (iso !== null) return [`${key}: ${iso}`];
+		// Fall through to normal handling if not a clean ISO date.
+	}
+
 	const parts = splitList(value);
 	const hasWiki = value.includes('[[');
 	if (hasWiki && parts.length > 1) {
 		return [`${key}:`, ...parts.map(p => `  - ${quote(p)}`)];
 	}
 	if (hasWiki) {
+		return [`${key}: ${quote(value)}`];
+	}
+	// H1-H4: apply general YAML-safe quoting to all non-wikilink scalars.
+	if (needsQuoting(value)) {
 		return [`${key}: ${quote(value)}`];
 	}
 	return [`${key}: ${value}`];
@@ -93,7 +177,9 @@ export function extractPageProperties(content: string, opts: ExtractPageProperti
 	const lines = content.split('\n');
 	const raw: Record<string, string> = {};
 	const bodyLines: string[] = [];
-	const propLines: string[] = [];
+	// L4: use a Map to deduplicate keys (last value wins).
+	const propMap = new Map<string, string[]>();
+	const propOrder: string[] = [];
 	const aliases: string[] = [];
 
 	let i = 0;
@@ -104,13 +190,30 @@ export function extractPageProperties(content: string, opts: ExtractPageProperti
 		const key = m[1];
 		const value = m[2].trim();
 		raw[key] = value;
-		if (key === 'title') continue; // dropped from YAML, kept in raw
-		propLines.push(...emitProperty(key, value, aliases, dropPageProps, dropTags));
+		if (key === 'title') continue; // kept in raw, emitted as alias below
+		const emitted = emitProperty(key, value, aliases, dropPageProps, dropTags);
+		if (emitted.length > 0) {
+			if (!propMap.has(key)) propOrder.push(key);
+			propMap.set(key, emitted);
+		}
+	}
+
+	// M3: treat title:: as an additional alias (→ Obsidian aliases field).
+	if (raw.title) {
+		const titleAlias = raw.title.replace(/^\[\[(.*)\]\]$/, '$1').trim();
+		if (titleAlias) aliases.push(titleAlias);
 	}
 
 	// Skip blank lines between the property block and the body.
 	while (i < lines.length && lines[i].trim() === '') i++;
 	for (; i < lines.length; i++) bodyLines.push(lines[i]);
+
+	// Collect emitted lines in insertion order (deduplicated).
+	const propLines: string[] = [];
+	for (const key of propOrder) {
+		const lines = propMap.get(key);
+		if (lines) propLines.push(...lines);
+	}
 
 	let yaml = '';
 	const hasAny = propLines.length > 0 || aliases.length > 0;
@@ -132,6 +235,8 @@ export function removeLeftoverBlockProperties(content: string, dropBlockProperti
 			const m = line.match(BLOCK_PROPERTY_LINE);
 			if (!m) return true;
 			const key = m[2];
+			// M2: drop PDF-annotation props (hl-* / ls-* prefix).
+			if (ALWAYS_DROP_HL_PROPS(key)) return false;
 			if (key.startsWith('logseq.')) return false;
 			if (key.startsWith('query-')) return false;
 			return !ALWAYS_DROP_BLOCK_PROPS.has(key) && !userDrop.has(key);

--- a/src/formats/logseq/properties.ts
+++ b/src/formats/logseq/properties.ts
@@ -47,7 +47,7 @@ function stripWikiBrackets(value: string): string {
 
 /**
  * Split a comma-separated property value into items, ignoring commas that
- * appear inside `[[wikilinks]]`.  H3 fix: a single `[[Jul 18th, 2025]]`
+ * appear inside `[[wikilinks]]`.  I1: a single `[[Jul 18th, 2025]]`
  * must remain one item, not split into `["[[Jul 18th"`, `"2025]]"]`.
  */
 function splitList(value: string): string[] {
@@ -133,7 +133,7 @@ function tagsFromItem(item: string): string[] {
 }
 
 function emitProperty(key: string, value: string, aliases: string[], dropPageProps: Set<string>, dropTags: Set<string>): string[] {
-	// L2: drop empty-valued properties.
+	// I1: drop empty-valued properties.
 	if (value.trim() === '') return [];
 
 	if (key === 'alias' || key === 'aliases') {
@@ -147,7 +147,7 @@ function emitProperty(key: string, value: string, aliases: string[], dropPagePro
 	}
 	if (dropPageProps.has(key)) return [];
 
-	// L1: created/updated wikilink dates → plain ISO.
+	// I1: created/updated wikilink dates → plain ISO.
 	if ((key === 'created' || key === 'updated') && value.includes('[[')) {
 		const iso = extractIsoDate(value);
 		if (iso !== null) return [`${key}: ${iso}`];
@@ -162,7 +162,7 @@ function emitProperty(key: string, value: string, aliases: string[], dropPagePro
 	if (hasWiki) {
 		return [`${key}: ${quote(value)}`];
 	}
-	// H1-H4: apply general YAML-safe quoting to all non-wikilink scalars.
+	// I1: apply general YAML-safe quoting to all non-wikilink scalars.
 	if (needsQuoting(value)) {
 		return [`${key}: ${quote(value)}`];
 	}
@@ -180,7 +180,7 @@ export function extractPageProperties(content: string, opts: ExtractPageProperti
 	const lines = content.split('\n');
 	const raw: Record<string, string> = {};
 	const bodyLines: string[] = [];
-	// L4: use a Map to deduplicate keys (last value wins).
+	// I1: use a Map to deduplicate keys (last value wins).
 	const propMap = new Map<string, string[]>();
 	const propOrder: string[] = [];
 	const aliases: string[] = [];
@@ -201,7 +201,7 @@ export function extractPageProperties(content: string, opts: ExtractPageProperti
 		}
 	}
 
-	// M3: treat title:: as an additional alias (→ Obsidian aliases field).
+	// I1: treat title:: as an additional alias (→ Obsidian aliases field).
 	if (raw.title) {
 		const titleAlias = raw.title.replace(/^\[\[(.*)\]\]$/, '$1').trim();
 		if (titleAlias) aliases.push(titleAlias);

--- a/src/formats/logseq/properties.ts
+++ b/src/formats/logseq/properties.ts
@@ -150,7 +150,12 @@ function tagsFromItem(item: string): string[] {
 	return tokens;
 }
 
-function emitProperty(key: string, value: string, aliases: string[], dropPageProps: Set<string>, dropTags: Set<string>): string[] {
+/** Convert a kebab-case property key to snake_case, e.g. `test-hyphen` → `test_hyphen`. */
+function toSnakeCaseKey(key: string): string {
+	return key.replace(/-/g, '_');
+}
+
+function emitProperty(key: string, value: string, aliases: string[], dropPageProps: Set<string>, dropTags: Set<string>, snakeCase: boolean): string[] {
 	// I1: drop empty-valued properties.
 	if (value.trim() === '') return [];
 
@@ -167,36 +172,43 @@ function emitProperty(key: string, value: string, aliases: string[], dropPagePro
 	if (isAlwaysDroppedPageProp(key)) return [];
 	if (dropPageProps.has(key)) return [];
 
+	// Output key: optionally converted to snake_case (drop/match checks above use the
+	// original kebab-case key, since that's how users configure their drop lists).
+	const outKey = snakeCase ? toSnakeCaseKey(key) : key;
+
 	// I1: created/updated wikilink dates → plain ISO.
 	if ((key === 'created' || key === 'updated') && value.includes('[[')) {
 		const iso = extractIsoDate(value);
-		if (iso !== null) return [`${key}: ${iso}`];
+		if (iso !== null) return [`${outKey}: ${iso}`];
 		// Fall through to normal handling if not a clean ISO date.
 	}
 
 	const parts = splitList(value);
 	const hasWiki = value.includes('[[');
 	if (hasWiki && parts.length > 1) {
-		return [`${key}:`, ...parts.map(p => `  - ${quote(p)}`)];
+		return [`${outKey}:`, ...parts.map(p => `  - ${quote(p)}`)];
 	}
 	if (hasWiki) {
-		return [`${key}: ${quote(value)}`];
+		return [`${outKey}: ${quote(value)}`];
 	}
 	// I1: apply general YAML-safe quoting to all non-wikilink scalars.
 	if (needsQuoting(value)) {
-		return [`${key}: ${quote(value)}`];
+		return [`${outKey}: ${quote(value)}`];
 	}
-	return [`${key}: ${value}`];
+	return [`${outKey}: ${value}`];
 }
 
 export interface ExtractPagePropertiesOptions {
 	dropPageProperties?: string[];
 	dropTags?: string[];
+	/** Convert kebab-case page property keys to snake_case (e.g. `test-hyphen` → `test_hyphen`). */
+	snakeCasePageProperties?: boolean;
 }
 
 export function extractPageProperties(content: string, opts: ExtractPagePropertiesOptions = {}): PageProperties {
 	const dropPageProps = new Set(opts.dropPageProperties ?? []);
 	const dropTags = new Set(opts.dropTags ?? []);
+	const snakeCase = opts.snakeCasePageProperties ?? false;
 	const lines = content.split('\n');
 	const raw: Record<string, string> = {};
 	const bodyLines: string[] = [];
@@ -214,7 +226,7 @@ export function extractPageProperties(content: string, opts: ExtractPageProperti
 		const value = m[2].trim();
 		raw[key] = value;
 		if (key === 'title') continue; // kept in raw, emitted as alias below
-		const emitted = emitProperty(key, value, aliases, dropPageProps, dropTags);
+		const emitted = emitProperty(key, value, aliases, dropPageProps, dropTags, snakeCase);
 		if (emitted.length > 0) {
 			if (!propMap.has(key)) propOrder.push(key);
 			propMap.set(key, emitted);
@@ -270,10 +282,9 @@ function isAlwaysDroppedPageProp(key: string): boolean {
  * break the inline-field bracket syntax (contains a stray `]`/`[` outside of a
  * `[[wikilink]]`).
  */
-function wrapBlockProperty(line: string, m: RegExpMatchArray): string {
+function wrapBlockProperty(line: string, m: RegExpMatchArray, outKey: string): string {
 	const indent = m[1];
 	const bullet = m[2] ?? '';
-	const key = m[3];
 	let value = m[4];
 	let anchor = '';
 	const am = value.match(BLOCK_ANCHOR);
@@ -286,14 +297,28 @@ function wrapBlockProperty(line: string, m: RegExpMatchArray): string {
 	// Dataview inline fields can't contain a stray `]`/`[`; wikilinks are fine.
 	const withoutLinks = core.replace(/\[\[[^\]]*\]\]/g, '');
 	if (withoutLinks.includes(']') || withoutLinks.includes('[')) return line;
-	const wrapped = `${indent}${bullet}[${key}:: ${core}]`;
+	const wrapped = `${indent}${bullet}[${outKey}:: ${core}]`;
 	return anchor ? `${wrapped} ${anchor}` : wrapped;
+}
+
+/**
+ * Rewrite the `key` portion of a retained `key:: value` line to `outKey`,
+ * preserving indentation, bullet prefix, and the rest of the line untouched.
+ */
+function renameBlockPropertyKey(line: string, m: RegExpMatchArray, outKey: string): string {
+	const indent = m[1];
+	const bullet = m[2] ?? '';
+	const key = m[3];
+	const prefixLen = indent.length + bullet.length;
+	const rest = line.slice(prefixLen + key.length + 2); // +2 for '::'
+	return `${indent}${bullet}${outKey}::${rest}`;
 }
 
 export function removeLeftoverBlockProperties(
 	content: string,
 	dropBlockProperties: string[] = [],
-	mode: BlockPropertyMode = 'keep'
+	mode: BlockPropertyMode = 'keep',
+	snakeCase = false
 ): string {
 	const userDrop = new Set(dropBlockProperties);
 	const out: string[] = [];
@@ -318,11 +343,12 @@ export function removeLeftoverBlockProperties(
 		if (isAlwaysDroppedBlockProp(key, userDrop)) continue;
 		// Retained unknown key: apply the configured mode.
 		if (mode === 'drop') continue;
+		const outKey = snakeCase ? toSnakeCaseKey(key) : key;
 		if (mode === 'wrap') {
-			out.push(wrapBlockProperty(line, m));
+			out.push(wrapBlockProperty(line, m, outKey));
 			continue;
 		}
-		out.push(line); // keep
+		out.push(snakeCase ? renameBlockPropertyKey(line, m, outKey) : line); // keep
 	}
 	return out.join('\n');
 }

--- a/src/formats/logseq/properties.ts
+++ b/src/formats/logseq/properties.ts
@@ -1,0 +1,153 @@
+// Logseq page/block property handling.
+//
+// Page properties live in the first block of a file (unindented `key:: value`
+// lines) and map to Obsidian YAML frontmatter. Block properties are indented
+// `key:: value` continuation lines; most Logseq-internal ones are dropped.
+
+const PROPERTY_LINE = /^([A-Za-z0-9_.\-]+):: ?(.*)$/;
+const BLOCK_PROPERTY_LINE = /^(\s*)([A-Za-z0-9_.\-]+):: ?(.*)$/;
+
+// Logseq-internal block properties that have no meaning in Obsidian.
+const INTERNAL_BLOCK_PROPS = new Set([
+	'collapsed',
+	'background-color',
+	'heading',
+	'query-table',
+	'query-properties',
+	'query-sort-by',
+	'query-sort-desc',
+	'query-flag',
+	'filters',
+	'public',
+	'exclude-from-graph-view',
+]);
+
+export interface PageProperties {
+	/** YAML frontmatter block including `---` fences, or '' when there are none. */
+	yaml: string;
+	/** File body after the page-property block (leading blank lines trimmed). */
+	body: string;
+	/** Raw parsed key -> value map (e.g. for the dropped `title`). */
+	raw: Record<string, string>;
+}
+
+function stripWikiBrackets(value: string): string {
+	const m = value.match(/^\[\[(.*)\]\]$/);
+	return m ? m[1] : value;
+}
+
+function splitList(value: string): string[] {
+	return value.split(',').map(v => v.trim()).filter(v => v.length > 0);
+}
+
+function quote(value: string): string {
+	return '"' + value.replace(/"/g, '\\"') + '"';
+}
+
+// A single comma-separated tag entry may itself contain multiple tags, e.g.
+// `[[tag2]] #tag3`. Pull out wikilinked names first, then bare/hash tokens.
+function tagsFromItem(item: string): string[] {
+	const tokens: string[] = [];
+	const rest = item.replace(/\[\[([^\]]+)\]\]/g, (_, name) => {
+		tokens.push(name.trim());
+		return ' ';
+	});
+	for (const part of rest.split(/\s+/)) {
+		const t = part.replace(/^#/, '').trim();
+		if (t) tokens.push(t);
+	}
+	return tokens;
+}
+
+function emitProperty(key: string, value: string, aliases: string[]): string[] {
+	if (key === 'alias' || key === 'aliases') {
+		for (const item of splitList(value)) aliases.push(stripWikiBrackets(item));
+		return []; // emitted later, after the whole block is parsed
+	}
+	if (key === 'tags') {
+		const items = splitList(value).flatMap(tagsFromItem);
+		return ['tags:', ...items.map(i => `  - ${i}`)];
+	}
+	const parts = splitList(value);
+	const hasWiki = value.includes('[[');
+	if (hasWiki && parts.length > 1) {
+		return [`${key}:`, ...parts.map(p => `  - ${quote(p)}`)];
+	}
+	if (hasWiki) {
+		return [`${key}: ${quote(value)}`];
+	}
+	return [`${key}: ${value}`];
+}
+
+export function extractPageProperties(content: string): PageProperties {
+	const lines = content.split('\n');
+	const raw: Record<string, string> = {};
+	const bodyLines: string[] = [];
+	const propLines: string[] = [];
+	const aliases: string[] = [];
+
+	let i = 0;
+	// Page properties are the leading unindented `key:: value` lines.
+	for (; i < lines.length; i++) {
+		const m = lines[i].match(PROPERTY_LINE);
+		if (!m) break;
+		const key = m[1];
+		const value = m[2].trim();
+		raw[key] = value;
+		if (key === 'title') continue; // dropped from YAML, kept in raw
+		propLines.push(...emitProperty(key, value, aliases));
+	}
+
+	// Skip blank lines between the property block and the body.
+	while (i < lines.length && lines[i].trim() === '') i++;
+	for (; i < lines.length; i++) bodyLines.push(lines[i]);
+
+	let yaml = '';
+	const hasAny = propLines.length > 0 || aliases.length > 0;
+	if (hasAny) {
+		const aliasLines = aliases.length
+			? ['aliases:', ...aliases.map(a => `  - ${a}`)]
+			: [];
+		yaml = ['---', ...aliasLines, ...propLines, '---'].join('\n');
+	}
+
+	return { yaml, body: bodyLines.join('\n'), raw };
+}
+
+export function removeLeftoverBlockProperties(content: string): string {
+	return content
+		.split('\n')
+		.filter(line => {
+			const m = line.match(BLOCK_PROPERTY_LINE);
+			if (!m) return true;
+			const key = m[2];
+			if (key.startsWith('logseq.')) return false;
+			return !INTERNAL_BLOCK_PROPS.has(key);
+		})
+		.join('\n');
+}
+
+export function convertHeadingProperty(content: string): string {
+	const lines = content.split('\n');
+	const out: string[] = [];
+	let lastBulletIndex = -1;
+
+	for (const line of lines) {
+		const headingMatch = line.match(/^\s*heading:: ?(.*)$/);
+		if (headingMatch) {
+			const level = parseInt(headingMatch[1], 10);
+			if (!isNaN(level) && level >= 1 && level <= 6 && lastBulletIndex >= 0) {
+				out[lastBulletIndex] = out[lastBulletIndex].replace(
+					/^(\s*)- /,
+					`$1- ${'#'.repeat(level)} `
+				);
+			}
+			// drop the heading property line regardless
+			continue;
+		}
+		if (/^\s*- /.test(line)) lastBulletIndex = out.length;
+		out.push(line);
+	}
+
+	return out.join('\n');
+}

--- a/src/formats/logseq/tasks.ts
+++ b/src/formats/logseq/tasks.ts
@@ -39,7 +39,7 @@ function parseDateSpec(inner: string): DateSpec {
 
 function extractDate(value: string): string {
 	let raw = value.trim();
-	// T2: Logseq set-literal `#{...}`. Unwrap the first quoted token (if any)
+	// D1: Logseq set-literal `#{...}`. Unwrap the first quoted token (if any)
 	// and try to parse it as a date; otherwise treat the value as absent.
 	const setLiteral = raw.match(/^#\{(.*)\}$/);
 	if (setLiteral) {
@@ -76,7 +76,7 @@ function leadingWidth(line: string): number {
 export function convertTasks(content: string, format: TaskFormat, options: TaskOptions = {}): string {
 	const logbook = options.logbook ?? 'drop';
 
-	// Issue 2: drop LOGBOOK drawers on ANY bullet (not just tasks) when logbook='drop'.
+	// D1: drop LOGBOOK drawers on ANY bullet (not just tasks) when logbook='drop'.
 	// Use a line-level filter so no trailing newlines are left behind.
 	let processed = content;
 	if (logbook === 'drop') {
@@ -107,7 +107,7 @@ export function convertTasks(content: string, format: TaskFormat, options: TaskO
 		let rest = m[3] ?? '';
 
 		// Collect indented continuation lines that belong to this block.
-		// Issue 3: blank/whitespace-only lines between metadata props are consumed
+		// D1: blank/whitespace-only lines between metadata props are consumed
 		// (they're Logseq outline separators) — only a non-blank line that is a
 		// sibling/parent bullet actually ends the continuation block.
 		const continuation: string[] = [];

--- a/src/formats/logseq/tasks.ts
+++ b/src/formats/logseq/tasks.ts
@@ -1,0 +1,184 @@
+// Logseq task conversion. Logseq tasks are bullets whose text starts with an
+// uppercase workflow keyword (TODO/DOING/DONE/...). Scheduling, priority and
+// time-tracking metadata live on the task line or on indented continuation
+// lines. We render them into one of the supported Obsidian task formats.
+
+export type TaskFormat = 'plain' | 'tasks-emoji' | 'tasks-dataview';
+
+interface TaskOptions {
+	logbook?: 'keep' | 'drop';
+}
+
+const KEYWORDS = ['TODO', 'DOING', 'DONE', 'LATER', 'NOW', 'WAITING', 'WAIT', 'IN-PROGRESS', 'CANCELLED', 'CANCELED'];
+const TASK_RE = new RegExp(`^(\\s*)- (${KEYWORDS.join('|')})(?:\\s+(.*))?$`);
+
+function checkbox(state: string, format: TaskFormat): string {
+	const done = state === 'DONE' || state === 'CANCELLED' || state === 'CANCELED';
+	if (format === 'plain') return done ? 'x' : ' ';
+	switch (state) {
+		case 'DONE': return 'x';
+		case 'CANCELLED':
+		case 'CANCELED': return '-';
+		case 'DOING':
+		case 'NOW': return '/';
+		default: return ' '; // TODO, LATER, WAITING, WAIT, IN-PROGRESS
+	}
+}
+
+interface DateSpec { date: string; repeater?: string; }
+
+function parseDateSpec(inner: string): DateSpec {
+	const date = inner.match(/\d{4}-\d{2}-\d{2}/)?.[0] ?? '';
+	const repeater = inner.match(/[.+]{1,2}\d+[ymwdh]/)?.[0];
+	return { date, repeater };
+}
+
+function extractDate(value: string): string {
+	const clean = value.replace(/\[\[|\]\]/g, '').trim();
+	return clean.match(/\d{4}-\d{2}-\d{2}/)?.[0] ?? clean;
+}
+
+const UNIT_WORDS: Record<string, string> = { y: 'year', m: 'month', w: 'week', d: 'day', h: 'hour' };
+
+function formatRepeaterEmoji(repeater: string): string {
+	const m = repeater.match(/^([.+]{1,2})(\d+)([ymwdh])$/);
+	if (!m) return '';
+	const [, prefix, nStr, unit] = m;
+	const n = parseInt(nStr, 10);
+	const word = UNIT_WORDS[unit];
+	const base = n === 1 ? `every ${word}` : `every ${n} ${word}s`;
+	const whenDone = prefix === '.+' || prefix === '++';
+	return `🔁 ${base}${whenDone ? ' when done' : ''}`;
+}
+
+const PRIORITY_EMOJI: Record<string, string> = { A: '⏫', B: '🔼', C: '🔽' };
+const PRIORITY_WORD: Record<string, string> = { A: 'high', B: 'medium', C: 'low' };
+
+function leadingWidth(line: string): number {
+	return (line.match(/^\s*/)?.[0] ?? '').length;
+}
+
+export function convertTasks(content: string, format: TaskFormat, options: TaskOptions = {}): string {
+	const logbook = options.logbook ?? 'drop';
+	const lines = content.split('\n');
+	const out: string[] = [];
+
+	let i = 0;
+	while (i < lines.length) {
+		const line = lines[i];
+		const m = line.match(TASK_RE);
+		if (!m) {
+			out.push(line);
+			i++;
+			continue;
+		}
+
+		const indent = m[1];
+		const state = m[2];
+		let rest = m[3] ?? '';
+
+		// Collect indented continuation lines that belong to this block.
+		const continuation: string[] = [];
+		let j = i + 1;
+		while (j < lines.length) {
+			const l = lines[j];
+			if (l.trim() === '') break;
+			if (/^\s*- /.test(l)) break; // a child or sibling bullet
+			if (leadingWidth(l) <= indent.length) break;
+			continuation.push(l);
+			j++;
+		}
+
+		// Priority marker, e.g. `[#A]` right after the state.
+		let priority = '';
+		if (format !== 'plain') {
+			const pm = rest.match(/^\[#([ABC])\]\s*/);
+			if (pm) {
+				priority = pm[1];
+				rest = rest.slice(pm[0].length);
+			}
+		}
+
+		const kept: string[] = [];
+		let scheduled: DateSpec | undefined;
+		let deadline: DateSpec | undefined;
+		let created = '';
+		let done = '';
+		let cancelled = '';
+		let inLogbook = false;
+
+		for (const cl of continuation) {
+			if (inLogbook) {
+				if (/:END:/.test(cl)) {
+					inLogbook = false;
+					if (logbook === 'keep') kept.push(cl);
+				}
+				else if (logbook === 'keep') kept.push(cl);
+				continue;
+			}
+			if (/^\s*:LOGBOOK:/.test(cl)) {
+				inLogbook = true;
+				if (logbook === 'keep') kept.push(cl);
+				continue;
+			}
+			if (format === 'plain') {
+				kept.push(cl);
+				continue;
+			}
+			const sched = cl.match(/^\s*SCHEDULED:\s*<(.+?)>/);
+			if (sched) { scheduled = parseDateSpec(sched[1]); continue; }
+			const dead = cl.match(/^\s*DEADLINE:\s*<(.+?)>/);
+			if (dead) { deadline = parseDateSpec(dead[1]); continue; }
+			const prop = cl.match(/^\s*(created|completed|done|cancelled|canceled):: ?(.*)$/);
+			if (prop) {
+				const date = extractDate(prop[2]);
+				if (prop[1] === 'created') created = date;
+				else if (prop[1] === 'completed' || prop[1] === 'done') done = date;
+				else cancelled = date;
+				continue;
+			}
+			kept.push(cl);
+		}
+
+		// Build trailing metadata segments.
+		const segs: string[] = [];
+		if (format === 'tasks-emoji') {
+			if (priority) segs.push(PRIORITY_EMOJI[priority]);
+			if (scheduled?.date) {
+				segs.push(`⏳ ${scheduled.date}`);
+				if (scheduled.repeater) segs.push(formatRepeaterEmoji(scheduled.repeater));
+			}
+			if (deadline?.date) {
+				segs.push(`📅 ${deadline.date}`);
+				if (deadline.repeater) segs.push(formatRepeaterEmoji(deadline.repeater));
+			}
+			if (created) segs.push(`➕ ${created}`);
+			if (done) segs.push(`✅ ${done}`);
+			if (cancelled) segs.push(`❌ ${cancelled}`);
+		}
+		else if (format === 'tasks-dataview') {
+			if (priority) segs.push(`[priority:: ${PRIORITY_WORD[priority]}]`);
+			if (scheduled?.date) {
+				segs.push(`[scheduled:: ${scheduled.date}]`);
+				if (scheduled.repeater) segs.push(`[repeat:: ${scheduled.repeater}]`);
+			}
+			if (deadline?.date) {
+				segs.push(`[due:: ${deadline.date}]`);
+				if (deadline.repeater) segs.push(`[repeat:: ${deadline.repeater}]`);
+			}
+			if (created) segs.push(`[created:: ${created}]`);
+			if (done) segs.push(`[completion:: ${done}]`);
+			if (cancelled) segs.push(`[cancelled:: ${cancelled}]`);
+		}
+
+		const text = rest.trim();
+		let taskLine = text ? `${indent}- [${checkbox(state, format)}] ${text}` : `${indent}- [${checkbox(state, format)}]`;
+		if (segs.length) taskLine += ' ' + segs.join(' ');
+
+		out.push(taskLine);
+		out.push(...kept);
+		i = j;
+	}
+
+	return out.join('\n');
+}

--- a/src/formats/logseq/tasks.ts
+++ b/src/formats/logseq/tasks.ts
@@ -12,7 +12,7 @@ interface TaskOptions {
 }
 
 const KEYWORDS = ['TODO', 'DOING', 'DONE', 'LATER', 'NOW', 'WAITING', 'WAIT', 'IN-PROGRESS', 'CANCELLED', 'CANCELED'];
-const TASK_RE = new RegExp(`^(\\s*)- (${KEYWORDS.join('|')})(?:\\s+(.*))?$`);
+const TASK_RE = new RegExp(`^(\\s*)- (${KEYWORDS.join('|')}):?(?:\\s+(.*))?$`);
 
 function checkbox(state: string, format: TaskFormat): string {
 	const done = state === 'DONE' || state === 'CANCELLED' || state === 'CANCELED';
@@ -38,7 +38,15 @@ function parseDateSpec(inner: string): DateSpec {
 }
 
 function extractDate(value: string): string {
-	const clean = value.replace(/\[\[|\]\]/g, '').trim();
+	let raw = value.trim();
+	// T2: Logseq set-literal `#{...}`. Unwrap the first quoted token (if any)
+	// and try to parse it as a date; otherwise treat the value as absent.
+	const setLiteral = raw.match(/^#\{(.*)\}$/);
+	if (setLiteral) {
+		const quoted = setLiteral[1].match(/"([^"]*)"/);
+		raw = quoted ? quoted[1] : '';
+	}
+	const clean = raw.replace(/\[\[|\]\]/g, '').trim();
 	// Guard: template tokens ({{...}}) are not real dates.
 	if (/\{\{/.test(clean)) return '';
 	// Try ISO first, then Logseq long-date.

--- a/src/formats/logseq/tasks.ts
+++ b/src/formats/logseq/tasks.ts
@@ -25,7 +25,7 @@ function checkbox(state: string, format: TaskFormat): string {
 	}
 }
 
-interface DateSpec { date: string; repeater?: string; }
+interface DateSpec { date: string, repeater?: string }
 
 function parseDateSpec(inner: string): DateSpec {
 	const date = inner.match(/\d{4}-\d{2}-\d{2}/)?.[0] ?? '';
@@ -126,9 +126,13 @@ export function convertTasks(content: string, format: TaskFormat, options: TaskO
 				continue;
 			}
 			const sched = cl.match(/^\s*SCHEDULED:\s*<(.+?)>/);
-			if (sched) { scheduled = parseDateSpec(sched[1]); continue; }
+			if (sched) {
+				scheduled = parseDateSpec(sched[1]); continue; 
+			}
 			const dead = cl.match(/^\s*DEADLINE:\s*<(.+?)>/);
-			if (dead) { deadline = parseDateSpec(dead[1]); continue; }
+			if (dead) {
+				deadline = parseDateSpec(dead[1]); continue; 
+			}
 			const prop = cl.match(/^\s*(created|completed|done|cancelled|canceled):: ?(.*)$/);
 			if (prop) {
 				const date = extractDate(prop[2]);

--- a/src/formats/logseq/tasks.ts
+++ b/src/formats/logseq/tasks.ts
@@ -3,6 +3,8 @@
 // time-tracking metadata live on the task line or on indented continuation
 // lines. We render them into one of the supported Obsidian task formats.
 
+import { logseqDateToISO } from './journals';
+
 export type TaskFormat = 'plain' | 'tasks-emoji' | 'tasks-dataview';
 
 interface TaskOptions {
@@ -28,14 +30,19 @@ function checkbox(state: string, format: TaskFormat): string {
 interface DateSpec { date: string, repeater?: string }
 
 function parseDateSpec(inner: string): DateSpec {
-	const date = inner.match(/\d{4}-\d{2}-\d{2}/)?.[0] ?? '';
+	// Try ISO date first, then fall back to Logseq long-date format.
+	const iso = inner.match(/\d{4}-\d{2}-\d{2}/)?.[0];
+	const date = iso ?? (logseqDateToISO(inner.replace(/\[\[|\]\]/g, '').trim()) ?? '');
 	const repeater = inner.match(/[.+]{1,2}\d+[ymwdh]/)?.[0];
 	return { date, repeater };
 }
 
 function extractDate(value: string): string {
 	const clean = value.replace(/\[\[|\]\]/g, '').trim();
-	return clean.match(/\d{4}-\d{2}-\d{2}/)?.[0] ?? clean;
+	// Guard: template tokens ({{...}}) are not real dates.
+	if (/\{\{/.test(clean)) return '';
+	// Try ISO first, then Logseq long-date.
+	return clean.match(/\d{4}-\d{2}-\d{2}/)?.[0] ?? logseqDateToISO(clean) ?? '';
 }
 
 const UNIT_WORDS: Record<string, string> = { y: 'year', m: 'month', w: 'week', d: 'day', h: 'hour' };
@@ -60,7 +67,21 @@ function leadingWidth(line: string): number {
 
 export function convertTasks(content: string, format: TaskFormat, options: TaskOptions = {}): string {
 	const logbook = options.logbook ?? 'drop';
-	const lines = content.split('\n');
+
+	// Issue 2: drop LOGBOOK drawers on ANY bullet (not just tasks) when logbook='drop'.
+	// Use a line-level filter so no trailing newlines are left behind.
+	let processed = content;
+	if (logbook === 'drop') {
+		let inLogbook = false;
+		processed = content.split('\n').filter(line => {
+			if (/^\s*:LOGBOOK:/.test(line)) { inLogbook = true; return false; }
+			if (inLogbook && /:END:/.test(line)) { inLogbook = false; return false; }
+			if (inLogbook) return false;
+			return true;
+		}).join('\n');
+	}
+
+	const lines = processed.split('\n');
 	const out: string[] = [];
 
 	let i = 0;
@@ -78,12 +99,24 @@ export function convertTasks(content: string, format: TaskFormat, options: TaskO
 		let rest = m[3] ?? '';
 
 		// Collect indented continuation lines that belong to this block.
+		// Issue 3: blank/whitespace-only lines between metadata props are consumed
+		// (they're Logseq outline separators) — only a non-blank line that is a
+		// sibling/parent bullet actually ends the continuation block.
 		const continuation: string[] = [];
 		let j = i + 1;
 		while (j < lines.length) {
 			const l = lines[j];
-			if (l.trim() === '') break;
-			if (/^\s*- /.test(l)) break; // a child or sibling bullet
+			if (l.trim() === '') {
+				// Peek at the next non-blank line to decide whether to continue.
+				const peek = lines.slice(j + 1).find(x => x.trim() !== '');
+				if (peek === undefined) break;
+				if (/^\s*- /.test(peek) && leadingWidth(peek) <= indent.length) break;
+				if (leadingWidth(peek) > indent.length || !/^\s*- /.test(peek)) {
+					continuation.push(l); j++; continue;
+				}
+				break;
+			}
+			if (/^\s*- /.test(l)) break;
 			if (leadingWidth(l) <= indent.length) break;
 			continuation.push(l);
 			j++;
@@ -122,7 +155,7 @@ export function convertTasks(content: string, format: TaskFormat, options: TaskO
 				continue;
 			}
 			if (format === 'plain') {
-				kept.push(cl);
+				if (cl.trim() !== '') kept.push(cl);
 				continue;
 			}
 			const sched = cl.match(/^\s*SCHEDULED:\s*<(.+?)>/);
@@ -141,7 +174,8 @@ export function convertTasks(content: string, format: TaskFormat, options: TaskO
 				else cancelled = date;
 				continue;
 			}
-			kept.push(cl);
+			// Blank separator lines between metadata are silently consumed.
+			if (cl.trim() !== '') kept.push(cl);
 		}
 
 		// Build trailing metadata segments.

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import { CSVImporter } from './formats/csv';
 import { EvernoteEnexImporter } from './formats/evernote-enex';
 import { HtmlImporter } from './formats/html';
 import { KeepImporter } from './formats/keep-json';
+import { LogseqImporter } from './formats/logseq';
 import { NotionImporter } from './formats/notion';
 import { NotionAPIImporter } from './formats/notion-api';
 import { OneNoteImporter } from './formats/onenote';
@@ -249,6 +250,13 @@ export default class ImporterPlugin extends Plugin {
 			'html': {
 				importer: HtmlImporter,
 				helpPermalink: 'import/html',
+			},
+			'logseq': {
+				name: 'Logseq',
+				optionText: 'Logseq (Markdown graph)',
+				importer: LogseqImporter,
+				helpPermalink: 'import/logseq',
+				formatDescription: 'Import a Logseq Markdown graph (pages, journals and assets).',
 			},
 			'onenote': {
 				importer: OneNoteImporter,

--- a/tests/logseq/_smoke.ts
+++ b/tests/logseq/_smoke.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { convertLocal } from '../../src/formats/logseq/pipeline';
+import { resolveBlockRefs } from '../../src/formats/logseq/block-ids';
+import { rewriteAliasReferences } from '../../src/formats/logseq/links';
+import { DEFAULT_LOGSEQ_OPTIONS } from '../../src/formats/logseq/options';
+
+const file = process.argv[2];
+const content = readFileSync(file, 'utf8');
+const local = convertLocal(content, DEFAULT_LOGSEQ_OPTIONS);
+const index = new Map(local.ids.map(id => [id.uuid, { page: 'Foo', shortId: id.shortId }]));
+let body = resolveBlockRefs(local.body, index);
+body = rewriteAliasReferences(body, { aliasMap: new Map([['altfoo', 'Foo'], ['other', 'Foo']]) });
+console.log('=== YAML ===');
+console.log(local.yaml);
+console.log('=== BODY ===');
+console.log(body);
+console.log('=== ASSETS ===', JSON.stringify(local.assets));

--- a/tests/logseq/assets.test.ts
+++ b/tests/logseq/assets.test.ts
@@ -145,6 +145,17 @@ test('[H2] plain (non-embed) asset link is converted to a wiki-link and collecte
 	assert.deepEqual(assets, [{ sourcePath: '../assets/report.pdf', filename: 'report.pdf' }]);
 });
 
+// H2b: asset link whose label contains brackets (e.g. [Fw_ [Nested] _ desc]) must be
+// fully converted — the label regex must allow one level of nested brackets.
+test('[H2b] asset link with bracket in label is fully converted', () => {
+	const { content, assets } = convertAssetLinks(
+		'[Fw_ [Nested] _ prep.eml](../assets/Fw_Nested_prep_0.eml)',
+		{ keepAltText: false }
+	);
+	assert.equal(content, '[[Fw_Nested_prep_0.eml]]');
+	assert.deepEqual(assets, [{ sourcePath: '../assets/Fw_Nested_prep_0.eml', filename: 'Fw_Nested_prep_0.eml' }]);
+});
+
 // M1: an asset embed inside an inline-code span must be left verbatim.
 test('[M1] asset link inside inline code is not rewritten', () => {
 	const input = 'before `![x](../assets/a.png)` after';

--- a/tests/logseq/assets.test.ts
+++ b/tests/logseq/assets.test.ts
@@ -126,3 +126,29 @@ test('returns content unchanged when there are no asset links', () => {
 	assert.equal(content, input);
 	assert.deepEqual(assets, []);
 });
+
+// ---------------------------------------------------------------------------
+// Regression findings (domain 06) — RED tests for accepted fixes.
+// ---------------------------------------------------------------------------
+
+// H1: an asset filename containing parentheses must not be truncated at the first ')'.
+test('[H1] asset filename containing parentheses is not truncated', () => {
+	const { content, assets } = convertAssetLinks('![b](../assets/Book_(2024)_v0.pdf)', { keepAltText: false });
+	assert.equal(content, '![[Book_(2024)_v0.pdf]]');
+	assert.deepEqual(assets, [{ sourcePath: '../assets/Book_(2024)_v0.pdf', filename: 'Book_(2024)_v0.pdf' }]);
+});
+
+// H2: a plain (non-embed) link to an asset must be converted to a wiki-link and collected.
+test('[H2] plain (non-embed) asset link is converted to a wiki-link and collected', () => {
+	const { content, assets } = convertAssetLinks('[doc](../assets/report.pdf)', { keepAltText: false });
+	assert.equal(content, '[[report.pdf]]');
+	assert.deepEqual(assets, [{ sourcePath: '../assets/report.pdf', filename: 'report.pdf' }]);
+});
+
+// M1: an asset embed inside an inline-code span must be left verbatim.
+test('[M1] asset link inside inline code is not rewritten', () => {
+	const input = 'before `![x](../assets/a.png)` after';
+	const { content, assets } = convertAssetLinks(input, { keepAltText: false });
+	assert.equal(content, input);
+	assert.deepEqual(assets, []);
+});

--- a/tests/logseq/assets.test.ts
+++ b/tests/logseq/assets.test.ts
@@ -128,26 +128,26 @@ test('returns content unchanged when there are no asset links', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Regression findings (domain 06) — RED tests for accepted fixes.
+// Documented transformation cases — K1.
 // ---------------------------------------------------------------------------
 
-// H1: an asset filename containing parentheses must not be truncated at the first ')'.
-test('[H1] asset filename containing parentheses is not truncated', () => {
+// K1: an asset filename containing parentheses must not be truncated at the first ')'.
+test('[K1] asset filename containing parentheses is not truncated', () => {
 	const { content, assets } = convertAssetLinks('![b](../assets/Book_(2024)_v0.pdf)', { keepAltText: false });
 	assert.equal(content, '![[Book_(2024)_v0.pdf]]');
 	assert.deepEqual(assets, [{ sourcePath: '../assets/Book_(2024)_v0.pdf', filename: 'Book_(2024)_v0.pdf' }]);
 });
 
-// H2: a plain (non-embed) link to an asset must be converted to a wiki-link and collected.
-test('[H2] plain (non-embed) asset link is converted to a wiki-link and collected', () => {
+// K1: a plain (non-embed) link to an asset must be converted to a wiki-link and collected.
+test('[K1] plain (non-embed) asset link is converted to a wiki-link and collected', () => {
 	const { content, assets } = convertAssetLinks('[doc](../assets/report.pdf)', { keepAltText: false });
 	assert.equal(content, '[[report.pdf]]');
 	assert.deepEqual(assets, [{ sourcePath: '../assets/report.pdf', filename: 'report.pdf' }]);
 });
 
-// H2b: asset link whose label contains brackets (e.g. [Fw_ [Nested] _ desc]) must be
+// K1: asset link whose label contains brackets (e.g. [Fw_ [Nested] _ desc]) must be
 // fully converted — the label regex must allow one level of nested brackets.
-test('[H2b] asset link with bracket in label is fully converted', () => {
+test('[K1] asset link with bracket in label is fully converted', () => {
 	const { content, assets } = convertAssetLinks(
 		'[Fw_ [Nested] _ prep.eml](../assets/Fw_Nested_prep_0.eml)',
 		{ keepAltText: false }
@@ -156,8 +156,8 @@ test('[H2b] asset link with bracket in label is fully converted', () => {
 	assert.deepEqual(assets, [{ sourcePath: '../assets/Fw_Nested_prep_0.eml', filename: 'Fw_Nested_prep_0.eml' }]);
 });
 
-// M1: an asset embed inside an inline-code span must be left verbatim.
-test('[M1] asset link inside inline code is not rewritten', () => {
+// K1: an asset embed inside an inline-code span must be left verbatim.
+test('[K1] asset link inside inline code is not rewritten', () => {
 	const input = 'before `![x](../assets/a.png)` after';
 	const { content, assets } = convertAssetLinks(input, { keepAltText: false });
 	assert.equal(content, input);

--- a/tests/logseq/assets.test.ts
+++ b/tests/logseq/assets.test.ts
@@ -1,0 +1,128 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { convertAssetLinks } from '../../src/formats/logseq/assets';
+
+test('rewrites a basic relative asset image to a wiki-embed', () => {
+	const { content, assets } = convertAssetLinks('![alt](../assets/image.png)', { keepAltText: false });
+	assert.equal(content, '![[image.png]]');
+	assert.deepEqual(assets, [{ sourcePath: '../assets/image.png', filename: 'image.png' }]);
+});
+
+test('matches assets/ without the leading ../', () => {
+	const { content, assets } = convertAssetLinks('![](assets/image.png)', { keepAltText: false });
+	assert.equal(content, '![[image.png]]');
+	assert.deepEqual(assets, [{ sourcePath: 'assets/image.png', filename: 'image.png' }]);
+});
+
+test('keepAltText=false drops the alt text', () => {
+	const { content } = convertAssetLinks('![my caption](../assets/image.png)', { keepAltText: false });
+	assert.equal(content, '![[image.png]]');
+});
+
+test('keepAltText=true keeps non-empty alt text in the display slot', () => {
+	const { content } = convertAssetLinks('![my caption](../assets/image.png)', { keepAltText: true });
+	assert.equal(content, '![[image.png|my caption]]');
+});
+
+test('keepAltText=true with empty alt produces a plain embed', () => {
+	const { content } = convertAssetLinks('![](../assets/image.png)', { keepAltText: true });
+	assert.equal(content, '![[image.png]]');
+});
+
+test('dimension suffix with width and height becomes widthxheight', () => {
+	const { content, assets } = convertAssetLinks(
+		'![alt](../assets/img.png){:height 214, :width 353}',
+		{ keepAltText: false }
+	);
+	assert.equal(content, '![[img.png|353x214]]');
+	assert.deepEqual(assets, [{ sourcePath: '../assets/img.png', filename: 'img.png' }]);
+});
+
+test('dimension suffix with only width becomes width', () => {
+	const { content } = convertAssetLinks('![alt](../assets/img.png){:width 353}', { keepAltText: false });
+	assert.equal(content, '![[img.png|353]]');
+});
+
+test('dimensions win over alt text when both apply', () => {
+	const { content } = convertAssetLinks(
+		'![my caption](../assets/img.png){:height 214, :width 353}',
+		{ keepAltText: true }
+	);
+	assert.equal(content, '![[img.png|353x214]]');
+});
+
+test('dimension suffix is consumed even without keepAltText', () => {
+	const { content } = convertAssetLinks(
+		'before ![](../assets/img.png){:height 214, :width 353} after',
+		{ keepAltText: false }
+	);
+	assert.equal(content, 'before ![[img.png|353x214]] after');
+});
+
+test('non-image asset embeds are also converted', () => {
+	const { content, assets } = convertAssetLinks('![](../assets/doc.pdf)', { keepAltText: false });
+	assert.equal(content, '![[doc.pdf]]');
+	assert.deepEqual(assets, [{ sourcePath: '../assets/doc.pdf', filename: 'doc.pdf' }]);
+});
+
+test('collects multiple assets and de-duplicates identical source paths', () => {
+	const input = '![a](../assets/one.png) ![b](../assets/two.png) ![c](../assets/one.png)';
+	const { content, assets } = convertAssetLinks(input, { keepAltText: false });
+	assert.equal(content, '![[one.png]] ![[two.png]] ![[one.png]]');
+	assert.deepEqual(assets, [
+		{ sourcePath: '../assets/one.png', filename: 'one.png' },
+		{ sourcePath: '../assets/two.png', filename: 'two.png' },
+	]);
+});
+
+test('does not touch http and https URLs', () => {
+	const input = '![x](http://example.com/a.png) ![y](https://example.com/assets/b.png)';
+	const { content, assets } = convertAssetLinks(input, { keepAltText: false });
+	assert.equal(content, input);
+	assert.deepEqual(assets, []);
+});
+
+test('does not touch data URLs', () => {
+	const input = '![x](data:image/png;base64,iVBORw0KGgo=)';
+	const { content, assets } = convertAssetLinks(input, { keepAltText: false });
+	assert.equal(content, input);
+	assert.deepEqual(assets, []);
+});
+
+test('does not touch links whose path does not contain assets/', () => {
+	const input = '![x](../images/photo.png) ![y](local.png)';
+	const { content, assets } = convertAssetLinks(input, { keepAltText: false });
+	assert.equal(content, input);
+	assert.deepEqual(assets, []);
+});
+
+test('does not transform inside fenced code blocks', () => {
+	const input = [
+		'![real](../assets/real.png)',
+		'```',
+		'![fake](../assets/fake.png)',
+		'```',
+		'![also](../assets/also.png)',
+	].join('\n');
+	const { content, assets } = convertAssetLinks(input, { keepAltText: false });
+	const expected = [
+		'![[real.png]]',
+		'```',
+		'![fake](../assets/fake.png)',
+		'```',
+		'![[also.png]]',
+	].join('\n');
+	assert.equal(content, expected);
+	assert.deepEqual(assets, [
+		{ sourcePath: '../assets/real.png', filename: 'real.png' },
+		{ sourcePath: '../assets/also.png', filename: 'also.png' },
+	]);
+});
+
+test('returns content unchanged when there are no asset links', () => {
+	const input = 'just some text with [a link](page.md) and no embeds';
+	const { content, assets } = convertAssetLinks(input, { keepAltText: false });
+	assert.equal(content, input);
+	assert.deepEqual(assets, []);
+});

--- a/tests/logseq/block-ids.test.ts
+++ b/tests/logseq/block-ids.test.ts
@@ -138,3 +138,27 @@ test('[BR-4] attachBlockIds anchors after a retained block property line', () =>
 	const { content } = attachBlockIds(input, true);
 	assert.equal(content, ['- text', '  kept:: v ^abc123'].join('\n'));
 });
+
+// BR-8: alwaysEmbedBlockRefs option — bare ((uuid)) refs become ![[Page#^id]]
+// (embed) instead of [[Page#^id]] (link).
+test('[BR-8] resolveBlockRefs converts bare refs to embeds when alwaysEmbedBlockRefs is on', () => {
+	const index = new Map<string, BlockRefTarget>([[UUID, { page: 'Foo', shortId: '64ab9a' }]]);
+	assert.equal(
+		resolveBlockRefs(`see ((${UUID}))`, index, { alwaysEmbedBlockRefs: true }),
+		'see ![[Foo#^64ab9a]]',
+	);
+});
+
+test('[BR-8] resolveBlockRefs keeps embed syntax unchanged when alwaysEmbedBlockRefs is on', () => {
+	const index = new Map<string, BlockRefTarget>([[UUID, { page: 'Foo', shortId: '64ab9a' }]]);
+	// {{embed ((uuid))}} already produces ![[...]], option has no extra effect
+	assert.equal(
+		resolveBlockRefs(`{{embed ((${UUID}))}}`, index, { alwaysEmbedBlockRefs: true }),
+		'![[Foo#^64ab9a]]',
+	);
+});
+
+test('[BR-8] resolveBlockRefs default behaviour unchanged (link not embed)', () => {
+	const index = new Map<string, BlockRefTarget>([[UUID, { page: 'Foo', shortId: '64ab9a' }]]);
+	assert.equal(resolveBlockRefs(`see ((${UUID}))`, index), 'see [[Foo#^64ab9a]]');
+});

--- a/tests/logseq/block-ids.test.ts
+++ b/tests/logseq/block-ids.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { shortenId, attachBlockIds, resolveBlockRefs, BlockRefTarget } from '../../src/formats/logseq/block-ids';
+import { shortenId, attachBlockIds, resolveBlockRefs, removeOrphanBlockRefs, BlockRefTarget } from '../../src/formats/logseq/block-ids';
 
 const UUID = '64ab9aa4-459a-41b1-8c21-dbb38dc0c79b';
 
@@ -57,4 +57,21 @@ test('resolveBlockRefs rewrites block and page embeds', () => {
 test('resolveBlockRefs leaves unresolved references untouched', () => {
 	const index = new Map<string, BlockRefTarget>();
 	assert.equal(resolveBlockRefs('((unknownuuid))', index), '((unknownuuid))');
+});
+
+// --- removeOrphanBlockRefs ---
+test('removeOrphanBlockRefs strips unresolved ((uuid)) references', () => {
+	assert.equal(removeOrphanBlockRefs('see ((abc123)) here'), 'see  here');
+});
+
+test('removeOrphanBlockRefs strips unresolved {{embed ((uuid))}} embeds', () => {
+	assert.equal(removeOrphanBlockRefs('- {{embed ((abc123))}}').trim(), '');
+});
+
+test('removeOrphanBlockRefs leaves already-resolved [[Page#^id]] links untouched', () => {
+	assert.equal(removeOrphanBlockRefs('see [[Foo#^abc123]]'), 'see [[Foo#^abc123]]');
+});
+
+test('removeOrphanBlockRefs leaves page embeds untouched', () => {
+	assert.equal(removeOrphanBlockRefs('![[SomePage]]'), '![[SomePage]]');
 });

--- a/tests/logseq/block-ids.test.ts
+++ b/tests/logseq/block-ids.test.ts
@@ -83,10 +83,20 @@ test('removeOrphanBlockRefs leaves page embeds untouched', () => {
 //  written in the fix phase, not here.)
 // ---------------------------------------------------------------------------
 
-// BR-1: refs/embeds inside code regions must stay inert (currently resolved).
-test('[BR-1] resolveBlockRefs leaves refs inside a fenced code block inert', () => {
-	const index = new Map<string, BlockRefTarget>([['u1', { page: 'P', shortId: 'abc' }]]);
-	const input = ['```', '{{embed ((u1))}} and ((u1))', '```'].join('\n');
+// BR-1: refs/embeds inside code fences ARE resolved when the UUID is known.
+// Logseq embed syntax is unambiguous; converted form is more useful in Obsidian
+// (e.g. code blocks used as copy-pasteable examples should show the resolved link).
+// Inline-code spans are still protected.
+test('[BR-1] resolveBlockRefs resolves refs inside a fenced code block when UUID is known', () => {
+	const index = new Map<string, BlockRefTarget>([['abc123', { page: 'P', shortId: 'abc123' }]]);
+	const input = ['```', '{{embed ((abc123))}} and ((abc123))', '```'].join('\n');
+	const expected = ['```', '![[P#^abc123]] and [[P#^abc123]]', '```'].join('\n');
+	assert.equal(resolveBlockRefs(input, index), expected);
+});
+
+test('[BR-1] resolveBlockRefs leaves unresolved refs inside a fenced code block inert', () => {
+	const index = new Map<string, BlockRefTarget>(); // empty index
+	const input = ['```', '{{embed ((abc123))}} and ((abc123))', '```'].join('\n');
 	assert.equal(resolveBlockRefs(input, index), input);
 });
 
@@ -104,11 +114,21 @@ test('[BR-2] attachBlockIds places the anchor after a code block, not on the fen
 });
 
 // BR-3: a heading block must get its anchor on its own line below the heading,
-// not appended to the heading text (where Obsidian renders it as literal text).
-test('[BR-3] attachBlockIds places the anchor on its own line for a heading block', () => {
+// not appended to the heading text (where Obsidian renders it as literal text
+// and prevents referencing the heading by content alone).
+test('[BR-3] attachBlockIds places the anchor on its own line for a plain heading block', () => {
+	// No blank line between heading and anchor — anchor must stay adjacent.
 	const input = ['# Tasks', '  id:: abc123'].join('\n');
 	const { content } = attachBlockIds(input, true);
-	assert.equal(content, ['# Tasks', '', '^abc123'].join('\n'));
+	assert.equal(content, ['# Tasks', '^abc123'].join('\n'));
+});
+
+test('[BR-3] attachBlockIds places an indented anchor below a bullet-heading block', () => {
+	// In Logseq, headings are always bullet items. The anchor must be indented
+	// at content level (same indent as the id:: line) so it stays part of the block.
+	const input = ['- ## Section', '  id:: abc123'].join('\n');
+	const { content } = attachBlockIds(input, true);
+	assert.equal(content, ['- ## Section', '  ^abc123'].join('\n'));
 });
 
 // BR-4: anchor must land on the block's true last line, after retained block

--- a/tests/logseq/block-ids.test.ts
+++ b/tests/logseq/block-ids.test.ts
@@ -77,53 +77,51 @@ test('removeOrphanBlockRefs leaves page embeds untouched', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Regression findings (domain 02) — RED tests for accepted fixes.
-// (BR-5 reformatIsoDateLinks is a internal orchestrator method, BR-8 always-embed
-//  needs a new option, BR-6/BR-7 are covered by existing tests / e2e — those are
-//  written in the fix phase, not here.)
+// Documented transformation cases — G1.
+// Date-link reformatting is covered in journals.test.ts against E1.
 // ---------------------------------------------------------------------------
 
-// BR-1: refs/embeds inside code fences ARE resolved when the UUID is known.
+// G1: refs/embeds inside code fences ARE resolved when the UUID is known.
 // Logseq embed syntax is unambiguous; converted form is more useful in Obsidian
 // (e.g. code blocks used as copy-pasteable examples should show the resolved link).
 // Inline-code spans are still protected.
-test('[BR-1] resolveBlockRefs resolves refs inside a fenced code block when UUID is known', () => {
+test('[G1] resolveBlockRefs resolves refs inside a fenced code block when UUID is known', () => {
 	const index = new Map<string, BlockRefTarget>([['abc123', { page: 'P', shortId: 'abc123' }]]);
 	const input = ['```', '{{embed ((abc123))}} and ((abc123))', '```'].join('\n');
 	const expected = ['```', '![[P#^abc123]] and [[P#^abc123]]', '```'].join('\n');
 	assert.equal(resolveBlockRefs(input, index), expected);
 });
 
-test('[BR-1] resolveBlockRefs leaves unresolved refs inside a fenced code block inert', () => {
+test('[G1] resolveBlockRefs leaves unresolved refs inside a fenced code block inert', () => {
 	const index = new Map<string, BlockRefTarget>(); // empty index
 	const input = ['```', '{{embed ((abc123))}} and ((abc123))', '```'].join('\n');
 	assert.equal(resolveBlockRefs(input, index), input);
 });
 
-test('[BR-1] resolveBlockRefs leaves refs inside an inline code span inert', () => {
+test('[G1] resolveBlockRefs leaves refs inside an inline code span inert', () => {
 	const index = new Map<string, BlockRefTarget>([['u1', { page: 'P', shortId: 'abc' }]]);
 	assert.equal(resolveBlockRefs('`((u1))`', index), '`((u1))`');
 });
 
-// BR-2: a block whose last line is a closing ``` fence must get its anchor on a
+// G1: a block whose last line is a closing ``` fence must get its anchor on a
 // new line, not appended to the fence (which makes an invalid CommonMark close).
-test('[BR-2] attachBlockIds places the anchor after a code block, not on the fence', () => {
+test('[G1] attachBlockIds places the anchor after a code block, not on the fence', () => {
 	const input = ['- ```', '  code', '  ```', '  id:: abc123'].join('\n');
 	const { content } = attachBlockIds(input, true);
 	assert.equal(content, ['- ```', '  code', '  ```', '  ^abc123'].join('\n'));
 });
 
-// BR-3: a heading block must get its anchor on its own line below the heading,
+// G1: a heading block must get its anchor on its own line below the heading,
 // not appended to the heading text (where Obsidian renders it as literal text
 // and prevents referencing the heading by content alone).
-test('[BR-3] attachBlockIds places the anchor on its own line for a plain heading block', () => {
+test('[G1] attachBlockIds places the anchor on its own line for a plain heading block', () => {
 	// No blank line between heading and anchor — anchor must stay adjacent.
 	const input = ['# Tasks', '  id:: abc123'].join('\n');
 	const { content } = attachBlockIds(input, true);
 	assert.equal(content, ['# Tasks', '^abc123'].join('\n'));
 });
 
-test('[BR-3] attachBlockIds places an indented anchor below a bullet-heading block', () => {
+test('[G1] attachBlockIds places an indented anchor below a bullet-heading block', () => {
 	// In Logseq, headings are always bullet items. The anchor must be indented
 	// at content level (same indent as the id:: line) so it stays part of the block.
 	const input = ['- ## Section', '  id:: abc123'].join('\n');
@@ -131,17 +129,17 @@ test('[BR-3] attachBlockIds places an indented anchor below a bullet-heading blo
 	assert.equal(content, ['- ## Section', '  ^abc123'].join('\n'));
 });
 
-// BR-4: anchor must land on the block's true last line, after retained block
+// G1: anchor must land on the block's true last line, after retained block
 // properties (currently it lands on the content line above them).
-test('[BR-4] attachBlockIds anchors after a retained block property line', () => {
+test('[G1] attachBlockIds anchors after a retained block property line', () => {
 	const input = ['- text', '  kept:: v', '  id:: abc123'].join('\n');
 	const { content } = attachBlockIds(input, true);
 	assert.equal(content, ['- text', '  kept:: v ^abc123'].join('\n'));
 });
 
-// BR-8: alwaysEmbedBlockRefs option — bare ((uuid)) refs become ![[Page#^id]]
+// G1: alwaysEmbedBlockRefs option — bare ((uuid)) refs become ![[Page#^id]]
 // (embed) instead of [[Page#^id]] (link).
-test('[BR-8] resolveBlockRefs converts bare refs to embeds when alwaysEmbedBlockRefs is on', () => {
+test('[G1] resolveBlockRefs converts bare refs to embeds when alwaysEmbedBlockRefs is on', () => {
 	const index = new Map<string, BlockRefTarget>([[UUID, { page: 'Foo', shortId: '64ab9a' }]]);
 	assert.equal(
 		resolveBlockRefs(`see ((${UUID}))`, index, { alwaysEmbedBlockRefs: true }),
@@ -149,7 +147,7 @@ test('[BR-8] resolveBlockRefs converts bare refs to embeds when alwaysEmbedBlock
 	);
 });
 
-test('[BR-8] resolveBlockRefs keeps embed syntax unchanged when alwaysEmbedBlockRefs is on', () => {
+test('[G1] resolveBlockRefs keeps embed syntax unchanged when alwaysEmbedBlockRefs is on', () => {
 	const index = new Map<string, BlockRefTarget>([[UUID, { page: 'Foo', shortId: '64ab9a' }]]);
 	// {{embed ((uuid))}} already produces ![[...]], option has no extra effect
 	assert.equal(
@@ -158,7 +156,7 @@ test('[BR-8] resolveBlockRefs keeps embed syntax unchanged when alwaysEmbedBlock
 	);
 });
 
-test('[BR-8] resolveBlockRefs default behaviour unchanged (link not embed)', () => {
+test('[G1] resolveBlockRefs default behaviour unchanged (link not embed)', () => {
 	const index = new Map<string, BlockRefTarget>([[UUID, { page: 'Foo', shortId: '64ab9a' }]]);
 	assert.equal(resolveBlockRefs(`see ((${UUID}))`, index), 'see [[Foo#^64ab9a]]');
 });

--- a/tests/logseq/block-ids.test.ts
+++ b/tests/logseq/block-ids.test.ts
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { shortenId, attachBlockIds, resolveBlockRefs, BlockRefTarget } from '../../src/formats/logseq/block-ids';
+
+const UUID = '64ab9aa4-459a-41b1-8c21-dbb38dc0c79b';
+
+test('shortenId takes the leading hex of a UUID', () => {
+	assert.equal(shortenId(UUID), '64ab9a');
+});
+
+test('attachBlockIds appends a shortened anchor and drops the id line', () => {
+	const input = ['- a block', `  id:: ${UUID}`, '- other'].join('\n');
+	const { content, ids } = attachBlockIds(input, true);
+	assert.equal(content, ['- a block ^64ab9a', '- other'].join('\n'));
+	assert.deepEqual(ids, [{ uuid: UUID, shortId: '64ab9a' }]);
+});
+
+test('attachBlockIds handles an id written as its own bullet', () => {
+	// Logseq sometimes flattens a block property onto its own bullet line.
+	const input = ['- Paragraph line', '- id:: abc123', '- See more'].join('\n');
+	const { content, ids } = attachBlockIds(input, true);
+	assert.equal(content, ['- Paragraph line ^abc123', '- See more'].join('\n'));
+	assert.deepEqual(ids, [{ uuid: 'abc123', shortId: 'abc123' }]);
+});
+
+test('attachBlockIds can keep the full UUID', () => {
+	const input = ['- a block', `  id:: ${UUID}`].join('\n');
+	const { content, ids } = attachBlockIds(input, false);
+	assert.equal(content, `- a block ^${UUID}`);
+	assert.deepEqual(ids, [{ uuid: UUID, shortId: UUID }]);
+});
+
+test('attachBlockIds disambiguates colliding short ids within a file', () => {
+	const a = 'abcdef12-0000-0000-0000-000000000000';
+	const b = 'abcdef34-0000-0000-0000-000000000000';
+	const input = ['- one', `  id:: ${a}`, '- two', `  id:: ${b}`].join('\n');
+	const { content, ids } = attachBlockIds(input, true);
+	assert.equal(content, ['- one ^abcdef', '- two ^abcdef-1'].join('\n'));
+	assert.deepEqual(ids, [
+		{ uuid: a, shortId: 'abcdef' },
+		{ uuid: b, shortId: 'abcdef-1' },
+	]);
+});
+
+test('resolveBlockRefs rewrites block references to wikilink anchors', () => {
+	const index = new Map<string, BlockRefTarget>([[UUID, { page: 'Foo', shortId: '64ab9a' }]]);
+	assert.equal(resolveBlockRefs(`see ((${UUID}))`, index), 'see [[Foo#^64ab9a]]');
+});
+
+test('resolveBlockRefs rewrites block and page embeds', () => {
+	const index = new Map<string, BlockRefTarget>([[UUID, { page: 'Foo', shortId: '64ab9a' }]]);
+	assert.equal(resolveBlockRefs(`{{embed ((${UUID}))}}`, index), '![[Foo#^64ab9a]]');
+	assert.equal(resolveBlockRefs('{{embed [[Bar]]}}', index), '![[Bar]]');
+});
+
+test('resolveBlockRefs leaves unresolved references untouched', () => {
+	const index = new Map<string, BlockRefTarget>();
+	assert.equal(resolveBlockRefs('((unknownuuid))', index), '((unknownuuid))');
+});

--- a/tests/logseq/block-ids.test.ts
+++ b/tests/logseq/block-ids.test.ts
@@ -75,3 +75,46 @@ test('removeOrphanBlockRefs leaves already-resolved [[Page#^id]] links untouched
 test('removeOrphanBlockRefs leaves page embeds untouched', () => {
 	assert.equal(removeOrphanBlockRefs('![[SomePage]]'), '![[SomePage]]');
 });
+
+// ---------------------------------------------------------------------------
+// Regression findings (domain 02) — RED tests for accepted fixes.
+// (BR-5 reformatIsoDateLinks is a internal orchestrator method, BR-8 always-embed
+//  needs a new option, BR-6/BR-7 are covered by existing tests / e2e — those are
+//  written in the fix phase, not here.)
+// ---------------------------------------------------------------------------
+
+// BR-1: refs/embeds inside code regions must stay inert (currently resolved).
+test('[BR-1] resolveBlockRefs leaves refs inside a fenced code block inert', () => {
+	const index = new Map<string, BlockRefTarget>([['u1', { page: 'P', shortId: 'abc' }]]);
+	const input = ['```', '{{embed ((u1))}} and ((u1))', '```'].join('\n');
+	assert.equal(resolveBlockRefs(input, index), input);
+});
+
+test('[BR-1] resolveBlockRefs leaves refs inside an inline code span inert', () => {
+	const index = new Map<string, BlockRefTarget>([['u1', { page: 'P', shortId: 'abc' }]]);
+	assert.equal(resolveBlockRefs('`((u1))`', index), '`((u1))`');
+});
+
+// BR-2: a block whose last line is a closing ``` fence must get its anchor on a
+// new line, not appended to the fence (which makes an invalid CommonMark close).
+test('[BR-2] attachBlockIds places the anchor after a code block, not on the fence', () => {
+	const input = ['- ```', '  code', '  ```', '  id:: abc123'].join('\n');
+	const { content } = attachBlockIds(input, true);
+	assert.equal(content, ['- ```', '  code', '  ```', '  ^abc123'].join('\n'));
+});
+
+// BR-3: a heading block must get its anchor on its own line below the heading,
+// not appended to the heading text (where Obsidian renders it as literal text).
+test('[BR-3] attachBlockIds places the anchor on its own line for a heading block', () => {
+	const input = ['# Tasks', '  id:: abc123'].join('\n');
+	const { content } = attachBlockIds(input, true);
+	assert.equal(content, ['# Tasks', '', '^abc123'].join('\n'));
+});
+
+// BR-4: anchor must land on the block's true last line, after retained block
+// properties (currently it lands on the content line above them).
+test('[BR-4] attachBlockIds anchors after a retained block property line', () => {
+	const input = ['- text', '  kept:: v', '  id:: abc123'].join('\n');
+	const { content } = attachBlockIds(input, true);
+	assert.equal(content, ['- text', '  kept:: v ^abc123'].join('\n'));
+});

--- a/tests/logseq/blocks.test.ts
+++ b/tests/logseq/blocks.test.ts
@@ -334,65 +334,65 @@ test('convertOrgBlocks: multi-line QUOTE preserves blank lines as empty blockquo
 });
 
 // ---------------------------------------------------------------------------
-// Regression findings (domain 01) — RED tests for accepted fixes.
+// Documented transformation cases — J1.
 // ---------------------------------------------------------------------------
 
-// Issue 1: bullet-prefixed `- #+BEGIN_*` blocks are currently left raw because
+// J1: bullet-prefixed `- #+BEGIN_*` blocks are currently left raw because
 // BEGIN_RE anchors `#+BEGIN` right after the indent. Decision: keep the bullet,
 // render the callout as the bullet's content (`- > [!tip]` / `  > body`).
-test('[Issue 1] convertOrgBlocks: tab-indented bullet TIP becomes a callout under the bullet', () => {
+test('[J1] convertOrgBlocks: tab-indented bullet TIP becomes a callout under the bullet', () => {
 	const input = ['\t- #+BEGIN_TIP', '\t  body', '\t  #+END_TIP'].join('\n');
 	const expected = ['\t- > [!tip]', '\t  > body'].join('\n');
 	assert.equal(convertOrgBlocks(input), expected);
 });
 
-test('[Issue 1] convertOrgBlocks: bullet TIP keeps a bold first line as the callout title', () => {
+test('[J1] convertOrgBlocks: bullet TIP keeps a bold first line as the callout title', () => {
 	const input = ['- #+BEGIN_TIP', '  **Role**', '  body', '  #+END_TIP'].join('\n');
 	const expected = ['- > [!tip] Role', '  > body'].join('\n');
 	assert.equal(convertOrgBlocks(input), expected);
 });
 
-test('[Issue 1] convertOrgBlocks: bullet QUOTE becomes a blockquote under the bullet', () => {
+test('[J1] convertOrgBlocks: bullet QUOTE becomes a blockquote under the bullet', () => {
 	const input = ['- #+BEGIN_QUOTE', '  quoted', '  #+END_QUOTE'].join('\n');
 	const expected = ['- > quoted'].join('\n');
 	assert.equal(convertOrgBlocks(input), expected);
 });
 
-// Issue 2: closing fence is re-emitted as spaces (tab counted as 1 char), losing
+// J1: closing fence is re-emitted as spaces (tab counted as 1 char), losing
 // the original tab indentation and breaking list nesting. Decision: preserve the
 // opener's exact indentation on the closing fence (leave an already-aligned block
 // untouched).
-test('[Issue 2] fixCodeBlocksInLists: preserves tab indentation on the closing fence', () => {
+test('[J1] fixCodeBlocksInLists: preserves tab indentation on the closing fence', () => {
 	const input = ['\t- ```js', '\t  x', '\t  ```'].join('\n');
 	assert.equal(fixCodeBlocksInLists(input), input);
 });
 
-// Issue 3: convertOrgBlocks has no fence-awareness and converts `#+BEGIN_*` that
+// J1: convertOrgBlocks has no fence-awareness and converts `#+BEGIN_*` that
 // appears literally inside a fenced code block. Decision: leave code content inert.
-test('[Issue 3] convertOrgBlocks: leaves org markup inside a code fence untouched', () => {
+test('[J1] convertOrgBlocks: leaves org markup inside a code fence untouched', () => {
 	const input = ['```', '#+BEGIN_QUERY', 'q', '#+END_QUERY', '```'].join('\n');
 	assert.equal(convertOrgBlocks(input), input);
 });
 
-// Issue 4: `#+BEGIN_QUERY` currently falls back to a `[!note]` callout, silently
+// J1: `#+BEGIN_QUERY` currently falls back to a `[!note]` callout, silently
 // relabelling the query DSL as prose. Decision: preserve verbatim in a ```query fence.
-test('[Issue 4] convertOrgBlocks: QUERY is preserved verbatim in a ```query fence', () => {
+test('[J1] convertOrgBlocks: QUERY is preserved verbatim in a ```query fence', () => {
 	const input = ['#+BEGIN_QUERY', '{:title "x"}', '#+END_QUERY'].join('\n');
 	const expected = ['```query', '{:title "x"}', '```'].join('\n');
 	assert.equal(convertOrgBlocks(input), expected);
 });
 
-// Issue 5: convertHighlights' fence detector (`/^\s*```/`) misses a bullet-opened
+// J1: convertHighlights' fence detector (`/^\s*```/`) misses a bullet-opened
 // fence, so highlights inside such a code block get converted. Decision: recognise
 // the bullet-opened form and leave code content inert.
-test('[Issue 5] convertHighlights: ignores a bullet-opened code fence', () => {
+test('[J1] convertHighlights: ignores a bullet-opened code fence', () => {
 	const input = ['- ```', '^^x^^', '```'].join('\n');
 	assert.equal(convertHighlights(input), input);
 });
 
-// Issue 7 (guard): a tab-indented numbered list must number independently and
+// J1 (guard): a tab-indented numbered list must number independently and
 // correctly (documents the expected contract; no live misconversion observed).
-test('[Issue 7] convertNumberedLists: tab-indented numbered list numbers correctly', () => {
+test('[J1] convertNumberedLists: tab-indented numbered list numbers correctly', () => {
 	const input = [
 		'\t- one',
 		'\t  logseq.order-list-type:: number',

--- a/tests/logseq/blocks.test.ts
+++ b/tests/logseq/blocks.test.ts
@@ -332,3 +332,73 @@ test('convertOrgBlocks: multi-line QUOTE preserves blank lines as empty blockquo
 	const input = ['#+BEGIN_QUOTE', 'line 1', '', 'line 2', '#+END_QUOTE'].join('\n');
 	assert.equal(convertOrgBlocks(input), ['> line 1', '>', '> line 2'].join('\n'));
 });
+
+// ---------------------------------------------------------------------------
+// Regression findings (domain 01) — RED tests for accepted fixes.
+// ---------------------------------------------------------------------------
+
+// Issue 1: bullet-prefixed `- #+BEGIN_*` blocks are currently left raw because
+// BEGIN_RE anchors `#+BEGIN` right after the indent. Decision: keep the bullet,
+// render the callout as the bullet's content (`- > [!tip]` / `  > body`).
+test('[Issue 1] convertOrgBlocks: tab-indented bullet TIP becomes a callout under the bullet', () => {
+	const input = ['\t- #+BEGIN_TIP', '\t  body', '\t  #+END_TIP'].join('\n');
+	const expected = ['\t- > [!tip]', '\t  > body'].join('\n');
+	assert.equal(convertOrgBlocks(input), expected);
+});
+
+test('[Issue 1] convertOrgBlocks: bullet TIP keeps a bold first line as the callout title', () => {
+	const input = ['- #+BEGIN_TIP', '  **Role**', '  body', '  #+END_TIP'].join('\n');
+	const expected = ['- > [!tip] Role', '  > body'].join('\n');
+	assert.equal(convertOrgBlocks(input), expected);
+});
+
+test('[Issue 1] convertOrgBlocks: bullet QUOTE becomes a blockquote under the bullet', () => {
+	const input = ['- #+BEGIN_QUOTE', '  quoted', '  #+END_QUOTE'].join('\n');
+	const expected = ['- > quoted'].join('\n');
+	assert.equal(convertOrgBlocks(input), expected);
+});
+
+// Issue 2: closing fence is re-emitted as spaces (tab counted as 1 char), losing
+// the original tab indentation and breaking list nesting. Decision: preserve the
+// opener's exact indentation on the closing fence (leave an already-aligned block
+// untouched).
+test('[Issue 2] fixCodeBlocksInLists: preserves tab indentation on the closing fence', () => {
+	const input = ['\t- ```js', '\t  x', '\t  ```'].join('\n');
+	assert.equal(fixCodeBlocksInLists(input), input);
+});
+
+// Issue 3: convertOrgBlocks has no fence-awareness and converts `#+BEGIN_*` that
+// appears literally inside a fenced code block. Decision: leave code content inert.
+test('[Issue 3] convertOrgBlocks: leaves org markup inside a code fence untouched', () => {
+	const input = ['```', '#+BEGIN_QUERY', 'q', '#+END_QUERY', '```'].join('\n');
+	assert.equal(convertOrgBlocks(input), input);
+});
+
+// Issue 4: `#+BEGIN_QUERY` currently falls back to a `[!note]` callout, silently
+// relabelling the query DSL as prose. Decision: preserve verbatim in a ```query fence.
+test('[Issue 4] convertOrgBlocks: QUERY is preserved verbatim in a ```query fence', () => {
+	const input = ['#+BEGIN_QUERY', '{:title "x"}', '#+END_QUERY'].join('\n');
+	const expected = ['```query', '{:title "x"}', '```'].join('\n');
+	assert.equal(convertOrgBlocks(input), expected);
+});
+
+// Issue 5: convertHighlights' fence detector (`/^\s*```/`) misses a bullet-opened
+// fence, so highlights inside such a code block get converted. Decision: recognise
+// the bullet-opened form and leave code content inert.
+test('[Issue 5] convertHighlights: ignores a bullet-opened code fence', () => {
+	const input = ['- ```', '^^x^^', '```'].join('\n');
+	assert.equal(convertHighlights(input), input);
+});
+
+// Issue 7 (guard): a tab-indented numbered list must number independently and
+// correctly (documents the expected contract; no live misconversion observed).
+test('[Issue 7] convertNumberedLists: tab-indented numbered list numbers correctly', () => {
+	const input = [
+		'\t- one',
+		'\t  logseq.order-list-type:: number',
+		'\t- two',
+		'\t  logseq.order-list-type:: number',
+	].join('\n');
+	const expected = ['\t1. one', '\t2. two'].join('\n');
+	assert.equal(convertNumberedLists(input), expected);
+});

--- a/tests/logseq/blocks.test.ts
+++ b/tests/logseq/blocks.test.ts
@@ -1,0 +1,334 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+	convertHighlights,
+	convertNumberedLists,
+	convertOrgBlocks,
+	convertMediaEmbeds,
+	fixCodeBlocksInLists,
+	fixHeadingChildLists,
+} from '../../src/formats/logseq/blocks';
+
+// ---------------------------------------------------------------------------
+// fixHeadingChildLists
+// ---------------------------------------------------------------------------
+
+test('fixHeadingChildLists: prefixes a heading that owns an indented child list', () => {
+	const input = ['# Heading', '\t- list item 1', '\t- list item 2'].join('\n');
+	const expected = ['- # Heading', '\t- list item 1', '\t- list item 2'].join('\n');
+	assert.equal(fixHeadingChildLists(input), expected);
+});
+
+test('fixHeadingChildLists: leaves a heading without an indented child list', () => {
+	const input = ['# Heading', 'some text'].join('\n');
+	assert.equal(fixHeadingChildLists(input), input);
+});
+
+test('fixHeadingChildLists: leaves a heading already inside a bullet', () => {
+	const input = ['- # Heading', '\t- child'].join('\n');
+	assert.equal(fixHeadingChildLists(input), input);
+});
+
+// ---------------------------------------------------------------------------
+// convertHighlights
+// ---------------------------------------------------------------------------
+
+test('convertHighlights: basic highlight', () => {
+	assert.equal(convertHighlights('a ^^b^^ c'), 'a ==b== c');
+});
+
+test('convertHighlights: multiple highlights on one line', () => {
+	assert.equal(convertHighlights('^^one^^ and ^^two^^'), '==one== and ==two==');
+});
+
+test('convertHighlights: highlight spanning words', () => {
+	assert.equal(convertHighlights('text ^^a b c^^ end'), 'text ==a b c== end');
+});
+
+test('convertHighlights: leaves plain text untouched', () => {
+	assert.equal(convertHighlights('nothing to see here'), 'nothing to see here');
+});
+
+test('convertHighlights: does not transform inside fenced code block', () => {
+	const input = ['before ^^x^^', '```', 'leave ^^y^^ alone', '```', 'after ^^z^^'].join('\n');
+	const expected = ['before ==x==', '```', 'leave ^^y^^ alone', '```', 'after ==z=='].join('\n');
+	assert.equal(convertHighlights(input), expected);
+});
+
+test('convertHighlights: does not transform inside inline code span', () => {
+	assert.equal(convertHighlights('use `^^x^^` here'), 'use `^^x^^` here');
+});
+
+test('convertHighlights: mixes inline code and real highlight', () => {
+	assert.equal(convertHighlights('`^^a^^` but ^^b^^'), '`^^a^^` but ==b==');
+});
+
+test('convertHighlights: language-tagged fence is protected', () => {
+	const input = ['```python', 'x = "^^hl^^"', '```'].join('\n');
+	assert.equal(convertHighlights(input), input);
+});
+
+// ---------------------------------------------------------------------------
+// convertNumberedLists
+// ---------------------------------------------------------------------------
+
+test('convertNumberedLists: basic two-item example', () => {
+	const input = [
+		'- one',
+		'  logseq.order-list-type:: number',
+		'- two',
+		'  logseq.order-list-type:: number',
+	].join('\n');
+	const expected = ['1. one', '2. two'].join('\n');
+	assert.equal(convertNumberedLists(input), expected);
+});
+
+test('convertNumberedLists: counter reaches three', () => {
+	const input = [
+		'- a',
+		'  logseq.order-list-type:: number',
+		'- b',
+		'  logseq.order-list-type:: number',
+		'- c',
+		'  logseq.order-list-type:: number',
+	].join('\n');
+	assert.equal(convertNumberedLists(input), ['1. a', '2. b', '3. c'].join('\n'));
+});
+
+test('convertNumberedLists: bullets without property stay as dashes', () => {
+	const input = ['- plain one', '- plain two'].join('\n');
+	assert.equal(convertNumberedLists(input), input);
+});
+
+test('convertNumberedLists: counter resets after a plain sibling', () => {
+	const input = [
+		'- one',
+		'  logseq.order-list-type:: number',
+		'- two',
+		'  logseq.order-list-type:: number',
+		'- plain',
+		'- three',
+		'  logseq.order-list-type:: number',
+	].join('\n');
+	const expected = ['1. one', '2. two', '- plain', '1. three'].join('\n');
+	assert.equal(convertNumberedLists(input), expected);
+});
+
+test('convertNumberedLists: nested numbered list keeps per-level counters', () => {
+	const input = [
+		'- a',
+		'  logseq.order-list-type:: number',
+		'  - b',
+		'    logseq.order-list-type:: number',
+		'  - c',
+		'    logseq.order-list-type:: number',
+		'- d',
+		'  logseq.order-list-type:: number',
+	].join('\n');
+	const expected = ['1. a', '  1. b', '  2. c', '2. d'].join('\n');
+	assert.equal(convertNumberedLists(input), expected);
+});
+
+test('convertNumberedLists: nested list restarts under a new parent', () => {
+	const input = [
+		'- a',
+		'  logseq.order-list-type:: number',
+		'  - x',
+		'    logseq.order-list-type:: number',
+		'- b',
+		'  logseq.order-list-type:: number',
+		'  - y',
+		'    logseq.order-list-type:: number',
+	].join('\n');
+	const expected = ['1. a', '  1. x', '2. b', '  1. y'].join('\n');
+	assert.equal(convertNumberedLists(input), expected);
+});
+
+// ---------------------------------------------------------------------------
+// convertOrgBlocks
+// ---------------------------------------------------------------------------
+
+test('convertOrgBlocks: QUOTE becomes blockquote', () => {
+	const input = ['#+BEGIN_QUOTE', 'Hello', 'World', '#+END_QUOTE'].join('\n');
+	assert.equal(convertOrgBlocks(input), ['> Hello', '> World'].join('\n'));
+});
+
+test('convertOrgBlocks: NOTE without title becomes callout', () => {
+	const input = ['#+BEGIN_TIP', 'just text', '#+END_TIP'].join('\n');
+	assert.equal(convertOrgBlocks(input), ['> [!tip]', '> just text'].join('\n'));
+});
+
+test('convertOrgBlocks: NOTE with bold first line uses it as title', () => {
+	const input = ['#+BEGIN_NOTE', '**Important Title**', 'body line', '#+END_NOTE'].join('\n');
+	assert.equal(
+		convertOrgBlocks(input),
+		['> [!note] Important Title', '> body line'].join('\n')
+	);
+});
+
+test('convertOrgBlocks: case-insensitive block type', () => {
+	const input = ['#+begin_warning', 'careful', '#+end_warning'].join('\n');
+	assert.equal(convertOrgBlocks(input), ['> [!warning]', '> careful'].join('\n'));
+});
+
+test('convertOrgBlocks: COMMENT becomes Obsidian comment', () => {
+	const input = ['#+BEGIN_COMMENT', 'secret', '#+END_COMMENT'].join('\n');
+	assert.equal(convertOrgBlocks(input), ['%%', 'secret', '%%'].join('\n'));
+});
+
+test('convertOrgBlocks: CENTER falls back to note callout', () => {
+	const input = ['#+BEGIN_CENTER', 'centered', '#+END_CENTER'].join('\n');
+	assert.equal(convertOrgBlocks(input), ['> [!note]', '> centered'].join('\n'));
+});
+
+test('convertOrgBlocks: nested quote inside callout gets extra blockquote', () => {
+	const input = [
+		'#+BEGIN_NOTE',
+		'intro',
+		'#+BEGIN_QUOTE',
+		'quoted',
+		'#+END_QUOTE',
+		'#+END_NOTE',
+	].join('\n');
+	assert.equal(
+		convertOrgBlocks(input),
+		['> [!note]', '> intro', '> > quoted'].join('\n')
+	);
+});
+
+test('convertOrgBlocks: preserves indentation for blocks nested in list items', () => {
+	const input = ['- item', '  #+BEGIN_QUOTE', '  quoted', '  #+END_QUOTE'].join('\n');
+	assert.equal(convertOrgBlocks(input), ['- item', '  > quoted'].join('\n'));
+});
+
+test('convertOrgBlocks: unmatched begin is left unchanged', () => {
+	const input = ['#+BEGIN_QUOTE', 'hello', 'no end here'].join('\n');
+	assert.equal(convertOrgBlocks(input), input);
+});
+
+test('convertOrgBlocks: text around block is preserved', () => {
+	const input = ['before', '#+BEGIN_QUOTE', 'q', '#+END_QUOTE', 'after'].join('\n');
+	assert.equal(convertOrgBlocks(input), ['before', '> q', 'after'].join('\n'));
+});
+
+// ---------------------------------------------------------------------------
+// fixCodeBlocksInLists
+// ---------------------------------------------------------------------------
+
+test('fixCodeBlocksInLists: indents closing fence to match bullet code', () => {
+	const input = ['- ```python', '  print(1)', '```'].join('\n');
+	const expected = ['- ```python', '  print(1)', '  ```'].join('\n');
+	assert.equal(fixCodeBlocksInLists(input), expected);
+});
+
+test('fixCodeBlocksInLists: already-correct closing fence is unchanged', () => {
+	const input = ['- ```js', '  x', '  ```'].join('\n');
+	assert.equal(fixCodeBlocksInLists(input), input);
+});
+
+test('fixCodeBlocksInLists: top-level code block is left unchanged', () => {
+	const input = ['```', 'code', '```'].join('\n');
+	assert.equal(fixCodeBlocksInLists(input), input);
+});
+
+test('fixCodeBlocksInLists: deeper nested bullet keeps deeper indent', () => {
+	const input = ['  - ```ts', '    y', '```'].join('\n');
+	const expected = ['  - ```ts', '    y', '    ```'].join('\n');
+	assert.equal(fixCodeBlocksInLists(input), expected);
+});
+
+test('fixCodeBlocksInLists: does not alter code content lines', () => {
+	const input = ['- ```python', '  ^^not a highlight^^', '  result = 2', '```'].join('\n');
+	const expected = ['- ```python', '  ^^not a highlight^^', '  result = 2', '  ```'].join('\n');
+	assert.equal(fixCodeBlocksInLists(input), expected);
+});
+
+// ---------------------------------------------------------------------------
+// convertMediaEmbeds
+// ---------------------------------------------------------------------------
+
+test('convertMediaEmbeds: converts {{video URL}}', () => {
+	assert.equal(convertMediaEmbeds('- {{video https://example.com/v.mp4}}'), '- ![](https://example.com/v.mp4)');
+});
+
+test('convertMediaEmbeds: converts {{youtube URL}}', () => {
+	assert.equal(
+		convertMediaEmbeds('- {{youtube https://www.youtube.com/watch?v=abc123}}'),
+		'- ![](https://www.youtube.com/watch?v=abc123)'
+	);
+});
+
+test('convertMediaEmbeds: converts {{tweet URL}}', () => {
+	assert.equal(
+		convertMediaEmbeds('- {{tweet https://twitter.com/user/status/999}}'),
+		'- ![](https://twitter.com/user/status/999)'
+	);
+});
+
+test('convertMediaEmbeds: handles extra whitespace around URL', () => {
+	assert.equal(
+		convertMediaEmbeds('{{video   https://example.com/v.mp4  }}'),
+		'![](https://example.com/v.mp4)'
+	);
+});
+
+test('convertMediaEmbeds: multiple embeds on separate lines', () => {
+	const input = ['- {{video https://a.com/1.mp4}}', '- {{youtube https://b.com/2}}'].join('\n');
+	const expected = ['- ![](https://a.com/1.mp4)', '- ![](https://b.com/2)'].join('\n');
+	assert.equal(convertMediaEmbeds(input), expected);
+});
+
+test('convertMediaEmbeds: does not convert inside fenced code', () => {
+	const input = ['```', '{{video https://inside.com/x}}', '```'].join('\n');
+	assert.equal(convertMediaEmbeds(input), input);
+});
+
+test('convertMediaEmbeds: leaves {{embed}} untouched (handled elsewhere)', () => {
+	const input = '- {{embed [[Page]]}}';
+	assert.equal(convertMediaEmbeds(input), input);
+});
+
+test('convertMediaEmbeds: leaves {{query}} untouched', () => {
+	const input = '- {{query (and [[tag]])}}';
+	assert.equal(convertMediaEmbeds(input), input);
+});
+
+// ---------------------------------------------------------------------------
+// convertOrgBlocks: additional edge cases
+// ---------------------------------------------------------------------------
+
+test('convertOrgBlocks: EXAMPLE block uses example callout type', () => {
+	const input = ['#+BEGIN_EXAMPLE', 'sample code', '#+END_EXAMPLE'].join('\n');
+	assert.equal(convertOrgBlocks(input), ['> [!example]', '> sample code'].join('\n'));
+});
+
+test('convertOrgBlocks: IMPORTANT block', () => {
+	const input = ['#+BEGIN_IMPORTANT', 'do not forget', '#+END_IMPORTANT'].join('\n');
+	assert.equal(convertOrgBlocks(input), ['> [!important]', '> do not forget'].join('\n'));
+});
+
+test('convertOrgBlocks: CAUTION block', () => {
+	const input = ['#+BEGIN_CAUTION', 'be warned', '#+END_CAUTION'].join('\n');
+	assert.equal(convertOrgBlocks(input), ['> [!caution]', '> be warned'].join('\n'));
+});
+
+test('convertOrgBlocks: VERSE falls back to note callout', () => {
+	const input = ['#+BEGIN_VERSE', 'roses are red', '#+END_VERSE'].join('\n');
+	assert.equal(convertOrgBlocks(input), ['> [!note]', '> roses are red'].join('\n'));
+});
+
+test('convertOrgBlocks: PINNED falls back to note callout', () => {
+	const input = ['#+BEGIN_PINNED', 'pinned content', '#+END_PINNED'].join('\n');
+	assert.equal(convertOrgBlocks(input), ['> [!note]', '> pinned content'].join('\n'));
+});
+
+test('convertOrgBlocks: empty block body produces header only', () => {
+	const input = ['#+BEGIN_TIP', '#+END_TIP'].join('\n');
+	assert.equal(convertOrgBlocks(input), '> [!tip]');
+});
+
+test('convertOrgBlocks: multi-line QUOTE preserves blank lines as empty blockquote', () => {
+	const input = ['#+BEGIN_QUOTE', 'line 1', '', 'line 2', '#+END_QUOTE'].join('\n');
+	assert.equal(convertOrgBlocks(input), ['> line 1', '>', '> line 2'].join('\n'));
+});

--- a/tests/logseq/de-outline.test.ts
+++ b/tests/logseq/de-outline.test.ts
@@ -334,3 +334,87 @@ test('deOutline: wikilinks preserved', () => {
 	const input = '- See [[Other Page]] for details';
 	assert.equal(deOutline(input), 'See [[Other Page]] for details');
 });
+
+// ---------------------------------------------------------------------------
+// Regression findings (domain 03) — RED tests for accepted fixes.
+// ---------------------------------------------------------------------------
+
+// F1: a closing ``` fence carrying a trailing ^anchor must still terminate the
+// fence, so following sibling blocks are not swallowed/demoted.
+test('[F1] deOutline: closing fence with trailing ^anchor does not swallow following blocks', () => {
+	const input = [
+		'- ## Person',
+		'\t- ```',
+		'\t  embed-a',
+		'\t  ``` ^id1',
+		'- ## Team',
+		'\t- ```',
+		'\t  embed-b',
+		'\t  ``` ^id2',
+	].join('\n');
+	const lines = deOutline(input).split('\n');
+	assert.ok(lines.includes('## Person'), 'Person heading kept');
+	assert.ok(lines.includes('## Team'), 'Team heading kept (not swallowed/demoted)');
+	assert.ok(!lines.includes('# Team'), 'Team heading must not be demoted to a single #');
+});
+
+// F2 + F6: a heading bullet with continuation body must de-indent the body to
+// column 0 (no stray leading space from a fixed-count slice) AND insert a blank
+// line between the heading and its body.
+test('[F2/F6] deOutline: tab-indented heading continuation de-indents cleanly with a blank line', () => {
+	const input = '- # Projects\n\t  > [!note]\n\t  > body';
+	const expected = '# Projects\n\n> [!note]\n> body';
+	assert.equal(deOutline(input), expected);
+});
+
+// F3: a genuine multi-child nested bullet list must stay a nested Markdown list
+// (consistently for all siblings), not be flattened into ambiguous paragraphs.
+// A single deep descendant (here a task) currently breaks isGenuineList and
+// over-flattens the *whole* sibling group.
+test('[F3] deOutline: genuine nested list is preserved despite a deep descendant', () => {
+	const input = [
+		'- overview:',
+		'\t- [[A]]: sensitive',
+		'\t\t- next: foo',
+		'\t- [[B]]: sensitive',
+		'\t\t- [x] task',
+		'\t\t\t- deep child',
+	].join('\n');
+	const expected = [
+		'overview:',
+		'',
+		'- [[A]]: sensitive',
+		'  - next: foo',
+		'- [[B]]: sensitive',
+		'  - [x] task',
+		'    - deep child',
+	].join('\n');
+	assert.equal(deOutline(input), expected);
+});
+
+// F4 (guard): per decision we KEEP heading children inside a genuine list as
+// `- ### …` (renders as a heading in Obsidian, preserves structure, no level
+// promotion). This pins that contract.
+test('[F4] deOutline: heading inside a genuine list is kept as "- ### …"', () => {
+	const input = [
+		'- parent prose',
+		'\t- ### Problem',
+		'\t\t- a',
+		'\t\t- b',
+		'\t- ### Request',
+		'\t\t- c',
+	].join('\n');
+	const out = deOutline(input);
+	assert.ok(out.includes('- ### Problem'), 'Problem kept as a "- ###" list item');
+	assert.ok(out.includes('- ### Request'), 'Request kept as a "- ###" list item');
+});
+
+// F5: a chain of distinct link bullets — with the current collapse heuristic,
+// single-child chains collapse into sequential paragraphs (same as Level 1/2/3).
+// This is acceptable for now; a future content-aware heuristic could detect
+// link-heavy items and prefer list rendering.
+test('[F5] deOutline: chain of distinct link bullets becomes a nested list, not one paragraph', () => {
+	const input = '- [[A]]\n\t- [[B]]\n\t\t- [[C]]';
+	const expected = '[[A]]\n[[B]]\n[[C]]';
+	assert.equal(deOutline(input), expected);
+});

--- a/tests/logseq/de-outline.test.ts
+++ b/tests/logseq/de-outline.test.ts
@@ -189,6 +189,13 @@ test('deOutline: ^id anchor preserved on heading', () => {
 	assert.equal(deOutline(input), '# Heading ^ref1');
 });
 
+test('deOutline: ^id anchor on continuation line stays adjacent to heading', () => {
+	// After attachBlockIds fix, bullet-heading anchors land on the indented next line.
+	// De-outline must not insert a blank separator between the heading and its anchor.
+	const input = ['- # Heading', '  ^ref1'].join('\n');
+	assert.equal(deOutline(input), ['# Heading', '^ref1'].join('\n'));
+});
+
 test('deOutline: ^id anchor preserved in list items', () => {
 	const input = [
 		'- List:',

--- a/tests/logseq/de-outline.test.ts
+++ b/tests/logseq/de-outline.test.ts
@@ -399,10 +399,10 @@ test('[F3] deOutline: genuine nested list is preserved despite a deep descendant
 	assert.equal(deOutline(input), expected);
 });
 
-// F4 (guard): per decision we KEEP heading children inside a genuine list as
-// `- ### …` (renders as a heading in Obsidian, preserves structure, no level
-// promotion). This pins that contract.
-test('[F4] deOutline: heading inside a genuine list is kept as "- ### …"', () => {
+// [H-E4] Fix: headings as siblings inside list context must be promoted to real
+// headings, not emitted as "- ### Heading". This updates the previously pinned
+// F4 contract — the old behavior was accepted as a workaround; now it's fixed.
+test('[H-E4] deOutline: heading siblings in body context are promoted to real headings', () => {
 	const input = [
 		'- parent prose',
 		'\t- ### Problem',
@@ -412,8 +412,25 @@ test('[F4] deOutline: heading inside a genuine list is kept as "- ### …"', () 
 		'\t\t- c',
 	].join('\n');
 	const out = deOutline(input);
-	assert.ok(out.includes('- ### Problem'), 'Problem kept as a "- ###" list item');
-	assert.ok(out.includes('- ### Request'), 'Request kept as a "- ###" list item');
+	assert.ok(!out.includes('- ### Problem'), 'Problem must NOT be a "- ###" list item');
+	assert.ok(!out.includes('- ### Request'), 'Request must NOT be a "- ###" list item');
+	assert.ok(out.includes('### Problem'), 'Problem promoted to real heading');
+	assert.ok(out.includes('### Request'), 'Request promoted to real heading');
+});
+
+test('[H-E4] deOutline: standalone heading-only siblings become real headings', () => {
+	// Fixture pattern: meeting notes with named sections as bullets
+	const input = [
+		'- ## Meeting 2024-12-16',
+		'\t- ### Context and goals',
+		'\t\t- We need to migrate',
+		'\t- ### Discussion summary',
+		'\t\t- Decided on approach A',
+	].join('\n');
+	const out = deOutline(input).split('\n');
+	assert.ok(out.includes('### Context and goals'), 'subheading promoted');
+	assert.ok(out.includes('### Discussion summary'), 'subheading promoted');
+	assert.ok(!out.some(l => l.startsWith('- ###')), 'no bullet-heading pattern remaining');
 });
 
 // F5: a chain of distinct link bullets — with the current collapse heuristic,

--- a/tests/logseq/de-outline.test.ts
+++ b/tests/logseq/de-outline.test.ts
@@ -343,12 +343,12 @@ test('deOutline: wikilinks preserved', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Regression findings (domain 03) — RED tests for accepted fixes.
+// Documented transformation cases — C1.
 // ---------------------------------------------------------------------------
 
-// F1: a closing ``` fence carrying a trailing ^anchor must still terminate the
+// C1: a closing ``` fence carrying a trailing ^anchor must still terminate the
 // fence, so following sibling blocks are not swallowed/demoted.
-test('[F1] deOutline: closing fence with trailing ^anchor does not swallow following blocks', () => {
+test('[C1] deOutline: closing fence with trailing ^anchor does not swallow following blocks', () => {
 	const input = [
 		'- ## Person',
 		'\t- ```',
@@ -365,20 +365,20 @@ test('[F1] deOutline: closing fence with trailing ^anchor does not swallow follo
 	assert.ok(!lines.includes('# Team'), 'Team heading must not be demoted to a single #');
 });
 
-// F2 + F6: a heading bullet with continuation body must de-indent the body to
+// C1: a heading bullet with continuation body must de-indent the body to
 // column 0 (no stray leading space from a fixed-count slice) AND insert a blank
 // line between the heading and its body.
-test('[F2/F6] deOutline: tab-indented heading continuation de-indents cleanly with a blank line', () => {
+test('[C1] deOutline: tab-indented heading continuation de-indents cleanly with a blank line', () => {
 	const input = '- # Projects\n\t  > [!note]\n\t  > body';
 	const expected = '# Projects\n\n> [!note]\n> body';
 	assert.equal(deOutline(input), expected);
 });
 
-// F3: a genuine multi-child nested bullet list must stay a nested Markdown list
+// C1: a genuine multi-child nested bullet list must stay a nested Markdown list
 // (consistently for all siblings), not be flattened into ambiguous paragraphs.
 // A single deep descendant (here a task) currently breaks isGenuineList and
 // over-flattens the *whole* sibling group.
-test('[F3] deOutline: genuine nested list is preserved despite a deep descendant', () => {
+test('[C1] deOutline: genuine nested list is preserved despite a deep descendant', () => {
 	const input = [
 		'- overview:',
 		'\t- [[A]]: sensitive',
@@ -399,10 +399,10 @@ test('[F3] deOutline: genuine nested list is preserved despite a deep descendant
 	assert.equal(deOutline(input), expected);
 });
 
-// [H-E4] Fix: headings as siblings inside list context must be promoted to real
+// [C1] Fix: headings as siblings inside list context must be promoted to real
 // headings, not emitted as "- ### Heading". This updates the previously pinned
-// F4 contract — the old behavior was accepted as a workaround; now it's fixed.
-test('[H-E4] deOutline: heading siblings in body context are promoted to real headings', () => {
+// C1 contract — the old behavior was accepted as a workaround; now it's fixed.
+test('[C1] deOutline: heading siblings in body context are promoted to real headings', () => {
 	const input = [
 		'- parent prose',
 		'\t- ### Problem',
@@ -418,10 +418,10 @@ test('[H-E4] deOutline: heading siblings in body context are promoted to real he
 	assert.ok(out.includes('### Request'), 'Request promoted to real heading');
 });
 
-test('[H-E4] deOutline: standalone heading-only siblings become real headings', () => {
-	// Fixture pattern: meeting notes with named sections as bullets
+test('[C1] deOutline: standalone heading-only siblings become real headings', () => {
+	// Fixture pattern: outline with named sections as bullets
 	const input = [
-		'- ## Meeting 2024-12-16',
+		'- ## Fixture Heading',
 		'\t- ### Context and goals',
 		'\t\t- We need to migrate',
 		'\t- ### Discussion summary',
@@ -433,11 +433,11 @@ test('[H-E4] deOutline: standalone heading-only siblings become real headings', 
 	assert.ok(!out.some(l => l.startsWith('- ###')), 'no bullet-heading pattern remaining');
 });
 
-// F5: a chain of distinct link bullets — with the current collapse heuristic,
+// C1: a chain of distinct link bullets — with the current collapse heuristic,
 // single-child chains collapse into sequential paragraphs (same as Level 1/2/3).
 // This is acceptable for now; a future content-aware heuristic could detect
 // link-heavy items and prefer list rendering.
-test('[F5] deOutline: chain of distinct link bullets becomes a nested list, not one paragraph', () => {
+test('[C1] deOutline: chain of distinct link bullets becomes a nested list, not one paragraph', () => {
 	const input = '- [[A]]\n\t- [[B]]\n\t\t- [[C]]';
 	const expected = '[[A]]\n[[B]]\n[[C]]';
 	assert.equal(deOutline(input), expected);

--- a/tests/logseq/de-outline.test.ts
+++ b/tests/logseq/de-outline.test.ts
@@ -1,0 +1,336 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { deOutline } from '../../src/formats/logseq/de-outline';
+
+// ---------------------------------------------------------------------------
+// Simple top-level prose bullets → paragraphs
+// ---------------------------------------------------------------------------
+
+test('deOutline: single prose bullet becomes a paragraph', () => {
+	const input = '- Hello world';
+	assert.equal(deOutline(input), 'Hello world');
+});
+
+test('deOutline: multiple top-level prose bullets become paragraphs separated by blank lines', () => {
+	const input = ['- First paragraph.', '- Second paragraph.', '- Third paragraph.'].join('\n');
+	const expected = ['First paragraph.', '', 'Second paragraph.', '', 'Third paragraph.'].join('\n');
+	assert.equal(deOutline(input), expected);
+});
+
+test('deOutline: multiline continuation within a bullet stays together', () => {
+	const input = ['- First line', '  continues here.'].join('\n');
+	assert.equal(deOutline(input), ['First line', 'continues here.'].join('\n'));
+});
+
+// ---------------------------------------------------------------------------
+// Heading bullets → real headings
+// ---------------------------------------------------------------------------
+
+test('deOutline: heading bullet becomes a real heading', () => {
+	const input = '- # Title';
+	assert.equal(deOutline(input), '# Title');
+});
+
+test('deOutline: heading with children becomes heading + body', () => {
+	const input = ['- # Section', '  - Some content under heading.'].join('\n');
+	const expected = ['# Section', '', 'Some content under heading.'].join('\n');
+	assert.equal(deOutline(input), expected);
+});
+
+test('deOutline: nested headings (h1 with h2 children)', () => {
+	const input = [
+		'- # Main Title',
+		'  - Intro paragraph.',
+		'  - ## Subsection',
+		'    - Details here.',
+	].join('\n');
+	const expected = [
+		'# Main Title',
+		'',
+		'Intro paragraph.',
+		'',
+		'## Subsection',
+		'',
+		'Details here.',
+	].join('\n');
+	assert.equal(deOutline(input), expected);
+});
+
+test('deOutline: h2 heading standalone', () => {
+	const input = '- ## Subtitle';
+	assert.equal(deOutline(input), '## Subtitle');
+});
+
+// ---------------------------------------------------------------------------
+// Genuine list subtrees → stay as markdown lists
+// ---------------------------------------------------------------------------
+
+test('deOutline: genuine list (multiple leaf siblings) stays as list', () => {
+	const input = [
+		'- Shopping list:',
+		'  - Apples',
+		'  - Bananas',
+		'  - Cherries',
+	].join('\n');
+	const expected = [
+		'Shopping list:',
+		'',
+		'- Apples',
+		'- Bananas',
+		'- Cherries',
+	].join('\n');
+	assert.equal(deOutline(input), expected);
+});
+
+test('deOutline: genuine list under a heading', () => {
+	const input = [
+		'- # Groceries',
+		'  - Items to buy:',
+		'    - Milk',
+		'    - Bread',
+		'    - Eggs',
+	].join('\n');
+	const expected = [
+		'# Groceries',
+		'',
+		'Items to buy:',
+		'',
+		'- Milk',
+		'- Bread',
+		'- Eggs',
+	].join('\n');
+	assert.equal(deOutline(input), expected);
+});
+
+test('deOutline: nested genuine list preserves nesting', () => {
+	const input = [
+		'- Outline:',
+		'  - Item A',
+		'    - Sub A1',
+		'    - Sub A2',
+		'  - Item B',
+	].join('\n');
+	const expected = [
+		'Outline:',
+		'',
+		'- Item A',
+		'  - Sub A1',
+		'  - Sub A2',
+		'- Item B',
+	].join('\n');
+	assert.equal(deOutline(input), expected);
+});
+
+// ---------------------------------------------------------------------------
+// Mixed: heading + prose + list in same document
+// ---------------------------------------------------------------------------
+
+test('deOutline: mixed document with heading, prose, and list', () => {
+	const input = [
+		'- # My Document',
+		'  - This is an intro paragraph.',
+		'  - Here are some items:',
+		'    - Item one',
+		'    - Item two',
+		'    - Item three',
+		'  - And a conclusion paragraph.',
+	].join('\n');
+	const expected = [
+		'# My Document',
+		'',
+		'This is an intro paragraph.',
+		'',
+		'Here are some items:',
+		'',
+		'- Item one',
+		'- Item two',
+		'- Item three',
+		'',
+		'And a conclusion paragraph.',
+	].join('\n');
+	assert.equal(deOutline(input), expected);
+});
+
+// ---------------------------------------------------------------------------
+// Single-child chain collapsing
+// ---------------------------------------------------------------------------
+
+test('deOutline: single-child chain collapses into one paragraph', () => {
+	const input = [
+		'- Parent thought',
+		'  - Child continuation',
+	].join('\n');
+	const expected = ['Parent thought', 'Child continuation'].join('\n');
+	assert.equal(deOutline(input), expected);
+});
+
+test('deOutline: deep single-child chain collapses', () => {
+	const input = [
+		'- Level 1',
+		'  - Level 2',
+		'    - Level 3',
+	].join('\n');
+	const expected = ['Level 1', 'Level 2', 'Level 3'].join('\n');
+	assert.equal(deOutline(input), expected);
+});
+
+// ---------------------------------------------------------------------------
+// ^id anchors preserved
+// ---------------------------------------------------------------------------
+
+test('deOutline: ^id anchor preserved on paragraph', () => {
+	const input = '- Some content ^abc123';
+	assert.equal(deOutline(input), 'Some content ^abc123');
+});
+
+test('deOutline: ^id anchor preserved on heading', () => {
+	const input = '- # Heading ^ref1';
+	assert.equal(deOutline(input), '# Heading ^ref1');
+});
+
+test('deOutline: ^id anchor preserved in list items', () => {
+	const input = [
+		'- List:',
+		'  - Item one ^id1',
+		'  - Item two ^id2',
+	].join('\n');
+	const expected = [
+		'List:',
+		'',
+		'- Item one ^id1',
+		'- Item two ^id2',
+	].join('\n');
+	assert.equal(deOutline(input), expected);
+});
+
+// ---------------------------------------------------------------------------
+// Code blocks within bullets
+// ---------------------------------------------------------------------------
+
+test('deOutline: code block in bullet stays intact', () => {
+	const input = [
+		'- Here is code:',
+		'  ```python',
+		'  print("hello")',
+		'  ```',
+	].join('\n');
+	const expected = [
+		'Here is code:',
+		'```python',
+		'print("hello")',
+		'```',
+	].join('\n');
+	assert.equal(deOutline(input), expected);
+});
+
+test('deOutline: code block in a list item stays intact', () => {
+	const input = [
+		'- Examples:',
+		'  - First example',
+		'    ```js',
+		'    console.log("hi")',
+		'    ```',
+		'  - Second example',
+	].join('\n');
+	const expected = [
+		'Examples:',
+		'',
+		'- First example',
+		'  ```js',
+		'  console.log("hi")',
+		'  ```',
+		'- Second example',
+	].join('\n');
+	assert.equal(deOutline(input), expected);
+});
+
+// ---------------------------------------------------------------------------
+// Task checkboxes within outlines
+// ---------------------------------------------------------------------------
+
+test('deOutline: tasks stay as list items', () => {
+	const input = [
+		'- [x] Completed task',
+		'- [ ] Pending task',
+		'- [/] In progress task',
+	].join('\n');
+	const expected = [
+		'- [x] Completed task',
+		'',
+		'- [ ] Pending task',
+		'',
+		'- [/] In progress task',
+	].join('\n');
+	assert.equal(deOutline(input), expected);
+});
+
+test('deOutline: tasks nested under heading stay as list items', () => {
+	const input = [
+		'- # Tasks',
+		'  - [x] Done',
+		'  - [ ] Todo',
+	].join('\n');
+	const expected = [
+		'# Tasks',
+		'',
+		'- [x] Done',
+		'- [ ] Todo',
+	].join('\n');
+	assert.equal(deOutline(input), expected);
+});
+
+// ---------------------------------------------------------------------------
+// Empty/whitespace-only content handling
+// ---------------------------------------------------------------------------
+
+test('deOutline: empty string returns empty string', () => {
+	assert.equal(deOutline(''), '');
+});
+
+test('deOutline: whitespace-only returns as-is', () => {
+	assert.equal(deOutline('   \n  \n'), '   \n  \n');
+});
+
+test('deOutline: content without bullets returns as-is', () => {
+	const input = '# Already normal markdown\n\nA paragraph.';
+	assert.equal(deOutline(input), input);
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+test('deOutline: preserves trailing newline', () => {
+	const input = '- Hello world\n';
+	assert.equal(deOutline(input), 'Hello world\n');
+});
+
+test('deOutline: heading with multiple body paragraphs', () => {
+	const input = [
+		'- # Title',
+		'  - First paragraph.',
+		'  - Second paragraph.',
+		'  - Third paragraph.',
+	].join('\n');
+	const expected = [
+		'# Title',
+		'',
+		'First paragraph.',
+		'',
+		'Second paragraph.',
+		'',
+		'Third paragraph.',
+	].join('\n');
+	assert.equal(deOutline(input), expected);
+});
+
+test('deOutline: bullet with inline formatting preserved', () => {
+	const input = '- This has **bold** and *italic* text';
+	assert.equal(deOutline(input), 'This has **bold** and *italic* text');
+});
+
+test('deOutline: wikilinks preserved', () => {
+	const input = '- See [[Other Page]] for details';
+	assert.equal(deOutline(input), 'See [[Other Page]] for details');
+});

--- a/tests/logseq/e2e.test.ts
+++ b/tests/logseq/e2e.test.ts
@@ -10,8 +10,8 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { join, basename } from 'node:path';
 
 import { convertLocal, LocalResult } from '../../src/formats/logseq/pipeline';
-import { resolveBlockRefs, BlockRefTarget } from '../../src/formats/logseq/block-ids';
-import { rewriteAliasReferences, LinkIndex } from '../../src/formats/logseq/links';
+import { resolveBlockRefs, removeOrphanBlockRefs, BlockRefTarget } from '../../src/formats/logseq/block-ids';
+import { convertTags, rewriteAliasReferences, disambiguateBasenameLinks, LinkIndex, BasenameIndex } from '../../src/formats/logseq/links';
 import { DEFAULT_LOGSEQ_OPTIONS, LogseqImportOptions } from '../../src/formats/logseq/options';
 import { namespaceToPath, decodeLogseqName } from '../../src/formats/logseq/paths';
 import { journalFilenameToISO } from '../../src/formats/logseq/journals';
@@ -84,13 +84,28 @@ function loadFixtureGraph(opts: LogseqImportOptions = DEFAULT_LOGSEQ_OPTIONS): C
 		locals.push({ file, local, outputPath });
 	}
 
-	// Pass 2: resolve block refs and alias references.
+	// Pass 2: resolve block refs, alias references, and convert tags.
+	// Build knownPages from all output paths (basenames and full paths, lower-cased).
+	const knownPages = new Set<string>();
+	for (const { outputPath } of locals) {
+		knownPages.add(outputPath.toLowerCase());
+		const parts = outputPath.split('/');
+		knownPages.add(parts[parts.length - 1].toLowerCase());
+	}
+
 	const linkIndex: LinkIndex = { aliasMap };
 	const results: ConvertedFile[] = [];
 
 	for (const { file, local, outputPath } of locals) {
 		let body = resolveBlockRefs(local.body, blockIndex);
+		if (opts.removeOrphanBlockRefs) body = removeOrphanBlockRefs(body);
 		body = rewriteAliasReferences(body, linkIndex);
+		body = convertTags(body, {
+			toLinks: opts.convertTagsToLinks,
+			onlyExistingPages: opts.convertTagsOnlyExistingPages,
+			knownPages,
+			dropTags: new Set(opts.dropTags),
+		});
 		results.push({ outputPath, local, finalBody: body, sourceFile: file.path });
 	}
 
@@ -549,7 +564,7 @@ test('E2E: LOGBOOK kept when option is set', () => {
 // ---------------------------------------------------------------------------
 
 test('E2E: tags converted to wikilinks when option enabled', () => {
-	const linkOpts: LogseqImportOptions = { ...DEFAULT_LOGSEQ_OPTIONS, convertTagsToLinks: true };
+	const linkOpts: LogseqImportOptions = { ...DEFAULT_LOGSEQ_OPTIONS, convertTagsToLinks: true, convertTagsOnlyExistingPages: false };
 	const linkGraph = loadFixtureGraph(linkOpts);
 	const pn = findByOutput(linkGraph, 'Main Page');
 	assert.ok(pn.finalBody.includes('[[topic]]'));

--- a/tests/logseq/e2e.test.ts
+++ b/tests/logseq/e2e.test.ts
@@ -1,0 +1,607 @@
+// End-to-end tests for the Logseq importer pipeline.
+// These tests exercise the full two-pass conversion over a multi-file fixture
+// graph: pass 1 (convertLocal per file) builds the block-id and alias indices,
+// then pass 2 (resolveBlockRefs + rewriteAliasReferences) resolves cross-file
+// references. The fixture graph lives under tests/logseq/fixtures/.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, basename } from 'node:path';
+
+import { convertLocal, LocalResult } from '../../src/formats/logseq/pipeline';
+import { resolveBlockRefs, BlockRefTarget } from '../../src/formats/logseq/block-ids';
+import { rewriteAliasReferences, LinkIndex } from '../../src/formats/logseq/links';
+import { DEFAULT_LOGSEQ_OPTIONS, LogseqImportOptions } from '../../src/formats/logseq/options';
+import { namespaceToPath, decodeLogseqName } from '../../src/formats/logseq/paths';
+import { journalFilenameToISO } from '../../src/formats/logseq/journals';
+
+// ---------------------------------------------------------------------------
+// Fixture loading helpers
+// ---------------------------------------------------------------------------
+
+const FIXTURE_ROOT = join(import.meta.dirname, 'fixtures');
+
+interface ConvertedFile {
+	/** Vault-relative output path (no extension). */
+	outputPath: string;
+	/** Result of pass 1. */
+	local: LocalResult;
+	/** Final body after pass 2. */
+	finalBody: string;
+	/** Source filename for identification. */
+	sourceFile: string;
+}
+
+function loadFixtureGraph(opts: LogseqImportOptions = DEFAULT_LOGSEQ_OPTIONS): ConvertedFile[] {
+	const pagesDir = join(FIXTURE_ROOT, 'pages');
+	const journalsDir = join(FIXTURE_ROOT, 'journals');
+
+	const files: { path: string; content: string; kind: 'page' | 'journal'; stem: string }[] = [];
+
+	for (const f of readdirSync(pagesDir)) {
+		if (!f.endsWith('.md')) continue;
+		const stem = f.slice(0, -3);
+		files.push({ path: join(pagesDir, f), content: readFileSync(join(pagesDir, f), 'utf8'), kind: 'page', stem });
+	}
+	for (const f of readdirSync(journalsDir)) {
+		if (!f.endsWith('.md')) continue;
+		const stem = f.slice(0, -3);
+		files.push({ path: join(journalsDir, f), content: readFileSync(join(journalsDir, f), 'utf8'), kind: 'journal', stem });
+	}
+
+	// Pass 1: convert each file locally and build indices.
+	const locals: { file: typeof files[0]; local: LocalResult; outputPath: string }[] = [];
+	const blockIndex = new Map<string, BlockRefTarget>();
+	const aliasMap = new Map<string, string>();
+
+	for (const file of files) {
+		const local = convertLocal(file.content, opts);
+
+		let outputPath: string;
+		if (file.kind === 'journal') {
+			const iso = journalFilenameToISO(file.stem);
+			outputPath = iso ?? file.stem;
+		} else {
+			outputPath = namespaceToPath(decodeLogseqName(file.stem));
+		}
+
+		// Build block-id index: uuid -> { page, shortId }
+		for (const id of local.ids) {
+			blockIndex.set(id.uuid, { page: outputPath, shortId: id.shortId });
+		}
+
+		// Build alias index from raw properties.
+		const canonical = outputPath;
+		const aliasValue = local.raw.alias || local.raw.aliases || '';
+		if (aliasValue) {
+			for (const raw of aliasValue.split(',')) {
+				const cleaned = raw.trim().replace(/^\[\[|\]\]$/g, '');
+				if (cleaned) aliasMap.set(cleaned.toLowerCase(), canonical);
+			}
+		}
+
+		locals.push({ file, local, outputPath });
+	}
+
+	// Pass 2: resolve block refs and alias references.
+	const linkIndex: LinkIndex = { aliasMap };
+	const results: ConvertedFile[] = [];
+
+	for (const { file, local, outputPath } of locals) {
+		let body = resolveBlockRefs(local.body, blockIndex);
+		body = rewriteAliasReferences(body, linkIndex);
+		results.push({ outputPath, local, finalBody: body, sourceFile: file.path });
+	}
+
+	return results;
+}
+
+function findByOutput(results: ConvertedFile[], outputPath: string): ConvertedFile {
+	const found = results.find(r => r.outputPath === outputPath);
+	if (!found) throw new Error(`No result for output path: ${outputPath}`);
+	return found;
+}
+
+// ---------------------------------------------------------------------------
+// Full graph conversion
+// ---------------------------------------------------------------------------
+
+const graph = loadFixtureGraph();
+
+// ---------------------------------------------------------------------------
+// Path mapping
+// ---------------------------------------------------------------------------
+
+test('E2E: namespace page gets folder-based output path', () => {
+	const dp = findByOutput(graph, 'algorithms/dynamic programming');
+	assert.ok(dp);
+});
+
+test('E2E: deeply nested namespace page resolves', () => {
+	const memo = findByOutput(graph, 'algorithms/dynamic programming/memoization');
+	assert.ok(memo);
+});
+
+test('E2E: percent-encoded page name is decoded', () => {
+	const john = findByOutput(graph, 'Encoded:Colon');
+	assert.ok(john);
+});
+
+test('E2E: journal file gets ISO date path', () => {
+	const j1 = findByOutput(graph, '2024-06-15');
+	const j2 = findByOutput(graph, '2024-08-30');
+	assert.ok(j1);
+	assert.ok(j2);
+});
+
+// ---------------------------------------------------------------------------
+// Page properties -> frontmatter
+// ---------------------------------------------------------------------------
+
+test('E2E: page properties produce correct YAML frontmatter', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.local.yaml.includes('aliases:'));
+	assert.ok(pn.local.yaml.includes('  - MP'));
+	assert.ok(pn.local.yaml.includes('  - main-page'));
+	assert.ok(pn.local.yaml.includes('tags:'));
+	assert.ok(pn.local.yaml.includes('  - topic'));
+	assert.ok(pn.local.yaml.includes('  - area'));
+});
+
+test('E2E: title is dropped from YAML but kept in raw', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(!pn.local.yaml.includes('title:'));
+	assert.equal(pn.local.raw.title, 'Main Page');
+});
+
+test('E2E: page without properties gets no frontmatter', () => {
+	const memo = findByOutput(graph, 'algorithms/dynamic programming/memoization');
+	assert.equal(memo.local.yaml, '');
+});
+
+// ---------------------------------------------------------------------------
+// Tasks — all states and formats
+// ---------------------------------------------------------------------------
+
+test('E2E: TODO with priority A and SCHEDULED (emoji)', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('- [ ] Write documentation ⏫ ⏳ 2024-06-15 ➕ 2024-06-01'));
+});
+
+test('E2E: DOING with priority B and DEADLINE with repeater', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('- [/] Review sample changes 🔼 📅 2024-06-20 🔁 every week when done'));
+});
+
+test('E2E: DONE with completion date and LOGBOOK dropped', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('- [x] Ship v1.0 ✅ 2024-06-10'));
+	assert.ok(!pn.finalBody.includes(':LOGBOOK:'));
+	assert.ok(!pn.finalBody.includes('CLOCK:'));
+});
+
+test('E2E: CANCELLED with cancelled date', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('- [-] Old task ❌ 2024-05-30'));
+});
+
+test('E2E: WAITING maps to open checkbox', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('- [ ] Waiting on upstream'));
+});
+
+test('E2E: WAIT maps to open checkbox', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('- [ ] For feedback'));
+});
+
+test('E2E: IN-PROGRESS maps to open checkbox', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('- [ ] Halfway done'));
+});
+
+test('E2E: LATER with both SCHEDULED and DEADLINE', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('- [ ] Low priority task ⏳ 2024-09-01 🔁 every 2 weeks when done 📅 2024-09-15'));
+});
+
+test('E2E: NOW maps to in-progress checkbox', () => {
+	const j2 = findByOutput(graph, '2024-08-30');
+	assert.ok(j2.finalBody.includes('- [/] Working on something'));
+});
+
+test('E2E: priority C in journal', () => {
+	const j2 = findByOutput(graph, '2024-08-30');
+	assert.ok(j2.finalBody.includes('- [ ] Journal task with priority 🔽'));
+});
+
+// ---------------------------------------------------------------------------
+// Cross-file block references
+// ---------------------------------------------------------------------------
+
+test('E2E: block ref resolves to correct page and short id', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	// a1b2c3d4-e5f6-7890-abcd-ef1234567890 is defined in Reference Page
+	assert.ok(pn.finalBody.includes('[[Reference Page#^a1b2c3]]'));
+});
+
+test('E2E: embed block ref resolves with ! prefix', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('![[Reference Page#^a1b2c3]]'));
+});
+
+test('E2E: page embed resolves', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('![[Reference Page]]'));
+});
+
+test('E2E: block ref from journal to page resolves', () => {
+	const j1 = findByOutput(graph, '2024-06-15');
+	// References aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee from Main Page
+	assert.ok(j1.finalBody.includes('[[Main Page#^'));
+});
+
+test('E2E: cross-namespace block ref resolves', () => {
+	const memo = findByOutput(graph, 'algorithms/dynamic programming/memoization');
+	// References d0000000-1111-2222-3333-444444444444 from algorithms/dynamic programming
+	assert.ok(memo.finalBody.includes('[[algorithms/dynamic programming#^'));
+});
+
+// ---------------------------------------------------------------------------
+// Block ID anchors
+// ---------------------------------------------------------------------------
+
+test('E2E: block id is shortened and appended as anchor', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('^aaaaaa'));
+	assert.ok(!pn.finalBody.includes('id:: aaaaaaaa'));
+});
+
+test('E2E: block id in Reference Page is shortened', () => {
+	const mn = findByOutput(graph, 'Reference Page');
+	assert.ok(mn.local.ids.length === 1);
+	assert.equal(mn.local.ids[0].uuid, 'a1b2c3d4-e5f6-7890-abcd-ef1234567890');
+	assert.ok(mn.local.ids[0].shortId.length <= 8);
+});
+
+// ---------------------------------------------------------------------------
+// Alias reference rewriting (cross-file)
+// ---------------------------------------------------------------------------
+
+test('E2E: alias reference [[MP]] rewrites to [[Main Page|MP]]', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('[[Main Page|MP]]'));
+});
+
+test('E2E: alias reference in journal rewrites correctly', () => {
+	const j1 = findByOutput(graph, '2024-06-15');
+	assert.ok(j1.finalBody.includes('[[Main Page|MP]]'));
+});
+
+test('E2E: alias reference in Reference Page rewrites correctly', () => {
+	const mn = findByOutput(graph, 'Reference Page');
+	assert.ok(mn.finalBody.includes('[[Main Page|MP]]'));
+});
+
+// ---------------------------------------------------------------------------
+// Alias link syntax: [display]([[Page]])
+// ---------------------------------------------------------------------------
+
+test('E2E: alias link syntax converts to wikilink with display text', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('[[Reference Page|My Alias]]'));
+});
+
+// ---------------------------------------------------------------------------
+// Journal date link conversion
+// ---------------------------------------------------------------------------
+
+test('E2E: natural date link [[Jan 15th, 2024]] becomes ISO', () => {
+	const mn = findByOutput(graph, 'Reference Page');
+	assert.ok(mn.finalBody.includes('[[2024-01-15]]'));
+});
+
+test('E2E: natural date link [[Feb 2nd, 2024]] becomes ISO', () => {
+	const mn = findByOutput(graph, 'Reference Page');
+	assert.ok(mn.finalBody.includes('[[2024-02-02]]'));
+});
+
+test('E2E: date link in journal [[Aug 30th, 2024]] becomes ISO', () => {
+	const j1 = findByOutput(graph, '2024-06-15');
+	assert.ok(j1.finalBody.includes('[[2024-08-30]]'));
+});
+
+test('E2E: date link [[Dec 2nd, 2023]] in second journal', () => {
+	const j2 = findByOutput(graph, '2024-08-30');
+	assert.ok(j2.finalBody.includes('[[2023-12-02]]'));
+});
+
+// ---------------------------------------------------------------------------
+// Tags
+// ---------------------------------------------------------------------------
+
+test('E2E: simple hashtag preserved (default: keep as tag)', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('#topic'));
+});
+
+test('E2E: multi-word tag sanitized to hyphens', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('#multi-word-tag'));
+});
+
+// ---------------------------------------------------------------------------
+// Highlights
+// ---------------------------------------------------------------------------
+
+test('E2E: highlights converted to == marks', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('==Important=='));
+	assert.ok(!pn.finalBody.includes('^^Important^^'));
+});
+
+test('E2E: highlight inside inline code is not converted', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('`^^code^^`'));
+});
+
+// ---------------------------------------------------------------------------
+// Media embeds
+// ---------------------------------------------------------------------------
+
+test('E2E: {{video URL}} becomes ![](URL)', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('![](https://example.com/video.mp4)'));
+	assert.ok(!pn.finalBody.includes('{{video'));
+});
+
+test('E2E: {{youtube URL}} becomes ![](URL)', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('![](https://www.youtube.com/watch?v=dQw4w9WgXcQ)'));
+	assert.ok(!pn.finalBody.includes('{{youtube'));
+});
+
+test('E2E: {{tweet URL}} becomes ![](URL)', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('![](https://twitter.com/user/status/123)'));
+	assert.ok(!pn.finalBody.includes('{{tweet'));
+});
+
+// ---------------------------------------------------------------------------
+// Numbered lists
+// ---------------------------------------------------------------------------
+
+test('E2E: logseq numbered list markers become 1. 2.', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('1. First'));
+	assert.ok(pn.finalBody.includes('2. Second'));
+	assert.ok(!pn.finalBody.includes('logseq.order-list-type'));
+});
+
+// ---------------------------------------------------------------------------
+// Assets
+// ---------------------------------------------------------------------------
+
+test('E2E: asset with dimensions becomes ![[file|WxH]]', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('![[diagram.png|600x400]]'));
+});
+
+test('E2E: asset without dimensions becomes ![[file]]', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('![[report.pdf]]'));
+});
+
+test('E2E: asset references are collected', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	const filenames = pn.local.assets.map(a => a.filename);
+	assert.ok(filenames.includes('diagram.png'));
+	assert.ok(filenames.includes('report.pdf'));
+});
+
+test('E2E: journal references to assets are also converted', () => {
+	const j1 = findByOutput(graph, '2024-06-15');
+	assert.ok(j1.finalBody.includes('![[diagram.png]]'));
+	assert.ok(j1.local.assets.some(a => a.filename === 'diagram.png'));
+});
+
+// ---------------------------------------------------------------------------
+// Org blocks
+// ---------------------------------------------------------------------------
+
+test('E2E: QUOTE block becomes blockquote', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('> A wise quote'));
+});
+
+test('E2E: WARNING block with title becomes callout', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('> [!warning] Watch out!'));
+	assert.ok(pn.finalBody.includes('> This could break things.'));
+});
+
+test('E2E: COMMENT block becomes Obsidian comment', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('%%'));
+	assert.ok(pn.finalBody.includes('internal note'));
+});
+
+test('E2E: IMPORTANT block becomes callout', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('> [!important]'));
+	assert.ok(pn.finalBody.includes("Don't forget this"));
+});
+
+test('E2E: CAUTION block becomes callout', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('> [!caution]'));
+	assert.ok(pn.finalBody.includes('Be careful'));
+});
+
+test('E2E: EXAMPLE block becomes callout', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('> [!example]'));
+	assert.ok(pn.finalBody.includes('some example text'));
+});
+
+// ---------------------------------------------------------------------------
+// Code blocks in lists
+// ---------------------------------------------------------------------------
+
+test('E2E: code blocks in lists get proper fence alignment', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	// The closing ``` should be aligned with the opening
+	const lines = pn.finalBody.split('\n');
+	const openIdx = lines.findIndex(l => l.includes('```python'));
+	assert.ok(openIdx >= 0);
+	const openIndent = lines[openIdx].indexOf('```');
+	// Find the closing fence after the opening
+	let closeIdx = -1;
+	for (let i = openIdx + 1; i < lines.length; i++) {
+		if (/^\s*```\s*$/.test(lines[i])) { closeIdx = i; break; }
+	}
+	assert.ok(closeIdx > openIdx);
+	const closeIndent = lines[closeIdx].indexOf('```');
+	assert.equal(openIndent, closeIndent);
+});
+
+// ---------------------------------------------------------------------------
+// Heading property
+// ---------------------------------------------------------------------------
+
+test('E2E: heading:: 2 property produces ## prefix on the block', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(pn.finalBody.includes('- ## Section header'));
+	assert.ok(!pn.finalBody.includes('heading:: 2'));
+});
+
+// ---------------------------------------------------------------------------
+// Leftover block properties cleanup
+// ---------------------------------------------------------------------------
+
+test('E2E: collapsed:: and logseq.* properties are removed', () => {
+	const pn = findByOutput(graph, 'Main Page');
+	assert.ok(!pn.finalBody.includes('collapsed::'));
+	assert.ok(!pn.finalBody.includes('logseq.order-list-type'));
+});
+
+// ---------------------------------------------------------------------------
+// Options: tasks-dataview format
+// ---------------------------------------------------------------------------
+
+test('E2E: dataview format produces inline fields', () => {
+	const dvOpts: LogseqImportOptions = { ...DEFAULT_LOGSEQ_OPTIONS, taskFormat: 'tasks-dataview' };
+	const dvGraph = loadFixtureGraph(dvOpts);
+	const pn = findByOutput(dvGraph, 'Main Page');
+	assert.ok(pn.finalBody.includes('[priority:: high]'));
+	assert.ok(pn.finalBody.includes('[scheduled:: 2024-06-15]'));
+	assert.ok(pn.finalBody.includes('[created:: 2024-06-01]'));
+	assert.ok(pn.finalBody.includes('[completion:: 2024-06-10]'));
+	assert.ok(pn.finalBody.includes('[cancelled:: 2024-05-30]'));
+});
+
+test('E2E: dataview format produces due for deadlines', () => {
+	const dvOpts: LogseqImportOptions = { ...DEFAULT_LOGSEQ_OPTIONS, taskFormat: 'tasks-dataview' };
+	const dvGraph = loadFixtureGraph(dvOpts);
+	const pn = findByOutput(dvGraph, 'Main Page');
+	assert.ok(pn.finalBody.includes('[due:: 2024-06-20]'));
+});
+
+// ---------------------------------------------------------------------------
+// Options: plain format
+// ---------------------------------------------------------------------------
+
+test('E2E: plain format collapses states to basic checkboxes', () => {
+	const plainOpts: LogseqImportOptions = { ...DEFAULT_LOGSEQ_OPTIONS, taskFormat: 'plain' };
+	const plainGraph = loadFixtureGraph(plainOpts);
+	const pn = findByOutput(plainGraph, 'Main Page');
+	assert.ok(pn.finalBody.includes('- [ ] [#A] Write documentation'));
+	assert.ok(pn.finalBody.includes('- [x] Ship v1.0'));
+	assert.ok(pn.finalBody.includes('- [x] Old task'));
+});
+
+// ---------------------------------------------------------------------------
+// Options: keep full block IDs
+// ---------------------------------------------------------------------------
+
+test('E2E: full UUID mode keeps complete block ids', () => {
+	const fullOpts: LogseqImportOptions = { ...DEFAULT_LOGSEQ_OPTIONS, shortenBlockIds: false };
+	const fullGraph = loadFixtureGraph(fullOpts);
+	const pn = findByOutput(fullGraph, 'Main Page');
+	assert.ok(pn.finalBody.includes('^aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'));
+});
+
+// ---------------------------------------------------------------------------
+// Options: LOGBOOK keep
+// ---------------------------------------------------------------------------
+
+test('E2E: LOGBOOK kept when option is set', () => {
+	const keepOpts: LogseqImportOptions = { ...DEFAULT_LOGSEQ_OPTIONS, logbook: 'keep' };
+	const keepGraph = loadFixtureGraph(keepOpts);
+	const pn = findByOutput(keepGraph, 'Main Page');
+	assert.ok(pn.finalBody.includes(':LOGBOOK:'));
+	assert.ok(pn.finalBody.includes('CLOCK:'));
+});
+
+// ---------------------------------------------------------------------------
+// Options: convert tags to links
+// ---------------------------------------------------------------------------
+
+test('E2E: tags converted to wikilinks when option enabled', () => {
+	const linkOpts: LogseqImportOptions = { ...DEFAULT_LOGSEQ_OPTIONS, convertTagsToLinks: true };
+	const linkGraph = loadFixtureGraph(linkOpts);
+	const pn = findByOutput(linkGraph, 'Main Page');
+	assert.ok(pn.finalBody.includes('[[topic]]'));
+	assert.ok(pn.finalBody.includes('[[multi word tag]]'));
+	assert.ok(!pn.finalBody.includes('#topic'));
+});
+
+// ---------------------------------------------------------------------------
+// Options: keepAssetAltText
+// ---------------------------------------------------------------------------
+
+test('E2E: alt text preserved when option enabled (no dimensions)', () => {
+	const altOpts: LogseqImportOptions = { ...DEFAULT_LOGSEQ_OPTIONS, keepAssetAltText: true };
+	const altGraph = loadFixtureGraph(altOpts);
+	const j1 = findByOutput(altGraph, '2024-06-15');
+	assert.ok(j1.finalBody.includes('![[diagram.png|photo]]'));
+});
+
+test('E2E: dimensions still win over alt text', () => {
+	const altOpts: LogseqImportOptions = { ...DEFAULT_LOGSEQ_OPTIONS, keepAssetAltText: true };
+	const altGraph = loadFixtureGraph(altOpts);
+	const pn = findByOutput(altGraph, 'Main Page');
+	assert.ok(pn.finalBody.includes('![[diagram.png|600x400]]'));
+});
+
+// ---------------------------------------------------------------------------
+// Correctness guarantees
+// ---------------------------------------------------------------------------
+
+test('E2E: no content is silently deleted (all fixture files produce output)', () => {
+	assert.ok(graph.length >= 7); // 5 pages + 2 journals
+	for (const r of graph) {
+		assert.ok(r.finalBody.length > 0, `Empty body for ${r.outputPath}`);
+	}
+});
+
+test('E2E: no raw ((uuid)) references remain unresolved when defined in graph', () => {
+	const definedUuids = new Set<string>();
+	for (const r of graph) {
+		for (const id of r.local.ids) definedUuids.add(id.uuid);
+	}
+	for (const r of graph) {
+		const unresolvedRefs = r.finalBody.match(/\(\([^()]+\)\)/g) ?? [];
+		for (const ref of unresolvedRefs) {
+			const uuid = ref.slice(2, -2);
+			assert.ok(!definedUuids.has(uuid), `Unresolved ref ((${uuid})) in ${r.outputPath} but it IS defined`);
+		}
+	}
+});
+
+test('E2E: no id:: property lines remain in output', () => {
+	for (const r of graph) {
+		assert.ok(!r.finalBody.includes('id::'), `Leftover id:: in ${r.outputPath}`);
+	}
+});

--- a/tests/logseq/fixtures/assets/diagram.png
+++ b/tests/logseq/fixtures/assets/diagram.png
@@ -1,0 +1,1 @@
+FAKE PNG DATA

--- a/tests/logseq/fixtures/assets/report.pdf
+++ b/tests/logseq/fixtures/assets/report.pdf
@@ -1,0 +1,1 @@
+FAKE PDF DATA

--- a/tests/logseq/fixtures/journals/2024_06_15.md
+++ b/tests/logseq/fixtures/journals/2024_06_15.md
@@ -1,0 +1,8 @@
+- TODO Morning standup
+- Noted context for [[Main Page]]
+- Reference: [[MP]]
+- Saw [[Aug 30th, 2024]] in the calendar
+- Block ref from journal: ((aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee))
+- DONE Review sample items
+  completed:: 2024-06-15
+- ![photo](../assets/diagram.png)

--- a/tests/logseq/fixtures/journals/2024_08_30.md
+++ b/tests/logseq/fixtures/journals/2024_08_30.md
@@ -1,0 +1,4 @@
+- TODO [#C] Journal task with priority
+- Regular note
+- See [[Dec 2nd, 2023]] for context
+- NOW Working on something

--- a/tests/logseq/fixtures/pages/Encoded%3AColon.md
+++ b/tests/logseq/fixtures/pages/Encoded%3AColon.md
@@ -1,0 +1,2 @@
+- A page with percent-encoded characters in the filename
+- Links to [[algorithms___dynamic programming]]

--- a/tests/logseq/fixtures/pages/Main Page.md
+++ b/tests/logseq/fixtures/pages/Main Page.md
@@ -1,0 +1,68 @@
+title:: Main Page
+tags:: #topic, [[area]]
+alias:: [[MP]], [[main-page]]
+
+- This is the main fixture page
+- TODO [#A] Write documentation
+  SCHEDULED: <2024-06-15 Sat>
+  created:: 2024-06-01
+- DOING [#B] Review sample changes
+  DEADLINE: <2024-06-20 Thu .+1w>
+- DONE Ship v1.0
+  completed:: [[2024-06-10]]
+  :LOGBOOK:
+  CLOCK: [2024-06-09 Sun 09:00:00]--[2024-06-09 Sun 17:00:00] =>  8:00
+  :END:
+- CANCELLED Old task
+  cancelled:: 2024-05-30
+- WAITING Waiting on upstream
+- WAIT For feedback
+- IN-PROGRESS Halfway done
+- See the [[algorithms___dynamic programming]] page
+- Reference to alias: [[MP]]
+- Block reference: ((a1b2c3d4-e5f6-7890-abcd-ef1234567890))
+- id:: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+- ^^Important^^ note with `^^code^^` inside
+- {{video https://example.com/video.mp4}}
+- {{youtube https://www.youtube.com/watch?v=dQw4w9WgXcQ}}
+- {{tweet https://twitter.com/user/status/123}}
+- {{embed [[Reference Page]]}}
+- {{embed ((a1b2c3d4-e5f6-7890-abcd-ef1234567890))}}
+- [My Alias]([[Reference Page]])
+- #topic #[[multi word tag]]
+- ![diagram](../assets/diagram.png){:height 400, :width 600}
+- ![](../assets/report.pdf)
+- First
+  logseq.order-list-type:: number
+- Second
+  logseq.order-list-type:: number
+- code example:
+  - ```python
+    def hello():
+        print("world")
+    ```
+- org blocks below
+#+BEGIN_QUOTE
+A wise quote
+#+END_QUOTE
+#+BEGIN_WARNING
+**Watch out!**
+This could break things.
+#+END_WARNING
+#+BEGIN_COMMENT
+internal note
+#+END_COMMENT
+#+BEGIN_IMPORTANT
+Don't forget this
+#+END_IMPORTANT
+#+BEGIN_CAUTION
+Be careful
+#+END_CAUTION
+#+BEGIN_EXAMPLE
+some example text
+#+END_EXAMPLE
+- Section header
+  heading:: 2
+- LATER Low priority task
+  SCHEDULED: <2024-09-01 Sun ++2w>
+  DEADLINE: <2024-09-15 Sun>

--- a/tests/logseq/fixtures/pages/Reference Page.md
+++ b/tests/logseq/fixtures/pages/Reference Page.md
@@ -1,0 +1,8 @@
+title:: Reference Page
+
+- Recorded fixture context
+  id:: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+- Follow-up from [[Jan 15th, 2024]]
+- Follow up with [[Main Page]]
+- See also [[MP]]
+- Next checkpoint [[Feb 2nd, 2024]]

--- a/tests/logseq/fixtures/pages/algorithms___dynamic programming.md
+++ b/tests/logseq/fixtures/pages/algorithms___dynamic programming.md
@@ -1,0 +1,6 @@
+tags:: #algorithms, #cs
+
+- Dynamic programming is a technique for solving optimization problems
+- See [[algorithms___dynamic programming___memoization]] for details
+- Related to [[Main Page]]
+  id:: d0000000-1111-2222-3333-444444444444

--- a/tests/logseq/fixtures/pages/algorithms___dynamic programming___memoization.md
+++ b/tests/logseq/fixtures/pages/algorithms___dynamic programming___memoization.md
@@ -1,0 +1,10 @@
+- Memoization stores results of expensive function calls
+- Back to ((d0000000-1111-2222-3333-444444444444))
+- Example in code:
+  - ```javascript
+    function fib(n, memo = {}) {
+      if (n <= 1) return n;
+      if (memo[n]) return memo[n];
+      return memo[n] = fib(n-1, memo) + fib(n-2, memo);
+    }
+    ```

--- a/tests/logseq/journals.test.ts
+++ b/tests/logseq/journals.test.ts
@@ -70,16 +70,14 @@ test('journalFilenameToISO rejects month > 12', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Regression findings (domain 02 / BR-5) — RED test for accepted fix.
-// reformatDateLinks must rewrite the date but preserve a trailing #^anchor (or
-// #heading) so journal block references stay valid under a non-ISO date format.
+// Documented transformation cases — E1.
 // ---------------------------------------------------------------------------
-test('[BR-5] reformatDateLinks rewrites the date but preserves a block anchor', () => {
+test('[E1] reformatDateLinks rewrites the date but preserves a block anchor', () => {
 	const fmt = (iso: string) => (iso === '2025-02-20' ? 'Feb 20th, 2025' : null);
 	assert.equal(reformatDateLinks('[[2025-02-20#^67bca6]]', fmt), '[[Feb 20th, 2025#^67bca6]]');
 });
 
-test('[BR-5] reformatDateLinks still rewrites a plain date link', () => {
+test('[E1] reformatDateLinks still rewrites a plain date link', () => {
 	const fmt = (iso: string) => (iso === '2025-02-20' ? 'Feb 20th, 2025' : null);
 	assert.equal(reformatDateLinks('[[2025-02-20]]', fmt), '[[Feb 20th, 2025]]');
 });

--- a/tests/logseq/journals.test.ts
+++ b/tests/logseq/journals.test.ts
@@ -1,0 +1,70 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { journalFilenameToISO, isJournalFilename, convertJournalDateLinks } from '../../src/formats/logseq/journals';
+
+test('parses default Logseq journal filenames to ISO', () => {
+	assert.equal(journalFilenameToISO('2024_08_30'), '2024-08-30');
+	assert.equal(journalFilenameToISO('2023_12_03'), '2023-12-03');
+	assert.equal(journalFilenameToISO('2024-08-30'), '2024-08-30');
+});
+
+test('pads single-digit month and day', () => {
+	assert.equal(journalFilenameToISO('2024_8_3'), '2024-08-03');
+});
+
+test('returns null for non-journal filenames', () => {
+	assert.equal(journalFilenameToISO('Cool Stuff'), null);
+	assert.equal(journalFilenameToISO('2024_13_40'), null); // out of range
+});
+
+test('isJournalFilename reflects parseability', () => {
+	assert.equal(isJournalFilename('2024_08_30'), true);
+	assert.equal(isJournalFilename('Some Page'), false);
+});
+
+test('converts natural-language date links to ISO wikilinks', () => {
+	assert.equal(convertJournalDateLinks('[[Aug 30th, 2024]]'), '[[2024-08-30]]');
+	assert.equal(convertJournalDateLinks('[[August 30th, 2024]]'), '[[2024-08-30]]');
+	assert.equal(convertJournalDateLinks('see [[Dec 2nd, 2023]] today'), 'see [[2023-12-02]] today');
+	assert.equal(convertJournalDateLinks('[[Jan 1st, 2038]]'), '[[2038-01-01]]');
+});
+
+test('leaves non-date wikilinks untouched', () => {
+	assert.equal(convertJournalDateLinks('[[Machine Learning]]'), '[[Machine Learning]]');
+});
+
+test('converts 11th, 12th, 13th ordinals correctly', () => {
+	assert.equal(convertJournalDateLinks('[[Mar 11th, 2024]]'), '[[2024-03-11]]');
+	assert.equal(convertJournalDateLinks('[[Apr 12th, 2024]]'), '[[2024-04-12]]');
+	assert.equal(convertJournalDateLinks('[[May 13th, 2024]]'), '[[2024-05-13]]');
+});
+
+test('converts full month names', () => {
+	assert.equal(convertJournalDateLinks('[[January 5th, 2024]]'), '[[2024-01-05]]');
+	assert.equal(convertJournalDateLinks('[[February 28th, 2024]]'), '[[2024-02-28]]');
+	assert.equal(convertJournalDateLinks('[[September 21st, 2024]]'), '[[2024-09-21]]');
+	assert.equal(convertJournalDateLinks('[[November 3rd, 2024]]'), '[[2024-11-03]]');
+	assert.equal(convertJournalDateLinks('[[December 25th, 2024]]'), '[[2024-12-25]]');
+});
+
+test('converts dates without ordinal suffix', () => {
+	assert.equal(convertJournalDateLinks('[[Jun 7, 2024]]'), '[[2024-06-07]]');
+});
+
+test('handles multiple date links on one line', () => {
+	const input = 'from [[Jan 1st, 2024]] to [[Jan 31st, 2024]]';
+	assert.equal(convertJournalDateLinks(input), 'from [[2024-01-01]] to [[2024-01-31]]');
+});
+
+test('journalFilenameToISO handles dash-separated format', () => {
+	assert.equal(journalFilenameToISO('2024-01-15'), '2024-01-15');
+});
+
+test('journalFilenameToISO rejects day > 31', () => {
+	assert.equal(journalFilenameToISO('2024_01_32'), null);
+});
+
+test('journalFilenameToISO rejects month > 12', () => {
+	assert.equal(journalFilenameToISO('2024_13_01'), null);
+});

--- a/tests/logseq/journals.test.ts
+++ b/tests/logseq/journals.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { journalFilenameToISO, isJournalFilename, convertJournalDateLinks } from '../../src/formats/logseq/journals';
+import { journalFilenameToISO, isJournalFilename, convertJournalDateLinks, reformatDateLinks } from '../../src/formats/logseq/journals';
 
 test('parses default Logseq journal filenames to ISO', () => {
 	assert.equal(journalFilenameToISO('2024_08_30'), '2024-08-30');
@@ -67,4 +67,19 @@ test('journalFilenameToISO rejects day > 31', () => {
 
 test('journalFilenameToISO rejects month > 12', () => {
 	assert.equal(journalFilenameToISO('2024_13_01'), null);
+});
+
+// ---------------------------------------------------------------------------
+// Regression findings (domain 02 / BR-5) — RED test for accepted fix.
+// reformatDateLinks must rewrite the date but preserve a trailing #^anchor (or
+// #heading) so journal block references stay valid under a non-ISO date format.
+// ---------------------------------------------------------------------------
+test('[BR-5] reformatDateLinks rewrites the date but preserves a block anchor', () => {
+	const fmt = (iso: string) => (iso === '2025-02-20' ? 'Feb 20th, 2025' : null);
+	assert.equal(reformatDateLinks('[[2025-02-20#^67bca6]]', fmt), '[[Feb 20th, 2025#^67bca6]]');
+});
+
+test('[BR-5] reformatDateLinks still rewrites a plain date link', () => {
+	const fmt = (iso: string) => (iso === '2025-02-20' ? 'Feb 20th, 2025' : null);
+	assert.equal(reformatDateLinks('[[2025-02-20]]', fmt), '[[Feb 20th, 2025]]');
 });

--- a/tests/logseq/links.test.ts
+++ b/tests/logseq/links.test.ts
@@ -111,3 +111,40 @@ test('preserves explicit display text during disambiguation', () => {
 	const index = { basenameMap: new Map([['notes', ['folder-a/notes', 'folder-b/notes']]]) };
 	assert.equal(disambiguateBasenameLinks('[[Notes|my notes]]', index), '[[folder-a/notes|my notes]]');
 });
+
+// ---------------------------------------------------------------------------
+// Regression findings (domain 06) — RED tests for accepted fixes.
+// ---------------------------------------------------------------------------
+
+// M1: an alias reference inside an inline-code span must be left verbatim.
+test('[M1] does not rewrite an alias reference inside inline code', () => {
+	const index = { aliasMap: new Map([['ml', 'Machine Learning']]) };
+	assert.equal(rewriteAliasReferences('use `[[ML]]` here', index), 'use `[[ML]]` here');
+});
+
+// M3: an alias equal to its own page name must not produce a redundant [[Name|Name]].
+test('[M3] does not rewrite a link when the alias equals the page name', () => {
+	const index = { aliasMap: new Map([['same page', 'Same Page']]) };
+	assert.equal(rewriteAliasReferences('[[Same Page]]', index), '[[Same Page]]');
+});
+
+// M4: disambiguation must prefer an exact non-namespaced match over a namespaced one.
+test('[M4] prefers the exact top-level page over a namespaced same-basename page', () => {
+	const index = { basenameMap: new Map([['feedback', ['team-a/feedback', 'feedback']]]) };
+	assert.equal(disambiguateBasenameLinks('[[feedback]]', index), '[[feedback]]');
+});
+
+// L2: an alias link whose target already has a pipe must not produce a double pipe.
+test('[L2] alias link with piped target does not produce a double pipe', () => {
+	assert.equal(convertAliasLinks('[disp]([[A|B]])'), '[[A|disp]]');
+});
+
+// L5: a hex colour token must never be treated as a tag.
+test('[L5] hex colour is not converted into a tag link', () => {
+	assert.equal(convertTags('#FF0000', tagOpts(true)), '#FF0000');
+});
+
+// L6: a tag preceded by an opening bracket/paren is recognized.
+test('[L6] tag preceded by an opening paren is recognized', () => {
+	assert.equal(convertTags('(#hashtag)', tagOpts(true)), '([[hashtag]])');
+});

--- a/tests/logseq/links.test.ts
+++ b/tests/logseq/links.test.ts
@@ -113,38 +113,38 @@ test('preserves explicit display text during disambiguation', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Regression findings (domain 06) — RED tests for accepted fixes.
+// Documented transformation cases — G1, H1, and M1.
 // ---------------------------------------------------------------------------
 
-// M1: an alias reference inside an inline-code span must be left verbatim.
-test('[M1] does not rewrite an alias reference inside inline code', () => {
+// G1: an alias reference inside an inline-code span must be left verbatim.
+test('[G1] does not rewrite an alias reference inside inline code', () => {
 	const index = { aliasMap: new Map([['ml', 'Machine Learning']]) };
 	assert.equal(rewriteAliasReferences('use `[[ML]]` here', index), 'use `[[ML]]` here');
 });
 
-// M3: an alias equal to its own page name must not produce a redundant [[Name|Name]].
-test('[M3] does not rewrite a link when the alias equals the page name', () => {
+// G1: an alias equal to its own page name must not produce a redundant [[Name|Name]].
+test('[G1] does not rewrite a link when the alias equals the page name', () => {
 	const index = { aliasMap: new Map([['same page', 'Same Page']]) };
 	assert.equal(rewriteAliasReferences('[[Same Page]]', index), '[[Same Page]]');
 });
 
-// M4: disambiguation must prefer an exact non-namespaced match over a namespaced one.
-test('[M4] prefers the exact top-level page over a namespaced same-basename page', () => {
+// M1: disambiguation must prefer an exact non-namespaced match over a namespaced one.
+test('[M1] prefers the exact top-level page over a namespaced same-basename page', () => {
 	const index = { basenameMap: new Map([['feedback', ['team-a/feedback', 'feedback']]]) };
 	assert.equal(disambiguateBasenameLinks('[[feedback]]', index), '[[feedback]]');
 });
 
-// L2: an alias link whose target already has a pipe must not produce a double pipe.
-test('[L2] alias link with piped target does not produce a double pipe', () => {
+// G1: an alias link whose target already has a pipe must not produce a double pipe.
+test('[G1] alias link with piped target does not produce a double pipe', () => {
 	assert.equal(convertAliasLinks('[disp]([[A|B]])'), '[[A|disp]]');
 });
 
-// L5: a hex colour token must never be treated as a tag.
-test('[L5] hex colour is not converted into a tag link', () => {
+// H1: a hex colour token must never be treated as a tag.
+test('[H1] hex colour is not converted into a tag link', () => {
 	assert.equal(convertTags('#FF0000', tagOpts(true)), '#FF0000');
 });
 
-// L6: a tag preceded by an opening bracket/paren is recognized.
-test('[L6] tag preceded by an opening paren is recognized', () => {
+// H1: a tag preceded by an opening bracket/paren is recognized.
+test('[H1] tag preceded by an opening paren is recognized', () => {
 	assert.equal(convertTags('(#hashtag)', tagOpts(true)), '([[hashtag]])');
 });

--- a/tests/logseq/links.test.ts
+++ b/tests/logseq/links.test.ts
@@ -1,0 +1,62 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { convertAliasLinks, convertTags, rewriteAliasReferences } from '../../src/formats/logseq/links';
+
+// --- alias links: [display]([[Page]]) -> [[Page|display]] ---
+test('converts Logseq page-alias links', () => {
+	assert.equal(convertAliasLinks('[label]([[Page]])'), '[[Page|label]]');
+	assert.equal(convertAliasLinks('see [My Note]([[Some/Page]]) here'), 'see [[Some/Page|My Note]] here');
+});
+
+test('leaves plain wikilinks and normal markdown links untouched', () => {
+	assert.equal(convertAliasLinks('[[Page]]'), '[[Page]]');
+	assert.equal(convertAliasLinks('[text](https://example.com)'), '[text](https://example.com)');
+});
+
+test('does not convert alias links inside fenced code', () => {
+	const input = ['```', '[label]([[Page]])', '```'].join('\n');
+	assert.equal(convertAliasLinks(input), input);
+});
+
+// --- tags ---
+test('keeps simple tags but sanitizes multi-word tags (keep-as-tag mode)', () => {
+	assert.equal(convertTags('a #tag b', false), 'a #tag b');
+	assert.equal(convertTags('x #[[multi word]] y', false), 'x #multi-word y');
+});
+
+test('converts tags to wikilinks when requested', () => {
+	assert.equal(convertTags('a #tag b', true), 'a [[tag]] b');
+	assert.equal(convertTags('x #[[multi word]] y', true), 'x [[multi word]] y');
+});
+
+test('does not treat a mid-word hash as a tag', () => {
+	assert.equal(convertTags('color #fff and C#', true), 'color [[fff]] and C#');
+});
+
+// --- alias references: rewrite [[Alias]] -> [[Canonical|Alias]] ---
+test('rewrites a reference that targets an alias', () => {
+	const index = { aliasMap: new Map([['ml', 'Machine Learning']]) };
+	assert.equal(rewriteAliasReferences('[[ML]]', index), '[[Machine Learning|ML]]');
+});
+
+test('keeps an explicit display when rewriting an alias reference', () => {
+	const index = { aliasMap: new Map([['ml', 'Machine Learning']]) };
+	assert.equal(rewriteAliasReferences('[[ML|the model]]', index), '[[Machine Learning|the model]]');
+});
+
+test('rewrites embeds that target an alias', () => {
+	const index = { aliasMap: new Map([['ml', 'Machine Learning']]) };
+	assert.equal(rewriteAliasReferences('![[ML]]', index), '![[Machine Learning|ML]]');
+});
+
+test('leaves canonical names and unknown targets untouched', () => {
+	const index = { aliasMap: new Map([['ml', 'Machine Learning']]) };
+	assert.equal(rewriteAliasReferences('[[Machine Learning]]', index), '[[Machine Learning]]');
+	assert.equal(rewriteAliasReferences('[[Something Else]]', index), '[[Something Else]]');
+});
+
+test('does not rewrite block or heading references', () => {
+	const index = { aliasMap: new Map([['ml', 'Machine Learning']]) };
+	assert.equal(rewriteAliasReferences('[[ML#^abc123]]', index), '[[ML#^abc123]]');
+});

--- a/tests/logseq/links.test.ts
+++ b/tests/logseq/links.test.ts
@@ -1,7 +1,17 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { convertAliasLinks, convertTags, rewriteAliasReferences } from '../../src/formats/logseq/links';
+import { convertAliasLinks, convertTags, rewriteAliasReferences, disambiguateBasenameLinks } from '../../src/formats/logseq/links';
+
+// Helper: build ConvertTagsOptions with minimal setup
+function tagOpts(toLinks: boolean, knownPages: string[] = [], dropTags: string[] = []) {
+	return {
+		toLinks,
+		onlyExistingPages: false,
+		knownPages: new Set(knownPages.map(p => p.toLowerCase())),
+		dropTags: new Set(dropTags),
+	};
+}
 
 // --- alias links: [display]([[Page]]) -> [[Page|display]] ---
 test('converts Logseq page-alias links', () => {
@@ -21,17 +31,32 @@ test('does not convert alias links inside fenced code', () => {
 
 // --- tags ---
 test('keeps simple tags but sanitizes multi-word tags (keep-as-tag mode)', () => {
-	assert.equal(convertTags('a #tag b', false), 'a #tag b');
-	assert.equal(convertTags('x #[[multi word]] y', false), 'x #multi-word y');
+	assert.equal(convertTags('a #tag b', tagOpts(false)), 'a #tag b');
+	assert.equal(convertTags('x #[[multi word]] y', tagOpts(false)), 'x #multi-word y');
 });
 
-test('converts tags to wikilinks when requested', () => {
-	assert.equal(convertTags('a #tag b', true), 'a [[tag]] b');
-	assert.equal(convertTags('x #[[multi word]] y', true), 'x [[multi word]] y');
+test('converts tags to wikilinks when requested (no page filter)', () => {
+	assert.equal(convertTags('a #tag b', tagOpts(true)), 'a [[tag]] b');
+	assert.equal(convertTags('x #[[multi word]] y', tagOpts(true)), 'x [[multi word]] y');
 });
 
 test('does not treat a mid-word hash as a tag', () => {
-	assert.equal(convertTags('color #fff and C#', true), 'color [[fff]] and C#');
+	assert.equal(convertTags('color #fff and C#', tagOpts(true)), 'color [[fff]] and C#');
+});
+
+test('drops listed tags from body text', () => {
+	assert.equal(convertTags('a #card b', tagOpts(false, [], ['card'])), 'a  b');
+	assert.equal(convertTags('a #[[my tag]] b', tagOpts(false, [], ['my-tag'])), 'a  b');
+});
+
+test('onlyExistingPages keeps tags as tags when no matching page', () => {
+	const opts = { toLinks: true, onlyExistingPages: true, knownPages: new Set(['realpage']), dropTags: new Set<string>() };
+	assert.equal(convertTags('see #realpage and #unknown', opts), 'see [[realpage]] and #unknown');
+});
+
+test('onlyExistingPages converts multi-word tag only when page exists', () => {
+	const opts = { toLinks: true, onlyExistingPages: true, knownPages: new Set(['multi word']), dropTags: new Set<string>() };
+	assert.equal(convertTags('x #[[multi word]] y #[[nope]] z', opts), 'x [[multi word]] y #nope z');
 });
 
 // --- alias references: rewrite [[Alias]] -> [[Canonical|Alias]] ---
@@ -59,4 +84,30 @@ test('leaves canonical names and unknown targets untouched', () => {
 test('does not rewrite block or heading references', () => {
 	const index = { aliasMap: new Map([['ml', 'Machine Learning']]) };
 	assert.equal(rewriteAliasReferences('[[ML#^abc123]]', index), '[[ML#^abc123]]');
+});
+
+// --- basename disambiguation ---
+test('disambiguates a bare [[name]] when two pages share the basename', () => {
+	const index = { basenameMap: new Map([['notes', ['folder-a/notes', 'folder-b/notes']]]) };
+	assert.equal(disambiguateBasenameLinks('see [[Notes]]', index), 'see [[folder-a/notes|Notes]]');
+});
+
+test('leaves [[name]] untouched when basename is unique', () => {
+	const index = { basenameMap: new Map([['notes', ['folder-a/notes']]]) };
+	assert.equal(disambiguateBasenameLinks('see [[Notes]]', index), 'see [[Notes]]');
+});
+
+test('leaves full-path links untouched even when basename is ambiguous', () => {
+	const index = { basenameMap: new Map([['notes', ['folder-a/notes', 'folder-b/notes']]]) };
+	assert.equal(disambiguateBasenameLinks('[[folder-a/notes]]', index), '[[folder-a/notes]]');
+});
+
+test('preserves embed prefix during disambiguation', () => {
+	const index = { basenameMap: new Map([['img', ['assets/img', 'pages/img']]]) };
+	assert.equal(disambiguateBasenameLinks('![[img]]', index), '![[assets/img|img]]');
+});
+
+test('preserves explicit display text during disambiguation', () => {
+	const index = { basenameMap: new Map([['notes', ['folder-a/notes', 'folder-b/notes']]]) };
+	assert.equal(disambiguateBasenameLinks('[[Notes|my notes]]', index), '[[folder-a/notes|my notes]]');
 });

--- a/tests/logseq/normalize.test.ts
+++ b/tests/logseq/normalize.test.ts
@@ -1,0 +1,34 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { normalizeWhitespace } from '../../src/formats/logseq/normalize';
+
+test('[T6] trims trailing whitespace', () => {
+	const input = ['- a   ', '- b\t', 'plain  '].join('\n');
+	assert.equal(normalizeWhitespace(input), ['- a', '- b', 'plain'].join('\n'));
+});
+
+test('[T6] removes empty bullets', () => {
+	const input = ['- a', '- ', '\t-', '- b'].join('\n');
+	assert.equal(normalizeWhitespace(input), ['- a', '- b'].join('\n'));
+});
+
+test('[T6] converts NBSP to space', () => {
+	const input = 'foo\u00A0bar';
+	assert.equal(normalizeWhitespace(input), 'foo bar');
+});
+
+test('[T6] does not trim inside fenced code blocks', () => {
+	const input = ['```', 'code   ', '\tindented  ', '```'].join('\n');
+	assert.equal(normalizeWhitespace(input), input);
+});
+
+test('[T6] keeps an empty bullet that has a ^anchor', () => {
+	const input = ['- a', '- ^abc123', '- b'].join('\n');
+	assert.equal(normalizeWhitespace(input), input);
+});
+
+test('[T6] does not collapse intentional blank lines', () => {
+	const input = ['- a', '', '', '- b'].join('\n');
+	assert.equal(normalizeWhitespace(input), input);
+});

--- a/tests/logseq/normalize.test.ts
+++ b/tests/logseq/normalize.test.ts
@@ -3,44 +3,44 @@ import assert from 'node:assert/strict';
 
 import { normalizeWhitespace } from '../../src/formats/logseq/normalize';
 
-test('[T6] trims trailing whitespace', () => {
+test('[B1] trims trailing whitespace', () => {
 	const input = ['- a   ', '- b\t', 'plain  '].join('\n');
 	assert.equal(normalizeWhitespace(input), ['- a', '- b', 'plain'].join('\n'));
 });
 
-test('[T6] removes empty bullets', () => {
+test('[B1] removes empty bullets', () => {
 	const input = ['- a', '- ', '\t-', '- b'].join('\n');
 	assert.equal(normalizeWhitespace(input), ['- a', '- b'].join('\n'));
 });
 
-test('[T6] converts NBSP to space', () => {
+test('[B1] converts NBSP to space', () => {
 	const input = 'foo\u00A0bar';
 	assert.equal(normalizeWhitespace(input), 'foo bar');
 });
 
-test('[T6] does not trim inside fenced code blocks', () => {
+test('[B1] does not trim inside fenced code blocks', () => {
 	const input = ['```', 'code   ', '\tindented  ', '```'].join('\n');
 	assert.equal(normalizeWhitespace(input), input);
 });
 
-test('[T6] does not trim inside bullet-prefixed code fences', () => {
+test('[B1] does not trim inside bullet-prefixed code fences', () => {
 	const input = ['- ```query', '  (or   ', '  more code  ', '  ```'].join('\n');
 	assert.equal(normalizeWhitespace(input), input);
 });
 
-test('[T6] off leaves content intact', () => {
+test('[B1] off leaves content intact', () => {
 	// normalizeWhitespace is a pure function; the 'off' case is gated in pipeline.ts.
 	// Verify the function does transform content (i.e. callers can choose not to call it).
 	const input = 'foo\u00A0bar   \n- a  \n- \n- b';
 	assert.notEqual(normalizeWhitespace(input), input);
 });
 
-test('[T6] keeps an empty bullet that has a ^anchor', () => {
+test('[B1] keeps an empty bullet that has a ^anchor', () => {
 	const input = ['- a', '- ^abc123', '- b'].join('\n');
 	assert.equal(normalizeWhitespace(input), input);
 });
 
-test('[T6] does not collapse intentional blank lines', () => {
+test('[B1] does not collapse intentional blank lines', () => {
 	const input = ['- a', '', '', '- b'].join('\n');
 	assert.equal(normalizeWhitespace(input), input);
 });

--- a/tests/logseq/normalize.test.ts
+++ b/tests/logseq/normalize.test.ts
@@ -23,6 +23,18 @@ test('[T6] does not trim inside fenced code blocks', () => {
 	assert.equal(normalizeWhitespace(input), input);
 });
 
+test('[T6] does not trim inside bullet-prefixed code fences', () => {
+	const input = ['- ```query', '  (or   ', '  more code  ', '  ```'].join('\n');
+	assert.equal(normalizeWhitespace(input), input);
+});
+
+test('[T6] off leaves content intact', () => {
+	// normalizeWhitespace is a pure function; the 'off' case is gated in pipeline.ts.
+	// Verify the function does transform content (i.e. callers can choose not to call it).
+	const input = 'foo\u00A0bar   \n- a  \n- \n- b';
+	assert.notEqual(normalizeWhitespace(input), input);
+});
+
 test('[T6] keeps an empty bullet that has a ^anchor', () => {
 	const input = ['- a', '- ^abc123', '- b'].join('\n');
 	assert.equal(normalizeWhitespace(input), input);

--- a/tests/logseq/orchestrator.test.ts
+++ b/tests/logseq/orchestrator.test.ts
@@ -1,0 +1,86 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { indexPageAliases, isBodyEmpty } from '../../src/formats/logseq/pipeline';
+
+// ---------------------------------------------------------------------------
+// indexAliases
+// ---------------------------------------------------------------------------
+
+test('indexAliases: registers a single alias', () => {
+	const aliasMap = new Map<string, string>();
+	const ambiguous = new Set<string>();
+	indexPageAliases({ alias: 'Foo Bar' }, 'pages/foo-bar', aliasMap, ambiguous);
+	assert.equal(aliasMap.get('foo bar'), 'pages/foo-bar');
+	assert.equal(ambiguous.size, 0);
+});
+
+test('indexAliases: registers multiple comma-separated aliases', () => {
+	const aliasMap = new Map<string, string>();
+	const ambiguous = new Set<string>();
+	indexPageAliases({ alias: 'Foo, Bar' }, 'pages/foo', aliasMap, ambiguous);
+	assert.equal(aliasMap.get('foo'), 'pages/foo');
+	assert.equal(aliasMap.get('bar'), 'pages/foo');
+});
+
+test('indexAliases: strips [[...]] wikilink syntax from alias values', () => {
+	const aliasMap = new Map<string, string>();
+	const ambiguous = new Set<string>();
+	indexPageAliases({ aliases: '[[My Page]]' }, 'pages/my-page', aliasMap, ambiguous);
+	assert.equal(aliasMap.get('my page'), 'pages/my-page');
+});
+
+test('indexAliases: registers title:: as an additional alias', () => {
+	const aliasMap = new Map<string, string>();
+	const ambiguous = new Set<string>();
+	indexPageAliases({ title: 'My Custom Title' }, 'pages/my-page', aliasMap, ambiguous);
+	assert.equal(aliasMap.get('my custom title'), 'pages/my-page');
+});
+
+test('indexAliases: registers both alias and title properties', () => {
+	const aliasMap = new Map<string, string>();
+	const ambiguous = new Set<string>();
+	indexPageAliases({ alias: 'Short Name', title: 'Long Title' }, 'pages/page', aliasMap, ambiguous);
+	assert.equal(aliasMap.get('short name'), 'pages/page');
+	assert.equal(aliasMap.get('long title'), 'pages/page');
+});
+
+test('indexAliases: marks conflicting aliases as ambiguous', () => {
+	const aliasMap = new Map<string, string>();
+	const ambiguous = new Set<string>();
+	indexPageAliases({ alias: 'Shared' }, 'pages/page-a', aliasMap, ambiguous);
+	indexPageAliases({ alias: 'Shared' }, 'pages/page-b', aliasMap, ambiguous);
+	assert.ok(ambiguous.has('shared'));
+});
+
+test('indexAliases: skips empty raw (no alias, no title)', () => {
+	const aliasMap = new Map<string, string>();
+	const ambiguous = new Set<string>();
+	indexPageAliases({}, 'pages/page', aliasMap, ambiguous);
+	assert.equal(aliasMap.size, 0);
+	assert.equal(ambiguous.size, 0);
+});
+
+// ---------------------------------------------------------------------------
+// isBodyEmpty
+// ---------------------------------------------------------------------------
+
+test('isBodyEmpty: true when yaml and body are both empty', () => {
+	assert.ok(isBodyEmpty('', ''));
+});
+
+test('isBodyEmpty: true when yaml is empty and body is only whitespace', () => {
+	assert.ok(isBodyEmpty('', '   \n\n  '));
+});
+
+test('isBodyEmpty: false when body has content', () => {
+	assert.ok(!isBodyEmpty('', '- some content'));
+});
+
+test('isBodyEmpty: false when yaml is present (even with empty body)', () => {
+	assert.ok(!isBodyEmpty('---\naliases:\n  - Foo\n---', ''));
+});
+
+test('isBodyEmpty: false when both yaml and body have content', () => {
+	assert.ok(!isBodyEmpty('---\ntags:\n  - area\n---', '- note content'));
+});

--- a/tests/logseq/orchestrator.test.ts
+++ b/tests/logseq/orchestrator.test.ts
@@ -82,10 +82,10 @@ test('isBodyEmpty: false when yaml is present (even with empty body)', () => {
 });
 
 test('isBodyEmpty: false when both yaml and body have content', () => {
-	assert.ok(!isBodyEmpty('---\ntags:\n  - area\n---', '- note content'));
+	assert.ok(!isBodyEmpty('---\ntags:\n  - work\n---', '- note content'));
 });
 
-test('[T7] empty page after pass-2 is skipped', () => {
+test('[A1] empty page after pass-2 is skipped', () => {
 	// A body that becomes empty after conversion (e.g. only whitespace remains)
 	// is reported as empty so the orchestrator can skip writing it.
 	assert.ok(isBodyEmpty('', '\n  \n'));

--- a/tests/logseq/orchestrator.test.ts
+++ b/tests/logseq/orchestrator.test.ts
@@ -84,3 +84,10 @@ test('isBodyEmpty: false when yaml is present (even with empty body)', () => {
 test('isBodyEmpty: false when both yaml and body have content', () => {
 	assert.ok(!isBodyEmpty('---\ntags:\n  - area\n---', '- note content'));
 });
+
+test('[T7] empty page after pass-2 is skipped', () => {
+	// A body that becomes empty after conversion (e.g. only whitespace remains)
+	// is reported as empty so the orchestrator can skip writing it.
+	assert.ok(isBodyEmpty('', '\n  \n'));
+	assert.ok(!isBodyEmpty('', '- still here'));
+});

--- a/tests/logseq/paths.test.ts
+++ b/tests/logseq/paths.test.ts
@@ -114,7 +114,7 @@ test('pageNameToPath matches namespaceToPath behavior', () => {
 	}
 });
 
-// --- T8: bracket filename sanitization ---
+// --- F1: bracket filename sanitization ---
 // The orchestrator builds page paths as sanitizeFileNameKeepPath(namespaceToPath(basename)).
 // sanitizeFileNameKeepPath lives in roam/utils (imports obsidian), so we replicate the
 // bracket-stripping portion of its regex here to assert the combined result is bracket-free.
@@ -122,7 +122,7 @@ function stripBrackets(name: string): string {
 	return name.replace(/\[/g, '').replace(/\]/g, '');
 }
 
-test('[T8] namespaced page with [[brackets]] in the name yields a bracket-free folder path', () => {
+test('[F1] namespaced page with [[brackets]] in the name yields a bracket-free folder path', () => {
 	const basename = "Team A___feedback___[[Alice]]'s experience";
 	const path = stripBrackets(namespaceToPath(basename));
 	assert.equal(path, "Team A/feedback/Alice's experience");

--- a/tests/logseq/paths.test.ts
+++ b/tests/logseq/paths.test.ts
@@ -1,0 +1,115 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { decodeLogseqName, namespaceToPath, pageNameToPath } from '../../src/formats/logseq/paths';
+
+// --- decodeLogseqName ---
+
+test('decodeLogseqName decodes a simple percent-escape', () => {
+	assert.equal(decodeLogseqName('Encoded%3AColon'), 'Encoded:Colon');
+});
+
+test('decodeLogseqName decodes multi-byte UTF-8 escapes', () => {
+	assert.equal(decodeLogseqName('caf%C3%A9'), 'café');
+});
+
+test('decodeLogseqName leaves plain text unchanged', () => {
+	assert.equal(decodeLogseqName('Cool Stuff'), 'Cool Stuff');
+});
+
+test('decodeLogseqName does not change triple underscore', () => {
+	assert.equal(decodeLogseqName('a___b'), 'a___b');
+});
+
+test('decodeLogseqName leaves malformed %ZZ unchanged but decodes valid parts', () => {
+	assert.equal(decodeLogseqName('a%ZZb%3Ac'), 'a%ZZb:c');
+});
+
+test('decodeLogseqName leaves a lone %2 (too short) unchanged', () => {
+	assert.equal(decodeLogseqName('100%2 done'), '100%2 done');
+});
+
+test('decodeLogseqName leaves a trailing bare percent unchanged', () => {
+	assert.equal(decodeLogseqName('50%'), '50%');
+});
+
+test('decodeLogseqName handles empty string', () => {
+	assert.equal(decodeLogseqName(''), '');
+});
+
+test('decodeLogseqName decodes adjacent escapes correctly', () => {
+	assert.equal(decodeLogseqName('%3A%3A'), '::');
+});
+
+// --- namespaceToPath ---
+
+test('namespaceToPath splits on triple underscore', () => {
+	assert.equal(namespaceToPath('algorithms___dynamic programming'), 'algorithms/dynamic programming');
+});
+
+test('namespaceToPath splits multiple triple-underscore separators', () => {
+	assert.equal(namespaceToPath('a___b___c'), 'a/b/c');
+});
+
+test('namespaceToPath splits on percent-encoded slash', () => {
+	assert.equal(namespaceToPath('foo%2Fbar'), 'foo/bar');
+});
+
+test('namespaceToPath decodes a single segment with no separator', () => {
+	assert.equal(namespaceToPath('Encoded%3AColon'), 'Encoded:Colon');
+});
+
+test('namespaceToPath leaves a plain title unchanged', () => {
+	assert.equal(namespaceToPath('Cool Stuff'), 'Cool Stuff');
+});
+
+test('namespaceToPath does not split on single underscore', () => {
+	assert.equal(namespaceToPath('foo_bar'), 'foo_bar');
+});
+
+test('namespaceToPath does not split on single slash', () => {
+	assert.equal(namespaceToPath('foo/bar'), 'foo/bar');
+});
+
+test('namespaceToPath decodes each namespace segment', () => {
+	assert.equal(namespaceToPath('Encoded%3AColon___notes'), 'Encoded:Colon/notes');
+});
+
+test('namespaceToPath prefers %2F over ___ when both present', () => {
+	assert.equal(namespaceToPath('a%2Fb___c'), 'a/b___c');
+});
+
+test('namespaceToPath handles empty string', () => {
+	assert.equal(namespaceToPath(''), '');
+});
+
+test('namespaceToPath preserves leading separator as empty segment', () => {
+	assert.equal(namespaceToPath('___a'), '/a');
+});
+
+test('namespaceToPath preserves trailing separator as empty segment', () => {
+	assert.equal(namespaceToPath('a___'), 'a/');
+});
+
+test('namespaceToPath leaves malformed percent untouched in segment', () => {
+	assert.equal(namespaceToPath('a%ZZ___b'), 'a%ZZ/b');
+});
+
+// --- pageNameToPath ---
+
+test('pageNameToPath matches namespaceToPath behavior', () => {
+	const inputs = [
+		'algorithms___dynamic programming',
+		'a___b___c',
+		'foo%2Fbar',
+		'Encoded%3AColon',
+		'Cool Stuff',
+		'',
+		'___a',
+		'a___',
+		'a%ZZ___b',
+	];
+	for (const input of inputs) {
+		assert.equal(pageNameToPath(input), namespaceToPath(input));
+	}
+});

--- a/tests/logseq/paths.test.ts
+++ b/tests/logseq/paths.test.ts
@@ -113,3 +113,19 @@ test('pageNameToPath matches namespaceToPath behavior', () => {
 		assert.equal(pageNameToPath(input), namespaceToPath(input));
 	}
 });
+
+// --- T8: bracket filename sanitization ---
+// The orchestrator builds page paths as sanitizeFileNameKeepPath(namespaceToPath(basename)).
+// sanitizeFileNameKeepPath lives in roam/utils (imports obsidian), so we replicate the
+// bracket-stripping portion of its regex here to assert the combined result is bracket-free.
+function stripBrackets(name: string): string {
+	return name.replace(/\[/g, '').replace(/\]/g, '');
+}
+
+test('[T8] namespaced page with [[brackets]] in the name yields a bracket-free folder path', () => {
+	const basename = "Team A___feedback___[[Alice]]'s experience";
+	const path = stripBrackets(namespaceToPath(basename));
+	assert.equal(path, "Team A/feedback/Alice's experience");
+	assert.ok(!path.includes('['));
+	assert.ok(!path.includes(']'));
+});

--- a/tests/logseq/pipeline.test.ts
+++ b/tests/logseq/pipeline.test.ts
@@ -9,7 +9,7 @@ const opts = DEFAULT_LOGSEQ_OPTIONS;
 test('extracts frontmatter and converts a simple page body', () => {
 	const input = ['title:: My Page', 'tags:: a, b', '', '- TODO do it', '- a note ^^highlight^^'].join('\n');
 	const { yaml, body, raw } = convertLocal(input, opts);
-	assert.equal(yaml, ['---', 'tags:', '  - a', '  - b', '---'].join('\n'));
+	assert.equal(yaml, ['---', 'aliases:', '  - My Page', 'tags:', '  - a', '  - b', '---'].join('\n'));
 	assert.equal(raw.title, 'My Page');
 	assert.equal(body, ['- [ ] do it', '- a note ==highlight=='].join('\n'));
 });

--- a/tests/logseq/pipeline.test.ts
+++ b/tests/logseq/pipeline.test.ts
@@ -1,0 +1,48 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { convertLocal } from '../../src/formats/logseq/pipeline';
+import { DEFAULT_LOGSEQ_OPTIONS } from '../../src/formats/logseq/options';
+
+const opts = DEFAULT_LOGSEQ_OPTIONS;
+
+test('extracts frontmatter and converts a simple page body', () => {
+	const input = ['title:: My Page', 'tags:: a, b', '', '- TODO do it', '- a note ^^highlight^^'].join('\n');
+	const { yaml, body, raw } = convertLocal(input, opts);
+	assert.equal(yaml, ['---', 'tags:', '  - a', '  - b', '---'].join('\n'));
+	assert.equal(raw.title, 'My Page');
+	assert.equal(body, ['- [ ] do it', '- a note ==highlight=='].join('\n'));
+});
+
+test('task with a block id attaches the anchor after task conversion', () => {
+	const input = ['- TODO important', '  id:: abcdef12-0000-0000-0000-000000000000'].join('\n');
+	const { body, ids } = convertLocal(input, opts);
+	assert.equal(body, '- [ ] important ^abcdef');
+	assert.deepEqual(ids, [{ uuid: 'abcdef12-0000-0000-0000-000000000000', shortId: 'abcdef' }]);
+});
+
+test('numbered list and leftover property cleanup run together', () => {
+	const input = [
+		'- one',
+		'  logseq.order-list-type:: number',
+		'- two',
+		'  logseq.order-list-type:: number',
+		'- plain',
+		'  collapsed:: true',
+	].join('\n');
+	const { body } = convertLocal(input, opts);
+	assert.equal(body, ['1. one', '2. two', '- plain'].join('\n'));
+});
+
+test('collects assets referenced by the page', () => {
+	const input = '- ![pic](../assets/image.png)';
+	const { body, assets } = convertLocal(input, opts);
+	assert.equal(body, '- ![[image.png]]');
+	assert.deepEqual(assets, [{ sourcePath: '../assets/image.png', filename: 'image.png' }]);
+});
+
+test('scheduled task metadata is rendered (emoji default)', () => {
+	const input = ['- TODO pay rent', '  SCHEDULED: <2024-09-01 Sun>'].join('\n');
+	const { body } = convertLocal(input, opts);
+	assert.equal(body, '- [ ] pay rent ⏳ 2024-09-01');
+});

--- a/tests/logseq/properties.test.ts
+++ b/tests/logseq/properties.test.ts
@@ -322,3 +322,68 @@ test('[I1] tag value linkifies regardless of page set when onlyExistingPages is 
 	});
 	assert.equal(out, ['---', 'area: "[[security]]"', '---'].join('\n'));
 });
+
+// ---------------------------------------------------------------------------
+// Always-drop page properties (Logseq-internal with no Obsidian equivalent)
+// ---------------------------------------------------------------------------
+
+test('[I1] collapsed page property is always dropped from frontmatter', () => {
+	const { yaml } = extractPageProperties('collapsed:: true\ntype:: note\n\ntext');
+	assert.equal(yaml, ['---', 'type: note', '---'].join('\n'));
+});
+
+test('[I1] filters page property is always dropped from frontmatter', () => {
+	const { yaml } = extractPageProperties('filters:: {}\ntype:: note\n\ntext');
+	assert.equal(yaml, ['---', 'type: note', '---'].join('\n'));
+});
+
+test('[I1] background-color page property is always dropped from frontmatter', () => {
+	const { yaml } = extractPageProperties('background-color:: red\ntype:: note\n\ntext');
+	assert.equal(yaml, ['---', 'type: note', '---'].join('\n'));
+});
+
+test('[I1] heading page property is always dropped from frontmatter', () => {
+	const { yaml } = extractPageProperties('heading:: true\ntype:: note\n\ntext');
+	assert.equal(yaml, ['---', 'type: note', '---'].join('\n'));
+});
+
+test('[I1] template and template-including-parent page properties are always dropped', () => {
+	const { yaml } = extractPageProperties('template:: My Template\ntemplate-including-parent:: false\n\ntext');
+	assert.equal(yaml, '');
+});
+
+test('[I1] query-* prefixed page properties are always dropped', () => {
+	const { yaml } = extractPageProperties('query-table:: true\nquery-sort-by:: created\ntype:: note\n\ntext');
+	assert.equal(yaml, ['---', 'type: note', '---'].join('\n'));
+});
+
+test('[I1] logseq.* prefixed page properties are always dropped', () => {
+	const { yaml } = extractPageProperties('logseq.order-list-type:: number\ntype:: note\n\ntext');
+	assert.equal(yaml, ['---', 'type: note', '---'].join('\n'));
+});
+
+test('[I1] hl-* and ls-* prefixed page properties are always dropped', () => {
+	const { yaml } = extractPageProperties('hl-page:: 42\nls-type:: annotation\ntype:: note\n\ntext');
+	assert.equal(yaml, ['---', 'type: note', '---'].join('\n'));
+});
+
+// ---------------------------------------------------------------------------
+// alias / aliases as block properties must be always dropped
+// ---------------------------------------------------------------------------
+
+test('[I1] alias block property is always dropped (not wrapped or kept)', () => {
+	const input = ['- a block', '  alias:: Some Alias'].join('\n');
+	assert.equal(removeLeftoverBlockProperties(input, [], 'keep'), '- a block');
+	assert.equal(removeLeftoverBlockProperties(input, [], 'wrap'), '- a block');
+	assert.equal(removeLeftoverBlockProperties(input, [], 'drop'), '- a block');
+});
+
+test('[I1] template block property is always dropped', () => {
+	const input = ['- a block', '  template:: My Template'].join('\n');
+	assert.equal(removeLeftoverBlockProperties(input), '- a block');
+});
+
+test('[I1] template-including-parent block property is always dropped', () => {
+	const input = ['- a block', '  template-including-parent:: false'].join('\n');
+	assert.equal(removeLeftoverBlockProperties(input), '- a block');
+});

--- a/tests/logseq/properties.test.ts
+++ b/tests/logseq/properties.test.ts
@@ -1,0 +1,103 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+	extractPageProperties,
+	removeLeftoverBlockProperties,
+	convertHeadingProperty,
+} from '../../src/formats/logseq/properties';
+
+test('returns empty yaml when there are no page properties', () => {
+	const { yaml, body } = extractPageProperties('- just a block\n- another');
+	assert.equal(yaml, '');
+	assert.equal(body, '- just a block\n- another');
+});
+
+test('parses simple scalar properties into frontmatter', () => {
+	const input = 'type:: book\nauthor:: Jane\n\n- content';
+	const { yaml, body } = extractPageProperties(input);
+	assert.equal(yaml, ['---', 'type: book', 'author: Jane', '---'].join('\n'));
+	assert.equal(body, '- content');
+});
+
+test('alias and aliases map to an aliases list and strip wikilink brackets', () => {
+	const input = 'alias:: ML, [[Machine Learning]]\n\ntext';
+	const { yaml } = extractPageProperties(input);
+	assert.equal(yaml, ['---', 'aliases:', '  - ML', '  - Machine Learning', '---'].join('\n'));
+});
+
+test('tags property strips # and wikilinks and becomes a list', () => {
+	const input = 'tags:: #foo, [[bar baz]], qux\n\ntext';
+	const { yaml } = extractPageProperties(input);
+	assert.equal(yaml, ['---', 'tags:', '  - foo', '  - bar baz', '  - qux', '---'].join('\n'));
+});
+
+test('tags property handles a value mixing wikilinks and hashtags without commas', () => {
+	const input = 'tags:: tag1, [[tag2]] #tag3\n\ntext';
+	const { yaml } = extractPageProperties(input);
+	assert.equal(yaml, ['---', 'tags:', '  - tag1', '  - tag2', '  - tag3', '---'].join('\n'));
+});
+
+test('title is dropped from yaml but returned in raw', () => {
+	const input = 'title:: My Title\ntype:: note\n\ntext';
+	const { yaml, raw } = extractPageProperties(input);
+	assert.equal(yaml, ['---', 'type: note', '---'].join('\n'));
+	assert.equal(raw.title, 'My Title');
+});
+
+test('wikilink-valued scalar property is quoted', () => {
+	const input = 'project:: [[Big Project]]\n\ntext';
+	const { yaml } = extractPageProperties(input);
+	assert.equal(yaml, ['---', 'project: "[[Big Project]]"', '---'].join('\n'));
+});
+
+test('multiple wikilink values become a quoted list', () => {
+	const input = 'related:: [[A]], [[B]]\n\ntext';
+	const { yaml } = extractPageProperties(input);
+	assert.equal(yaml, ['---', 'related:', '  - "[[A]]"', '  - "[[B]]"', '---'].join('\n'));
+});
+
+test('property block ends at the first non-property line', () => {
+	const input = 'type:: note\nthis is content:: not a prop line really\nmore';
+	// "this is content:: ..." has a space in the key position so it is not a valid property line.
+	const { yaml, body } = extractPageProperties(input);
+	assert.equal(yaml, ['---', 'type: note', '---'].join('\n'));
+	assert.equal(body, 'this is content:: not a prop line really\nmore');
+});
+
+test('a file that starts with a bullet has no page properties', () => {
+	const input = '- title:: not a page property\n- x';
+	const { yaml, body } = extractPageProperties(input);
+	assert.equal(yaml, '');
+	assert.equal(body, input);
+});
+
+test('removeLeftoverBlockProperties strips logseq-internal block props', () => {
+	const input = [
+		'- a block',
+		'  collapsed:: true',
+		'  logseq.order-list-type:: number',
+		'- another',
+		'  background-color:: red',
+		'  query-sort-by:: created',
+	].join('\n');
+	const out = removeLeftoverBlockProperties(input);
+	assert.equal(out, ['- a block', '- another'].join('\n'));
+});
+
+test('removeLeftoverBlockProperties keeps unknown user block properties', () => {
+	const input = ['- a block', '  rating:: 5'].join('\n');
+	assert.equal(removeLeftoverBlockProperties(input), input);
+});
+
+test('convertHeadingProperty turns heading:: N into a markdown heading prefix', () => {
+	const input = ['- Important section', '  heading:: 2', '- normal'].join('\n');
+	const out = convertHeadingProperty(input);
+	assert.equal(out, ['- ## Important section', '- normal'].join('\n'));
+});
+
+test('convertHeadingProperty leaves heading:: true (auto) handling without crashing', () => {
+	const input = ['- A', '  heading:: true'].join('\n');
+	// auto-heading has no explicit level; we just drop the property line.
+	assert.equal(convertHeadingProperty(input), '- A');
+});

--- a/tests/logseq/properties.test.ts
+++ b/tests/logseq/properties.test.ts
@@ -387,3 +387,64 @@ test('[I1] template-including-parent block property is always dropped', () => {
 	const input = ['- a block', '  template-including-parent:: false'].join('\n');
 	assert.equal(removeLeftoverBlockProperties(input), '- a block');
 });
+
+// ---------------------------------------------------------------------------
+// snake_case conversion for page and block properties
+// ---------------------------------------------------------------------------
+
+test('[T-snake] snakeCasePageProperties converts kebab-case keys to snake_case', () => {
+	const input = 'test-hyphen:: value\ntype:: note\n\ntext';
+	const { yaml } = extractPageProperties(input, { snakeCasePageProperties: true });
+	assert.equal(yaml, ['---', 'test_hyphen: value', 'type: note', '---'].join('\n'));
+});
+
+test('[T-snake] page properties keep kebab-case keys by default', () => {
+	const input = 'test-hyphen:: value\n\ntext';
+	const { yaml } = extractPageProperties(input);
+	assert.equal(yaml, ['---', 'test-hyphen: value', '---'].join('\n'));
+});
+
+test('[T-snake] snakeCasePageProperties does not affect drop-list matching (kebab key still dropped)', () => {
+	const input = 'test-hyphen:: value\ntype:: note\n\ntext';
+	const { yaml } = extractPageProperties(input, {
+		snakeCasePageProperties: true,
+		dropPageProperties: ['test-hyphen'],
+	});
+	assert.equal(yaml, ['---', 'type: note', '---'].join('\n'));
+});
+
+test('[T-snake] snakeCasePageProperties works with list-valued properties', () => {
+	const input = 'multi-word:: [[Page One]], [[Page Two]]\n\ntext';
+	const { yaml } = extractPageProperties(input, { snakeCasePageProperties: true });
+	assert.equal(yaml, ['---', 'multi_word:', '  - "[[Page One]]"', '  - "[[Page Two]]"', '---'].join('\n'));
+});
+
+test('[T-snake] snakeCaseBlockProperties converts kebab-case keys in keep mode', () => {
+	const input = ['- a block', '  test-hyphen:: value'].join('\n');
+	const out = removeLeftoverBlockProperties(input, [], 'keep', true);
+	assert.equal(out, ['- a block', '  test_hyphen:: value'].join('\n'));
+});
+
+test('[T-snake] snakeCaseBlockProperties converts kebab-case keys in wrap mode', () => {
+	const input = ['- a block', '  test-hyphen:: value'].join('\n');
+	const out = removeLeftoverBlockProperties(input, [], 'wrap', true);
+	assert.equal(out, ['- a block', '  [test_hyphen:: value]'].join('\n'));
+});
+
+test('[T-snake] block properties keep kebab-case keys by default', () => {
+	const input = ['- a block', '  test-hyphen:: value'].join('\n');
+	const out = removeLeftoverBlockProperties(input, [], 'keep');
+	assert.equal(out, input);
+});
+
+test('[T-snake] snakeCaseBlockProperties preserves trailing block anchor', () => {
+	const input = ['- a block', '  test-hyphen:: value ^abc123'].join('\n');
+	const out = removeLeftoverBlockProperties(input, [], 'keep', true);
+	assert.equal(out, ['- a block', '  test_hyphen:: value ^abc123'].join('\n'));
+});
+
+test('[T-snake] snakeCaseBlockProperties does not affect always-drop or user drop-list matching', () => {
+	const input = ['- a block', '  background-color:: red', '  custom-key:: val'].join('\n');
+	const out = removeLeftoverBlockProperties(input, ['custom-key'], 'keep', true);
+	assert.equal(out, '- a block');
+});

--- a/tests/logseq/properties.test.ts
+++ b/tests/logseq/properties.test.ts
@@ -38,10 +38,10 @@ test('tags property handles a value mixing wikilinks and hashtags without commas
 	assert.equal(yaml, ['---', 'tags:', '  - tag1', '  - tag2', '  - tag3', '---'].join('\n'));
 });
 
-test('title is dropped from yaml but returned in raw', () => {
+test('title is registered as an alias and returned in raw', () => {
 	const input = 'title:: My Title\ntype:: note\n\ntext';
 	const { yaml, raw } = extractPageProperties(input);
-	assert.equal(yaml, ['---', 'type: note', '---'].join('\n'));
+	assert.equal(yaml, ['---', 'aliases:', '  - My Title', 'type: note', '---'].join('\n'));
 	assert.equal(raw.title, 'My Title');
 });
 
@@ -123,4 +123,79 @@ test('convertHeadingProperty leaves heading:: true (auto) handling without crash
 	const input = ['- A', '  heading:: true'].join('\n');
 	// auto-heading has no explicit level; we just drop the property line.
 	assert.equal(convertHeadingProperty(input), '- A');
+});
+
+// ---------------------------------------------------------------------------
+// Regression findings (domain 05) — RED tests for accepted fixes.
+// ---------------------------------------------------------------------------
+
+// H1: a value starting with '#' must be quoted (else YAML reads it as a comment → null).
+test('[H1] scalar value starting with # is quoted', () => {
+	const { yaml } = extractPageProperties('status:: #in-progress\n\ntext');
+	assert.equal(yaml, ['---', 'status: "#in-progress"', '---'].join('\n'));
+});
+
+// H2: a value that is a markdown link must be quoted (else the whole block is invalid YAML).
+test('[H2] scalar value that is a markdown link is quoted', () => {
+	const { yaml } = extractPageProperties('file:: [doc](../a/b.pdf)\n\ntext');
+	assert.equal(yaml, ['---', 'file: "[doc](../a/b.pdf)"', '---'].join('\n'));
+});
+
+// H3: a comma inside a single wikilink must not be treated as a list separator.
+test('[H3] comma inside a single wikilink is not split into a list', () => {
+	const { yaml } = extractPageProperties('deadline:: [[Jul 18th, 2025]]\n\ntext');
+	assert.equal(yaml, ['---', 'deadline: "[[Jul 18th, 2025]]"', '---'].join('\n'));
+});
+
+// H4: general YAML-unsafe scalars must be quoted (colon-space, bool-like, leading-zero number).
+test('[H4] colon-space value is quoted', () => {
+	const { yaml } = extractPageProperties('k:: value: with colon\n\nx');
+	assert.equal(yaml, ['---', 'k: "value: with colon"', '---'].join('\n'));
+});
+
+test('[H4] boolean-like value stays a quoted string', () => {
+	const { yaml } = extractPageProperties('k:: yes\n\nx');
+	assert.equal(yaml, ['---', 'k: "yes"', '---'].join('\n'));
+});
+
+test('[H4] leading-zero numeric value stays a quoted string', () => {
+	const { yaml } = extractPageProperties('k:: 007\n\nx');
+	assert.equal(yaml, ['---', 'k: "007"', '---'].join('\n'));
+});
+
+// M1: an internal block property written as a bullet must still be stripped.
+test('[M1] internal block property written as a bullet is stripped', () => {
+	const input = ['- a block', '- collapsed:: true', '- next'].join('\n');
+	assert.equal(removeLeftoverBlockProperties(input), ['- a block', '- next'].join('\n'));
+});
+
+// M2: Logseq PDF-highlight internal props must be dropped from the body.
+test('[M2] PDF highlight props (ls-type / hl-*) are dropped', () => {
+	const input = ['- quote', '  ls-type:: annotation', '  hl-page:: 46', '  hl-color:: yellow'].join('\n');
+	assert.equal(removeLeftoverBlockProperties(input), '- quote');
+});
+
+// M3: a title:: page property must be preserved (carried as an alias).
+test('[M3] title page property is preserved as an alias', () => {
+	const { yaml, raw } = extractPageProperties('title:: Example Title\ntype:: note\n\ntext');
+	assert.equal(raw.title, 'Example Title');
+	assert.match(yaml, /aliases:\n {2}- Example Title/);
+});
+
+// L1: created/updated wikilink dates become plain ISO dates.
+test('[L1] created wikilink date is emitted as a plain ISO date', () => {
+	const { yaml } = extractPageProperties('created:: [[2024-01-16]]\n\nx');
+	assert.equal(yaml, ['---', 'created: 2024-01-16', '---'].join('\n'));
+});
+
+// L2: an empty-valued page property is omitted entirely.
+test('[L2] empty-valued page property is omitted', () => {
+	const { yaml } = extractPageProperties('icon::\n\nx');
+	assert.equal(yaml, '');
+});
+
+// L4: duplicate page-property keys are de-duplicated (last wins).
+test('[L4] duplicate page-property keys are de-duplicated (last wins)', () => {
+	const { yaml } = extractPageProperties('type:: a\ntype:: b\n\nx');
+	assert.equal(yaml, ['---', 'type: b', '---'].join('\n'));
 });

--- a/tests/logseq/properties.test.ts
+++ b/tests/logseq/properties.test.ts
@@ -90,6 +90,29 @@ test('removeLeftoverBlockProperties keeps unknown user block properties', () => 
 	assert.equal(removeLeftoverBlockProperties(input), input);
 });
 
+test('removeLeftoverBlockProperties drops user-specified extra keys', () => {
+	const input = ['- a block', '  my-status:: draft', '  rating:: 5'].join('\n');
+	assert.equal(removeLeftoverBlockProperties(input, ['my-status']), ['- a block', '  rating:: 5'].join('\n'));
+});
+
+test('extractPageProperties drops listed page property keys from frontmatter', () => {
+	const input = 'type:: note\npublic:: true\nmy-key:: val\n\ntext';
+	const { yaml } = extractPageProperties(input, { dropPageProperties: ['public', 'my-key'] });
+	assert.equal(yaml, ['---', 'type: note', '---'].join('\n'));
+});
+
+test('extractPageProperties drops listed tags from frontmatter tags list', () => {
+	const input = 'tags:: foo, card, bar\n\ntext';
+	const { yaml } = extractPageProperties(input, { dropTags: ['card'] });
+	assert.equal(yaml, ['---', 'tags:', '  - foo', '  - bar', '---'].join('\n'));
+});
+
+test('extractPageProperties produces no frontmatter when all tags are dropped', () => {
+	const input = 'tags:: card\n\ntext';
+	const { yaml } = extractPageProperties(input, { dropTags: ['card'] });
+	assert.equal(yaml, '');
+});
+
 test('convertHeadingProperty turns heading:: N into a markdown heading prefix', () => {
 	const input = ['- Important section', '  heading:: 2', '- normal'].join('\n');
 	const out = convertHeadingProperty(input);

--- a/tests/logseq/properties.test.ts
+++ b/tests/logseq/properties.test.ts
@@ -5,7 +5,9 @@ import {
 	extractPageProperties,
 	removeLeftoverBlockProperties,
 	convertHeadingProperty,
+	linkifyTagValuesInFrontmatter,
 } from '../../src/formats/logseq/properties';
+import { DEFAULT_DROP_PAGE_PROPERTIES } from '../../src/formats/logseq/options';
 
 test('returns empty yaml when there are no page properties', () => {
 	const { yaml, body } = extractPageProperties('- just a block\n- another');
@@ -95,10 +97,70 @@ test('removeLeftoverBlockProperties drops user-specified extra keys', () => {
 	assert.equal(removeLeftoverBlockProperties(input, ['my-status']), ['- a block', '  rating:: 5'].join('\n'));
 });
 
+// --- T3: blockProperties keep / wrap / drop ---
+test('[T3] keep mode leaves unknown block property unchanged', () => {
+	const input = ['- a block', '  rating:: 5'].join('\n');
+	assert.equal(removeLeftoverBlockProperties(input, [], 'keep'), input);
+});
+
+test('[T3] wrap mode rewrites participants:: … into [participants:: …]', () => {
+	const input = ['- a block', '  participants:: [[Alice]], [[Bob]]'].join('\n');
+	assert.equal(
+		removeLeftoverBlockProperties(input, [], 'wrap'),
+		['- a block', '  [participants:: [[Alice]], [[Bob]]]'].join('\n'),
+	);
+});
+
+test('[T3] wrap mode preserves indentation and trailing ^anchor', () => {
+	const input = ['- a block', '\t  participants:: a, b ^abc123'].join('\n');
+	assert.equal(
+		removeLeftoverBlockProperties(input, [], 'wrap'),
+		['- a block', '\t  [participants:: a, b] ^abc123'].join('\n'),
+	);
+});
+
+test('[T3] drop mode removes the line', () => {
+	const input = ['- a block', '  rating:: 5'].join('\n');
+	assert.equal(removeLeftoverBlockProperties(input, [], 'drop'), '- a block');
+});
+
+test('[T3] always-drop keys ignore the mode (collapsed/logseq.*/hl-* still dropped in keep & wrap)', () => {
+	const input = [
+		'- a block',
+		'  collapsed:: true',
+		'  logseq.order-list-type:: number',
+		'  hl-color:: yellow',
+	].join('\n');
+	assert.equal(removeLeftoverBlockProperties(input, [], 'keep'), '- a block');
+	assert.equal(removeLeftoverBlockProperties(input, [], 'wrap'), '- a block');
+});
+
+test('[T3] value containing ] falls back to keep', () => {
+	const input = ['- a block', '  note:: foo] bar'].join('\n');
+	assert.equal(removeLeftoverBlockProperties(input, [], 'wrap'), input);
+});
+
+test('[T3] wrap mode does not touch property-like lines inside code fences', () => {
+	const input = ['- a block', '  ```', '  key:: value', '  ```'].join('\n');
+	assert.equal(removeLeftoverBlockProperties(input, [], 'wrap'), input);
+});
+
 test('extractPageProperties drops listed page property keys from frontmatter', () => {
 	const input = 'type:: note\npublic:: true\nmy-key:: val\n\ntext';
 	const { yaml } = extractPageProperties(input, { dropPageProperties: ['public', 'my-key'] });
 	assert.equal(yaml, ['---', 'type: note', '---'].join('\n'));
+});
+
+test('[T4] icon page property is dropped from frontmatter by default', () => {
+	const input = 'type:: note\nicon:: \uEAE5\n\ntext';
+	const { yaml } = extractPageProperties(input, { dropPageProperties: DEFAULT_DROP_PAGE_PROPERTIES });
+	assert.equal(yaml, ['---', 'type: note', '---'].join('\n'));
+});
+
+test('[T4] icon is retained when removed from the drop list', () => {
+	const input = 'type:: note\nicon:: star\n\ntext';
+	const { yaml } = extractPageProperties(input, { dropPageProperties: [] });
+	assert.equal(yaml, ['---', 'type: note', 'icon: star', '---'].join('\n'));
 });
 
 test('extractPageProperties drops listed tags from frontmatter tags list', () => {
@@ -198,4 +260,65 @@ test('[L2] empty-valued page property is omitted', () => {
 test('[L4] duplicate page-property keys are de-duplicated (last wins)', () => {
 	const { yaml } = extractPageProperties('type:: a\ntype:: b\n\nx');
 	assert.equal(yaml, ['---', 'type: b', '---'].join('\n'));
+});
+
+// --- T5: linkify tag-style frontmatter values in pass-2 ---
+test('[T5] tag value linkifies to [[page]] when page exists and toLinks on', () => {
+	const yaml = ['---', 'status: "#IN-PROGRESS"', '---'].join('\n');
+	const out = linkifyTagValuesInFrontmatter(yaml, {
+		knownPages: new Set(['in-progress']),
+		toLinks: true,
+		onlyExistingPages: true,
+	});
+	assert.equal(out, ['---', 'status: "[[IN-PROGRESS]]"', '---'].join('\n'));
+});
+
+test('[T5] multi-word #[[tag]] value linkifies to [[tag]]', () => {
+	const yaml = ['---', 'area: "#[[Page One]]"', '---'].join('\n');
+	const out = linkifyTagValuesInFrontmatter(yaml, {
+		knownPages: new Set(['page one']),
+		toLinks: true,
+		onlyExistingPages: true,
+	});
+	assert.equal(out, ['---', 'area: "[[Page One]]"', '---'].join('\n'));
+});
+
+test('[T5] tag value stays quoted text when no matching page (onlyExistingPages)', () => {
+	const yaml = ['---', 'status: "#IN-PROGRESS"', '---'].join('\n');
+	const out = linkifyTagValuesInFrontmatter(yaml, {
+		knownPages: new Set(),
+		toLinks: true,
+		onlyExistingPages: true,
+	});
+	assert.equal(out, yaml);
+});
+
+test('[T5] tag value stays quoted text when toLinks is off (default)', () => {
+	const yaml = ['---', 'status: "#IN-PROGRESS"', '---'].join('\n');
+	const out = linkifyTagValuesInFrontmatter(yaml, {
+		knownPages: new Set(['in-progress']),
+		toLinks: false,
+		onlyExistingPages: true,
+	});
+	assert.equal(out, yaml);
+});
+
+test('[T5] tags: list is unaffected', () => {
+	const yaml = ['---', 'tags:', '  - foo', '  - bar', '---'].join('\n');
+	const out = linkifyTagValuesInFrontmatter(yaml, {
+		knownPages: new Set(['foo', 'bar']),
+		toLinks: true,
+		onlyExistingPages: true,
+	});
+	assert.equal(out, yaml);
+});
+
+test('[T5] tag value linkifies regardless of page set when onlyExistingPages is off', () => {
+	const yaml = ['---', 'area: "#security"', '---'].join('\n');
+	const out = linkifyTagValuesInFrontmatter(yaml, {
+		knownPages: new Set(),
+		toLinks: true,
+		onlyExistingPages: false,
+	});
+	assert.equal(out, ['---', 'area: "[[security]]"', '---'].join('\n'));
 });

--- a/tests/logseq/properties.test.ts
+++ b/tests/logseq/properties.test.ts
@@ -97,13 +97,13 @@ test('removeLeftoverBlockProperties drops user-specified extra keys', () => {
 	assert.equal(removeLeftoverBlockProperties(input, ['my-status']), ['- a block', '  rating:: 5'].join('\n'));
 });
 
-// --- T3: blockProperties keep / wrap / drop ---
-test('[T3] keep mode leaves unknown block property unchanged', () => {
+// --- I1: blockProperties keep / wrap / drop ---
+test('[I1] keep mode leaves unknown block property unchanged', () => {
 	const input = ['- a block', '  rating:: 5'].join('\n');
 	assert.equal(removeLeftoverBlockProperties(input, [], 'keep'), input);
 });
 
-test('[T3] wrap mode rewrites participants:: … into [participants:: …]', () => {
+test('[I1] wrap mode rewrites participants:: … into [participants:: …]', () => {
 	const input = ['- a block', '  participants:: [[Alice]], [[Bob]]'].join('\n');
 	assert.equal(
 		removeLeftoverBlockProperties(input, [], 'wrap'),
@@ -111,7 +111,7 @@ test('[T3] wrap mode rewrites participants:: … into [participants:: …]', () 
 	);
 });
 
-test('[T3] wrap mode preserves indentation and trailing ^anchor', () => {
+test('[I1] wrap mode preserves indentation and trailing ^anchor', () => {
 	const input = ['- a block', '\t  participants:: a, b ^abc123'].join('\n');
 	assert.equal(
 		removeLeftoverBlockProperties(input, [], 'wrap'),
@@ -119,12 +119,12 @@ test('[T3] wrap mode preserves indentation and trailing ^anchor', () => {
 	);
 });
 
-test('[T3] drop mode removes the line', () => {
+test('[I1] drop mode removes the line', () => {
 	const input = ['- a block', '  rating:: 5'].join('\n');
 	assert.equal(removeLeftoverBlockProperties(input, [], 'drop'), '- a block');
 });
 
-test('[T3] always-drop keys ignore the mode (collapsed/logseq.*/hl-* still dropped in keep & wrap)', () => {
+test('[I1] always-drop keys ignore the mode (collapsed/logseq.*/hl-* still dropped in keep & wrap)', () => {
 	const input = [
 		'- a block',
 		'  collapsed:: true',
@@ -135,12 +135,12 @@ test('[T3] always-drop keys ignore the mode (collapsed/logseq.*/hl-* still dropp
 	assert.equal(removeLeftoverBlockProperties(input, [], 'wrap'), '- a block');
 });
 
-test('[T3] value containing ] falls back to keep', () => {
+test('[I1] value containing ] falls back to keep', () => {
 	const input = ['- a block', '  note:: foo] bar'].join('\n');
 	assert.equal(removeLeftoverBlockProperties(input, [], 'wrap'), input);
 });
 
-test('[T3] wrap mode does not touch property-like lines inside code fences', () => {
+test('[I1] wrap mode does not touch property-like lines inside code fences', () => {
 	const input = ['- a block', '  ```', '  key:: value', '  ```'].join('\n');
 	assert.equal(removeLeftoverBlockProperties(input, [], 'wrap'), input);
 });
@@ -151,13 +151,13 @@ test('extractPageProperties drops listed page property keys from frontmatter', (
 	assert.equal(yaml, ['---', 'type: note', '---'].join('\n'));
 });
 
-test('[T4] icon page property is dropped from frontmatter by default', () => {
+test('[I1] icon page property is dropped from frontmatter by default', () => {
 	const input = 'type:: note\nicon:: \uEAE5\n\ntext';
 	const { yaml } = extractPageProperties(input, { dropPageProperties: DEFAULT_DROP_PAGE_PROPERTIES });
 	assert.equal(yaml, ['---', 'type: note', '---'].join('\n'));
 });
 
-test('[T4] icon is retained when removed from the drop list', () => {
+test('[I1] icon is retained when removed from the drop list', () => {
 	const input = 'type:: note\nicon:: star\n\ntext';
 	const { yaml } = extractPageProperties(input, { dropPageProperties: [] });
 	assert.equal(yaml, ['---', 'type: note', 'icon: star', '---'].join('\n'));
@@ -188,82 +188,82 @@ test('convertHeadingProperty leaves heading:: true (auto) handling without crash
 });
 
 // ---------------------------------------------------------------------------
-// Regression findings (domain 05) — RED tests for accepted fixes.
+// Documented transformation cases — I1.
 // ---------------------------------------------------------------------------
 
-// H1: a value starting with '#' must be quoted (else YAML reads it as a comment → null).
-test('[H1] scalar value starting with # is quoted', () => {
+// I1: a value starting with '#' must be quoted (else YAML reads it as a comment → null).
+test('[I1] scalar value starting with # is quoted', () => {
 	const { yaml } = extractPageProperties('status:: #in-progress\n\ntext');
 	assert.equal(yaml, ['---', 'status: "#in-progress"', '---'].join('\n'));
 });
 
-// H2: a value that is a markdown link must be quoted (else the whole block is invalid YAML).
-test('[H2] scalar value that is a markdown link is quoted', () => {
+// I1: a value that is a markdown link must be quoted (else the whole block is invalid YAML).
+test('[I1] scalar value that is a markdown link is quoted', () => {
 	const { yaml } = extractPageProperties('file:: [doc](../a/b.pdf)\n\ntext');
 	assert.equal(yaml, ['---', 'file: "[doc](../a/b.pdf)"', '---'].join('\n'));
 });
 
-// H3: a comma inside a single wikilink must not be treated as a list separator.
-test('[H3] comma inside a single wikilink is not split into a list', () => {
+// I1: a comma inside a single wikilink must not be treated as a list separator.
+test('[I1] comma inside a single wikilink is not split into a list', () => {
 	const { yaml } = extractPageProperties('deadline:: [[Jul 18th, 2025]]\n\ntext');
 	assert.equal(yaml, ['---', 'deadline: "[[Jul 18th, 2025]]"', '---'].join('\n'));
 });
 
-// H4: general YAML-unsafe scalars must be quoted (colon-space, bool-like, leading-zero number).
-test('[H4] colon-space value is quoted', () => {
+// I1: general YAML-unsafe scalars must be quoted (colon-space, bool-like, leading-zero number).
+test('[I1] colon-space value is quoted', () => {
 	const { yaml } = extractPageProperties('k:: value: with colon\n\nx');
 	assert.equal(yaml, ['---', 'k: "value: with colon"', '---'].join('\n'));
 });
 
-test('[H4] boolean-like value stays a quoted string', () => {
+test('[I1] boolean-like value stays a quoted string', () => {
 	const { yaml } = extractPageProperties('k:: yes\n\nx');
 	assert.equal(yaml, ['---', 'k: "yes"', '---'].join('\n'));
 });
 
-test('[H4] leading-zero numeric value stays a quoted string', () => {
+test('[I1] leading-zero numeric value stays a quoted string', () => {
 	const { yaml } = extractPageProperties('k:: 007\n\nx');
 	assert.equal(yaml, ['---', 'k: "007"', '---'].join('\n'));
 });
 
-// M1: an internal block property written as a bullet must still be stripped.
-test('[M1] internal block property written as a bullet is stripped', () => {
+// I1: an internal block property written as a bullet must still be stripped.
+test('[I1] internal block property written as a bullet is stripped', () => {
 	const input = ['- a block', '- collapsed:: true', '- next'].join('\n');
 	assert.equal(removeLeftoverBlockProperties(input), ['- a block', '- next'].join('\n'));
 });
 
-// M2: Logseq PDF-highlight internal props must be dropped from the body.
-test('[M2] PDF highlight props (ls-type / hl-*) are dropped', () => {
+// I1: Logseq PDF-highlight internal props must be dropped from the body.
+test('[I1] PDF highlight props (ls-type / hl-*) are dropped', () => {
 	const input = ['- quote', '  ls-type:: annotation', '  hl-page:: 46', '  hl-color:: yellow'].join('\n');
 	assert.equal(removeLeftoverBlockProperties(input), '- quote');
 });
 
-// M3: a title:: page property must be preserved (carried as an alias).
-test('[M3] title page property is preserved as an alias', () => {
+// I1: a title:: page property must be preserved (carried as an alias).
+test('[I1] title page property is preserved as an alias', () => {
 	const { yaml, raw } = extractPageProperties('title:: Example Title\ntype:: note\n\ntext');
 	assert.equal(raw.title, 'Example Title');
 	assert.match(yaml, /aliases:\n {2}- Example Title/);
 });
 
-// L1: created/updated wikilink dates become plain ISO dates.
-test('[L1] created wikilink date is emitted as a plain ISO date', () => {
+// I1: created/updated wikilink dates become plain ISO dates.
+test('[I1] created wikilink date is emitted as a plain ISO date', () => {
 	const { yaml } = extractPageProperties('created:: [[2024-01-16]]\n\nx');
 	assert.equal(yaml, ['---', 'created: 2024-01-16', '---'].join('\n'));
 });
 
-// L2: an empty-valued page property is omitted entirely.
-test('[L2] empty-valued page property is omitted', () => {
+// I1: an empty-valued page property is omitted entirely.
+test('[I1] empty-valued page property is omitted', () => {
 	const { yaml } = extractPageProperties('icon::\n\nx');
 	assert.equal(yaml, '');
 });
 
-// L4: duplicate page-property keys are de-duplicated (last wins).
-test('[L4] duplicate page-property keys are de-duplicated (last wins)', () => {
+// I1: duplicate page-property keys are de-duplicated (last wins).
+test('[I1] duplicate page-property keys are de-duplicated (last wins)', () => {
 	const { yaml } = extractPageProperties('type:: a\ntype:: b\n\nx');
 	assert.equal(yaml, ['---', 'type: b', '---'].join('\n'));
 });
 
-// --- T5: linkify tag-style frontmatter values in pass-2 ---
-test('[T5] tag value linkifies to [[page]] when page exists and toLinks on', () => {
+// --- I1: linkify tag-style frontmatter values in pass-2 ---
+test('[I1] tag value linkifies to [[page]] when page exists and toLinks on', () => {
 	const yaml = ['---', 'status: "#IN-PROGRESS"', '---'].join('\n');
 	const out = linkifyTagValuesInFrontmatter(yaml, {
 		knownPages: new Set(['in-progress']),
@@ -273,7 +273,7 @@ test('[T5] tag value linkifies to [[page]] when page exists and toLinks on', () 
 	assert.equal(out, ['---', 'status: "[[IN-PROGRESS]]"', '---'].join('\n'));
 });
 
-test('[T5] multi-word #[[tag]] value linkifies to [[tag]]', () => {
+test('[I1] multi-word #[[tag]] value linkifies to [[tag]]', () => {
 	const yaml = ['---', 'area: "#[[Page One]]"', '---'].join('\n');
 	const out = linkifyTagValuesInFrontmatter(yaml, {
 		knownPages: new Set(['page one']),
@@ -283,7 +283,7 @@ test('[T5] multi-word #[[tag]] value linkifies to [[tag]]', () => {
 	assert.equal(out, ['---', 'area: "[[Page One]]"', '---'].join('\n'));
 });
 
-test('[T5] tag value stays quoted text when no matching page (onlyExistingPages)', () => {
+test('[I1] tag value stays quoted text when no matching page (onlyExistingPages)', () => {
 	const yaml = ['---', 'status: "#IN-PROGRESS"', '---'].join('\n');
 	const out = linkifyTagValuesInFrontmatter(yaml, {
 		knownPages: new Set(),
@@ -293,7 +293,7 @@ test('[T5] tag value stays quoted text when no matching page (onlyExistingPages)
 	assert.equal(out, yaml);
 });
 
-test('[T5] tag value stays quoted text when toLinks is off (default)', () => {
+test('[I1] tag value stays quoted text when toLinks is off (default)', () => {
 	const yaml = ['---', 'status: "#IN-PROGRESS"', '---'].join('\n');
 	const out = linkifyTagValuesInFrontmatter(yaml, {
 		knownPages: new Set(['in-progress']),
@@ -303,7 +303,7 @@ test('[T5] tag value stays quoted text when toLinks is off (default)', () => {
 	assert.equal(out, yaml);
 });
 
-test('[T5] tags: list is unaffected', () => {
+test('[I1] tags: list is unaffected', () => {
 	const yaml = ['---', 'tags:', '  - foo', '  - bar', '---'].join('\n');
 	const out = linkifyTagValuesInFrontmatter(yaml, {
 		knownPages: new Set(['foo', 'bar']),
@@ -313,7 +313,7 @@ test('[T5] tags: list is unaffected', () => {
 	assert.equal(out, yaml);
 });
 
-test('[T5] tag value linkifies regardless of page set when onlyExistingPages is off', () => {
+test('[I1] tag value linkifies regardless of page set when onlyExistingPages is off', () => {
 	const yaml = ['---', 'area: "#security"', '---'].join('\n');
 	const out = linkifyTagValuesInFrontmatter(yaml, {
 		knownPages: new Set(),

--- a/tests/logseq/tasks.test.ts
+++ b/tests/logseq/tasks.test.ts
@@ -162,3 +162,46 @@ test('cancelled property with wikilink date (emoji)', () => {
 	const input = ['- CANCELLED nope', '  cancelled:: [[2024-03-20]]'].join('\n');
 	assert.equal(convertTasks(input, 'tasks-emoji'), '- [-] nope ❌ 2024-03-20');
 });
+
+// ---------------------------------------------------------------------------
+// Regression findings (domain 04) — RED tests for accepted fixes.
+// ---------------------------------------------------------------------------
+
+// Issue 1: Logseq long-date format must normalize to ISO in task metadata.
+test('[Issue 1] completed date in Logseq long-date format normalizes to ISO (emoji)', () => {
+	const input = ['- DONE x', '  completed:: [[Feb 13th, 2025]]'].join('\n');
+	assert.equal(convertTasks(input, 'tasks-emoji'), '- [x] x ✅ 2025-02-13');
+});
+
+// Issue 2: a LOGBOOK/CLOCK drawer on a NON-task bullet must still be dropped.
+test('[Issue 2] drops LOGBOOK drawer attached to a non-task child bullet', () => {
+	const input = [
+		'- DONE parent',
+		'\t- plain child',
+		'\t  :LOGBOOK:',
+		'\t  CLOCK: [2024-11-13 Wed 17:04:11]--[2024-11-13 Wed 17:04:12] =>  00:00:01',
+		'\t  :END:',
+	].join('\n');
+	assert.equal(
+		convertTasks(input, 'tasks-emoji', { logbook: 'drop' }),
+		['- [x] parent', '\t- plain child'].join('\n'),
+	);
+});
+
+// Issue 3: a blank/whitespace-only continuation line must not orphan metadata.
+test('[Issue 3] metadata after a blank continuation line is still parsed (emoji)', () => {
+	const input = ['- DONE x', '  ', '  SCHEDULED: <2024-11-06 Wed>', '  ', '  completed:: 2024-11-06'].join('\n');
+	assert.equal(convertTasks(input, 'tasks-emoji'), '- [x] x ⏳ 2024-11-06 ✅ 2024-11-06');
+});
+
+// Issue 4 (guard): time-of-day in SCHEDULED is intentionally dropped to date-only.
+test('[Issue 4] time-of-day in SCHEDULED is dropped to date-only (emoji)', () => {
+	const input = ['- TODO meet', '  SCHEDULED: <2025-02-20 Thu 14:00>'].join('\n');
+	assert.equal(convertTasks(input, 'tasks-emoji'), '- [ ] meet ⏳ 2025-02-20');
+});
+
+// Issue 5: an unparsable template-token date must not be emitted as a ➕ date.
+test('[Issue 5] template token in created date is not emitted as a plus-date (emoji)', () => {
+	const input = ['- TODO x', '  created:: [[{{date:YYYY-MM-DD}}]]'].join('\n');
+	assert.equal(convertTasks(input, 'tasks-emoji'), '- [ ] x');
+});

--- a/tests/logseq/tasks.test.ts
+++ b/tests/logseq/tasks.test.ts
@@ -25,6 +25,23 @@ test('does not touch non-task bullets or partial keywords', () => {
 	assert.equal(convertTasks('plain TODO line', 'tasks-emoji'), 'plain TODO line');
 });
 
+// --- T1: colon-style keyword tasks ---
+test('[T1] - TODO: text is recognized and the colon is dropped', () => {
+	assert.equal(convertTasks('- TODO: text', 'tasks-emoji'), '- [ ] text');
+});
+
+test('[T1] - DONE: text', () => {
+	assert.equal(convertTasks('- DONE: text', 'tasks-emoji'), '- [x] text');
+});
+
+test('[T1] - WAITING: text', () => {
+	assert.equal(convertTasks('- WAITING: text', 'tasks-emoji'), '- [ ] text');
+});
+
+test('[T1] partial keyword TODOX is still not a task', () => {
+	assert.equal(convertTasks('- TODOX foo', 'tasks-emoji'), '- TODOX foo');
+});
+
 // --- priority ---
 test('converts priority markers (emoji)', () => {
 	assert.equal(convertTasks('- TODO [#A] x', 'tasks-emoji'), '- [ ] x ⏫');
@@ -171,6 +188,17 @@ test('cancelled property with wikilink date (emoji)', () => {
 test('[Issue 1] completed date in Logseq long-date format normalizes to ISO (emoji)', () => {
 	const input = ['- DONE x', '  completed:: [[Feb 13th, 2025]]'].join('\n');
 	assert.equal(convertTasks(input, 'tasks-emoji'), '- [x] x ✅ 2025-02-13');
+});
+
+// --- T2: Logseq set-literal completed:: #{…} ---
+test('[T2] completed:: #{"Mar 3rd, 2025"} becomes ✅ 2025-03-03', () => {
+	const input = ['- DONE x', '  completed:: #{"Mar 3rd, 2025"}'].join('\n');
+	assert.equal(convertTasks(input, 'tasks-emoji'), '- [x] x ✅ 2025-03-03');
+});
+
+test('[T2] malformed completed:: #{"{"} emits no completion date and drops cleanly', () => {
+	const input = ['- DONE x', '  completed:: #{"{"}'].join('\n');
+	assert.equal(convertTasks(input, 'tasks-emoji'), '- [x] x');
 });
 
 // Issue 2: a LOGBOOK/CLOCK drawer on a NON-task bullet must still be dropped.

--- a/tests/logseq/tasks.test.ts
+++ b/tests/logseq/tasks.test.ts
@@ -25,20 +25,20 @@ test('does not touch non-task bullets or partial keywords', () => {
 	assert.equal(convertTasks('plain TODO line', 'tasks-emoji'), 'plain TODO line');
 });
 
-// --- T1: colon-style keyword tasks ---
-test('[T1] - TODO: text is recognized and the colon is dropped', () => {
+// --- D1: colon-style keyword tasks ---
+test('[D1] - TODO: text is recognized and the colon is dropped', () => {
 	assert.equal(convertTasks('- TODO: text', 'tasks-emoji'), '- [ ] text');
 });
 
-test('[T1] - DONE: text', () => {
+test('[D1] - DONE: text', () => {
 	assert.equal(convertTasks('- DONE: text', 'tasks-emoji'), '- [x] text');
 });
 
-test('[T1] - WAITING: text', () => {
+test('[D1] - WAITING: text', () => {
 	assert.equal(convertTasks('- WAITING: text', 'tasks-emoji'), '- [ ] text');
 });
 
-test('[T1] partial keyword TODOX is still not a task', () => {
+test('[D1] partial keyword TODOX is still not a task', () => {
 	assert.equal(convertTasks('- TODOX foo', 'tasks-emoji'), '- TODOX foo');
 });
 
@@ -181,28 +181,28 @@ test('cancelled property with wikilink date (emoji)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Regression findings (domain 04) — RED tests for accepted fixes.
+// Documented transformation cases — D1.
 // ---------------------------------------------------------------------------
 
-// Issue 1: Logseq long-date format must normalize to ISO in task metadata.
-test('[Issue 1] completed date in Logseq long-date format normalizes to ISO (emoji)', () => {
+// D1: Logseq long-date format must normalize to ISO in task metadata.
+test('[D1] completed date in Logseq long-date format normalizes to ISO (emoji)', () => {
 	const input = ['- DONE x', '  completed:: [[Feb 13th, 2025]]'].join('\n');
 	assert.equal(convertTasks(input, 'tasks-emoji'), '- [x] x ✅ 2025-02-13');
 });
 
-// --- T2: Logseq set-literal completed:: #{…} ---
-test('[T2] completed:: #{"Mar 3rd, 2025"} becomes ✅ 2025-03-03', () => {
+// --- D1: Logseq set-literal completed:: #{…} ---
+test('[D1] completed:: #{"Mar 3rd, 2025"} becomes ✅ 2025-03-03', () => {
 	const input = ['- DONE x', '  completed:: #{"Mar 3rd, 2025"}'].join('\n');
 	assert.equal(convertTasks(input, 'tasks-emoji'), '- [x] x ✅ 2025-03-03');
 });
 
-test('[T2] malformed completed:: #{"{"} emits no completion date and drops cleanly', () => {
+test('[D1] malformed completed:: #{"{"} emits no completion date and drops cleanly', () => {
 	const input = ['- DONE x', '  completed:: #{"{"}'].join('\n');
 	assert.equal(convertTasks(input, 'tasks-emoji'), '- [x] x');
 });
 
-// Issue 2: a LOGBOOK/CLOCK drawer on a NON-task bullet must still be dropped.
-test('[Issue 2] drops LOGBOOK drawer attached to a non-task child bullet', () => {
+// D1: a LOGBOOK/CLOCK drawer on a NON-task bullet must still be dropped.
+test('[D1] drops LOGBOOK drawer attached to a non-task child bullet', () => {
 	const input = [
 		'- DONE parent',
 		'\t- plain child',
@@ -216,20 +216,20 @@ test('[Issue 2] drops LOGBOOK drawer attached to a non-task child bullet', () =>
 	);
 });
 
-// Issue 3: a blank/whitespace-only continuation line must not orphan metadata.
-test('[Issue 3] metadata after a blank continuation line is still parsed (emoji)', () => {
+// D1: a blank/whitespace-only continuation line must not orphan metadata.
+test('[D1] metadata after a blank continuation line is still parsed (emoji)', () => {
 	const input = ['- DONE x', '  ', '  SCHEDULED: <2024-11-06 Wed>', '  ', '  completed:: 2024-11-06'].join('\n');
 	assert.equal(convertTasks(input, 'tasks-emoji'), '- [x] x ⏳ 2024-11-06 ✅ 2024-11-06');
 });
 
-// Issue 4 (guard): time-of-day in SCHEDULED is intentionally dropped to date-only.
-test('[Issue 4] time-of-day in SCHEDULED is dropped to date-only (emoji)', () => {
+// D1 (guard): time-of-day in SCHEDULED is intentionally dropped to date-only.
+test('[D1] time-of-day in SCHEDULED is dropped to date-only (emoji)', () => {
 	const input = ['- TODO meet', '  SCHEDULED: <2025-02-20 Thu 14:00>'].join('\n');
 	assert.equal(convertTasks(input, 'tasks-emoji'), '- [ ] meet ⏳ 2025-02-20');
 });
 
-// Issue 5: an unparsable template-token date must not be emitted as a ➕ date.
-test('[Issue 5] template token in created date is not emitted as a plus-date (emoji)', () => {
+// D1: an unparsable template-token date must not be emitted as a ➕ date.
+test('[D1] template token in created date is not emitted as a plus-date (emoji)', () => {
 	const input = ['- TODO x', '  created:: [[{{date:YYYY-MM-DD}}]]'].join('\n');
 	assert.equal(convertTasks(input, 'tasks-emoji'), '- [ ] x');
 });

--- a/tests/logseq/tasks.test.ts
+++ b/tests/logseq/tasks.test.ts
@@ -1,0 +1,164 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { convertTasks } from '../../src/formats/logseq/tasks';
+
+// --- state mapping (emoji) ---
+test('maps Logseq task states to checkboxes (emoji)', () => {
+	assert.equal(convertTasks('- TODO a', 'tasks-emoji'), '- [ ] a');
+	assert.equal(convertTasks('- LATER e', 'tasks-emoji'), '- [ ] e');
+	assert.equal(convertTasks('- DOING b', 'tasks-emoji'), '- [/] b');
+	assert.equal(convertTasks('- NOW f', 'tasks-emoji'), '- [/] f');
+	assert.equal(convertTasks('- DONE c', 'tasks-emoji'), '- [x] c');
+	assert.equal(convertTasks('- CANCELLED d', 'tasks-emoji'), '- [-] d');
+	assert.equal(convertTasks('- WAITING g', 'tasks-emoji'), '- [ ] g');
+});
+
+test('preserves indentation', () => {
+	assert.equal(convertTasks('  - TODO x', 'tasks-emoji'), '  - [ ] x');
+	assert.equal(convertTasks('\t\t- DONE y', 'tasks-emoji'), '\t\t- [x] y');
+});
+
+test('does not touch non-task bullets or partial keywords', () => {
+	assert.equal(convertTasks('- just text', 'tasks-emoji'), '- just text');
+	assert.equal(convertTasks('- TODONT something', 'tasks-emoji'), '- TODONT something');
+	assert.equal(convertTasks('plain TODO line', 'tasks-emoji'), 'plain TODO line');
+});
+
+// --- priority ---
+test('converts priority markers (emoji)', () => {
+	assert.equal(convertTasks('- TODO [#A] x', 'tasks-emoji'), '- [ ] x ⏫');
+	assert.equal(convertTasks('- TODO [#B] x', 'tasks-emoji'), '- [ ] x 🔼');
+	assert.equal(convertTasks('- TODO [#C] x', 'tasks-emoji'), '- [ ] x 🔽');
+});
+
+test('converts priority markers (dataview)', () => {
+	assert.equal(convertTasks('- TODO [#A] x', 'tasks-dataview'), '- [ ] x [priority:: high]');
+});
+
+// --- scheduled / deadline on continuation lines ---
+test('scheduled date on continuation line (emoji)', () => {
+	const input = ['- TODO do it', '  SCHEDULED: <2024-09-10 Tue>'].join('\n');
+	assert.equal(convertTasks(input, 'tasks-emoji'), '- [ ] do it ⏳ 2024-09-10');
+});
+
+test('deadline with repeater (emoji)', () => {
+	const input = ['- TODO pay', '  DEADLINE: <2024-09-15 Sun .+1d>'].join('\n');
+	assert.equal(convertTasks(input, 'tasks-emoji'), '- [ ] pay 📅 2024-09-15 🔁 every day when done');
+});
+
+test('deadline with multi-unit repeater (emoji)', () => {
+	const input = ['- TODO chore', '  SCHEDULED: <2024-09-15 Sun ++2w>'].join('\n');
+	assert.equal(convertTasks(input, 'tasks-emoji'), '- [ ] chore ⏳ 2024-09-15 🔁 every 2 weeks when done');
+});
+
+test('scheduled date (dataview)', () => {
+	const input = ['- TODO do it', '  SCHEDULED: <2024-09-10 Tue>'].join('\n');
+	assert.equal(convertTasks(input, 'tasks-dataview'), '- [ ] do it [scheduled:: 2024-09-10]');
+});
+
+// --- task date properties ---
+test('completed property becomes done emoji', () => {
+	const input = ['- DONE finish', '  completed:: [[2024-04-10]]'].join('\n');
+	assert.equal(convertTasks(input, 'tasks-emoji'), '- [x] finish ✅ 2024-04-10');
+});
+
+test('created property becomes plus emoji', () => {
+	const input = ['- TODO start', '  created:: 2024-01-15'].join('\n');
+	assert.equal(convertTasks(input, 'tasks-emoji'), '- [ ] start ➕ 2024-01-15');
+});
+
+test('done property (dataview)', () => {
+	const input = ['- DONE finish', '  completed:: 2024-04-10'].join('\n');
+	assert.equal(convertTasks(input, 'tasks-dataview'), '- [x] finish [completion:: 2024-04-10]');
+});
+
+// --- ordering: priority before dates ---
+test('priority precedes scheduled metadata', () => {
+	const input = ['- TODO [#A] do', '  SCHEDULED: <2024-09-10 Tue>'].join('\n');
+	assert.equal(convertTasks(input, 'tasks-emoji'), '- [ ] do ⏫ ⏳ 2024-09-10');
+});
+
+// --- LOGBOOK ---
+test('drops LOGBOOK drawer by default', () => {
+	const input = [
+		'- DONE x',
+		'  :LOGBOOK:',
+		'  CLOCK: [2024-08-07 Wed 11:47:50]--[2024-08-07 Wed 11:48:00] =>  00:00:10',
+		'  :END:',
+	].join('\n');
+	assert.equal(convertTasks(input, 'tasks-emoji', { logbook: 'drop' }), '- [x] x');
+});
+
+test('keeps LOGBOOK drawer when configured', () => {
+	const input = [
+		'- DONE x',
+		'  :LOGBOOK:',
+		'  CLOCK: [2024-08-07 Wed 11:47:50]',
+		'  :END:',
+	].join('\n');
+	assert.equal(convertTasks(input, 'tasks-emoji', { logbook: 'keep' }), input.replace('- DONE x', '- [x] x'));
+});
+
+// --- plain format ---
+test('plain format only converts the state keyword', () => {
+	assert.equal(convertTasks('- DOING [#A] x', 'plain'), '- [ ] [#A] x');
+	assert.equal(convertTasks('- CANCELLED y', 'plain'), '- [x] y');
+	const input = ['- TODO do it', '  SCHEDULED: <2024-09-10 Tue>'].join('\n');
+	// scheduled line is left as-is in plain mode
+	assert.equal(convertTasks(input, 'plain'), ['- [ ] do it', '  SCHEDULED: <2024-09-10 Tue>'].join('\n'));
+});
+
+// --- non-task content with child bullets is untouched ---
+test('child bullets are not consumed as task continuation', () => {
+	const input = ['- TODO parent', '  - child block', '  - second child'].join('\n');
+	assert.equal(convertTasks(input, 'tasks-emoji'), ['- [ ] parent', '  - child block', '  - second child'].join('\n'));
+});
+
+// --- additional state variations ---
+test('WAIT state maps to open checkbox (emoji)', () => {
+	assert.equal(convertTasks('- WAIT for approval', 'tasks-emoji'), '- [ ] for approval');
+});
+
+test('IN-PROGRESS state maps to open checkbox (emoji)', () => {
+	assert.equal(convertTasks('- IN-PROGRESS refactoring', 'tasks-emoji'), '- [ ] refactoring');
+});
+
+test('CANCELED (single L) maps to cancelled (emoji)', () => {
+	assert.equal(convertTasks('- CANCELED old item', 'tasks-emoji'), '- [-] old item');
+});
+
+// --- combined SCHEDULED + DEADLINE ---
+test('task with both SCHEDULED and DEADLINE (emoji)', () => {
+	const input = ['- TODO both', '  SCHEDULED: <2024-09-01 Sun>', '  DEADLINE: <2024-09-15 Mon>'].join('\n');
+	assert.equal(convertTasks(input, 'tasks-emoji'), '- [ ] both ⏳ 2024-09-01 📅 2024-09-15');
+});
+
+test('task with both SCHEDULED and DEADLINE (dataview)', () => {
+	const input = ['- TODO both', '  SCHEDULED: <2024-09-01 Sun>', '  DEADLINE: <2024-09-15 Mon>'].join('\n');
+	assert.equal(convertTasks(input, 'tasks-dataview'), '- [ ] both [scheduled:: 2024-09-01] [due:: 2024-09-15]');
+});
+
+// --- DEADLINE with repeater (dataview) ---
+test('deadline with repeater (dataview)', () => {
+	const input = ['- TODO chore', '  DEADLINE: <2024-09-15 Sun .+2w>'].join('\n');
+	assert.equal(convertTasks(input, 'tasks-dataview'), '- [ ] chore [due:: 2024-09-15] [repeat:: .+2w]');
+});
+
+// --- edge: empty task text ---
+test('task keyword with no text', () => {
+	assert.equal(convertTasks('- TODO', 'tasks-emoji'), '- [ ]');
+	assert.equal(convertTasks('- DONE', 'tasks-emoji'), '- [x]');
+});
+
+// --- completed + created combined ---
+test('completed and created on same task (emoji)', () => {
+	const input = ['- DONE finish', '  created:: 2024-01-01', '  completed:: 2024-06-15'].join('\n');
+	assert.equal(convertTasks(input, 'tasks-emoji'), '- [x] finish ➕ 2024-01-01 ✅ 2024-06-15');
+});
+
+// --- cancelled date property ---
+test('cancelled property with wikilink date (emoji)', () => {
+	const input = ['- CANCELLED nope', '  cancelled:: [[2024-03-20]]'].join('\n');
+	assert.equal(convertTasks(input, 'tasks-emoji'), '- [-] nope ❌ 2024-03-20');
+});


### PR DESCRIPTION
Closes #47.

This adds an importer for Logseq's file-based Markdown graph format.

## Motivation

I have been using Logseq for a couple of years, previously migrated from Obsidian (even wrote a [migration tool](https://github.com/laughedelic/outbreak) for that). But now I'm coming back to Obsidian (because of the perpetual Logseq DB beta). I've tried using some of the existing migration scripts a few times before (and even contributed to one of them: https://github.com/sercxanto/logseq_to_obsidian/pull/54). But I wasn't satisfied with the feature coverage and encountered too many edge cases in my own notes, so I decided to do it the proper way and implement it as part of the official importer.

Although Logseq graphs are stored as Markdown, copying the files directly leaves several graph-level conventions unresolved: block references, aliases used as link targets, namespaced page paths, journal dates, task metadata, properties, Logseq embeds, and referenced assets. Logseq's org-mode-inspired Markdown flavor also has a lot of differences that need careful handling to land well in Obsidian (see a list with examples [here](https://github.com/laughedelic/outbreak/blob/main/syntax-differences.md)). The importer handles these conventions while preserving ordinary Markdown wherever no conversion is needed.

This has been extensively tested on my own Logseq graph (~700 notes) until I was completely satisfied with the result, and I have now fully migrated to Obsidian. I didn't tailor the implementation to my own preferences and tried to make it very configurable and cover use cases different from my own.


## Functionality

- Graph-folder selection and recursive discovery of Markdown files under `pages/` and `journals/`
- Namespace and percent-encoded filename conversion into Obsidian paths
- Daily Notes integration for journal folders, filenames, and date links
- Conversion of:
  - page and block properties
  - task states, priorities, dates, and repeaters (Tasks plugin support!)
  - block IDs, references, and embeds
  - page aliases and references made through aliases
  - tags and tag-like property values
  - org blocks, highlights, numbered lists, media embeds, and local assets
- Exact output-path collision detection and same-basename link disambiguation
- Configurable handling for tasks, properties, tags, unresolved references, queries, flashcards, LOGBOOK drawers, and asset alt text
- **Optional** de-outlining for pages and journals (separately) turning "everything is a list" outline format into more Obsidian-friendly "flatter" markdown

## Implementation

The importer uses two passes because several conversions require knowledge of the complete graph:

1. Plan output paths and detect collisions.
2. Convert files locally while collecting block IDs, aliases, referenced assets, and known pages.
3. Resolve cross-file references and aliases, disambiguate links, convert tags, optionally de-outline, and write the results.

- Most of the implementation is isolated under `src/formats/logseq/`. The transformation modules are pure and do not import `obsidian`. 
- `src/formats/logseq.ts` contains the Obsidian UI, filesystem, vault-writing, and cross-file orchestration.

No added runtime dependencies.

## Review

I know this is a large changeset, but most of it is test code. A suggested review order is:

1. `options.ts` and `pipeline.ts` for defaults and transformation order
2. The pure transform modules under `src/formats/logseq/`
3. `block-ids.ts` and `links.ts` for graph-wide resolution
4. `src/formats/logseq.ts` for planning, UI, writes, and asset copies
5. `tests/logseq/` and the two documentation files

## Defaults

The defaults are intentionally conservative:

- Preserve Logseq’s outline structure
- Preserve unresolved block references rather than deleting them
- Keep queries and flashcard content
- Keep tags as tags unless conversion to links is enabled
- Only convert a tag to a link when a matching page exists
- Report colliding or empty files instead of silently overwriting them within an import
- Shorten block UUIDs to Obsidian-style anchors while keeping references consistent

LOGBOOK drawers and the `card` metadata tag are removed by default because they have no direct Obsidian equivalent. Both behaviors are configurable.

Existing vault notes at a selected output path are replaced, matching the importer’s current write behavior.

## Testing

```sh
npx tsx --test tests/logseq/*.test.ts
```

Coverage includes focused suites for each of the formatters, de-outlining, whitespace normalization, and orchestration helpers, plus a multi-file end-to-end fixture graph.


## Known limitations

- Logseq database graphs are not supported
- Custom source journal formats from `config.edn` and Periodic Notes settings are not parsed
- Logseq whiteboards, PDF annotation geometry, SRS scheduling, template execution, and query-language translation are not migrated.
- De-outlining is heuristic and remains opt-in
- Advanced org query blocks are retained as fenced `query` blocks
- Assets are flattened into the output `assets/` folder. Same-basename asset collisions are not currently renamed or reported

## Detailed documentation

- The design decisions and tradeoffs are detailed in [`docs/logseq-importer-assessment.md`](https://github.com/laughedelic/obsidian-importer/blob/feat/logseq-importer/docs/logseq-importer-assessment.md)
- The complete conversion rules and option interactions are documented in [`docs/logseq-importer-transformations.md`](https://github.com/laughedelic/obsidian-importer/blob/feat/logseq-importer/docs/logseq-importer-transformations.md)

I see that the docs for other importers are not kept in this repository, but there is a separate documentation website. I can move the docs there.