### PR TITLE
Notion: Cover the fixes that shipped without tests, and make page discovery testable

### DIFF
--- a/src/formats/notion-api.ts
+++ b/src/formats/notion-api.ts
@@ -20,26 +20,7 @@ import { convertBlocksToMarkdown } from './notion-api/block-converter';
 import { processDatabasePlaceholders, importDatabaseCore, replaceRelationValue } from './notion-api/database-helpers';
 import { DatabaseInfo, RelationPlaceholder, DatabaseProcessingContext, FetchAndImportPageParams, NOTION_VERSION } from './notion-api/types';
 import { downloadAttachment } from './notion-api/attachment-helpers';
-
-// Notion API parent types (based on @notionhq/client internal types)
-type NotionParent =
-	| { type: 'page_id', page_id: string }
-	| { type: 'data_source_id', data_source_id: string, database_id: string }
-	| { type: 'database_id', database_id: string }
-	| { type: 'workspace', workspace: true }
-	| { type: 'block_id', block_id: string };
-
-// Tree node for page/database selection
-interface NotionTreeNode {
-	id: string; // For pages: page ID; For databases: data_source ID
-	title: string;
-	type: 'page' | 'database';
-	parentId: string | null;
-	children: NotionTreeNode[];
-	selected: boolean;
-	disabled: boolean; // Disabled when parent is selected
-	collapsed: boolean; // Whether the node's children are collapsed
-}
+import { buildTree, collectItems, type NotionTreeNode } from './notion-api/discovery';
 
 export class NotionAPIImporter extends FormatImporter {
 	/** Resolved from the keychain on each read, so unlinking the secret takes effect immediately */
@@ -391,69 +372,10 @@ export class NotionAPIImporter extends FormatImporter {
 				cursor = response.has_more ? response.next_cursor ?? undefined : undefined;
 			} while (cursor);
 
-			// Phase 1: Identify items that should be filtered
-			// Collect IDs of pages and databases that won't appear in tree:
-			// - Databases with database_parent.type === 'block_id'
-			// - Pages with parent.type === 'block_id'
-			const filteredIds = new Set<string>();
-
-			for (const item of allRawItems) {
-				if (item.object === 'data_source') {
-					// Databases inside blocks
-					if (item.database_parent && item.database_parent.type === 'block_id') {
-						filteredIds.add(item.id);
-					}
-				}
-				else if (item.object === 'page') {
-					// Pages with block_id parent
-					if (item.parent && item.parent.type === 'block_id') {
-						filteredIds.add(item.id);
-					}
-				}
-			}
-
-			// Phase 2: Process items and filter appropriately
-			const allItems: Array<{ id: string, title: string, type: 'page' | 'database', parentId: string | null }> = [];
-			for (const item of allRawItems) {
-				// Skip if this item itself is in the filtered list
-				if (filteredIds.has(item.id)) {
-					continue;
-				}
-
-				// Skip databases whose parent page is filtered
-				if (item.object === 'data_source' && item.database_parent && item.database_parent.type === 'page_id') {
-					const parentPageId = item.database_parent.page_id;
-					if (filteredIds.has(parentPageId)) {
-						continue;
-					}
-				}
-
-				// Skip pages that belong to filtered databases
-				if (item.object === 'page' && item.parent && item.parent.type === 'data_source_id') {
-					const dataSourceId = item.parent.data_source_id;
-					if (filteredIds.has(dataSourceId)) {
-						continue;
-					}
-				}
-
-				// Process page or data_source (database)
-				if (item.object === 'page' || item.object === 'data_source') {
-					const isDatabase = item.object === 'data_source';
-					const title = this.extractItemTitle(item, isDatabase ? 'Untitled Database' : 'Untitled');
-					const parentObj = isDatabase ? item.database_parent : item.parent;
-					const parentId = this.extractParentId(parentObj, isDatabase ? 'database' : 'page');
-
-					allItems.push({
-						id: item.id,
-						title,
-						type: isDatabase ? 'database' : 'page',
-						parentId
-					});
-				}
-			}
+			const allItems = collectItems(allRawItems);
 
 			// Build tree structure
-			this.pageTree = this.buildTree(allItems);
+			this.pageTree = buildTree(allItems);
 
 			// Render tree (this will also update button text)
 			this.renderPageTree();
@@ -481,84 +403,6 @@ export class NotionAPIImporter extends FormatImporter {
 	}
 
 	/**
-	 * Extract title from a Notion item (page or data_source)
-	 * Both use the same title array structure with rich text
-	 */
-	private extractItemTitle(item: any, defaultTitle: string = 'Untitled'): string {
-		let titleArray: any[] | undefined;
-
-		// data_source has title directly
-		if (item.title) {
-			titleArray = item.title;
-		}
-		// page has title in properties object
-		// properties is an object where one of the keys has type: 'title'
-		else if (item.properties) {
-			// Find the property with type 'title'
-			for (const key in item.properties) {
-				const prop = item.properties[key];
-				if (prop.type === 'title' && prop.title) {
-					titleArray = prop.title;
-					break;
-				}
-			}
-		}
-
-		if (!titleArray || !Array.isArray(titleArray)) {
-			return defaultTitle;
-		}
-
-		const title = titleArray
-			.map((t: any) => t.text?.content || t.plain_text || '')
-			.join('')
-			.trim();
-
-		return title || defaultTitle;
-	}
-
-	/**
-	 * Extract parent ID from a parent object (used for both page.parent and data_source.database_parent)
-	 * Note: Items with block_id parent should be filtered out before calling this
-	 */
-	private extractParentId(
-		parentObj: NotionParent | null | undefined,
-		context: 'page' | 'database'
-	): string | null {
-		if (!parentObj) {
-			return null;
-		}
-
-		switch (parentObj.type) {
-			case 'page_id':
-				return parentObj.page_id;
-
-			case 'data_source_id':
-				// Pages in a database have data_source_id as parent
-				return parentObj.data_source_id;
-
-			case 'database_id':
-				// Databases can have database_id as parent (nested databases)
-				return parentObj.database_id;
-
-			case 'workspace':
-				// Top-level item
-				return null;
-
-			case 'block_id':
-				// This should have been filtered out before calling this function
-				console.warn(`[Notion Importer] block_id parent should be filtered before calling extractParentId`);
-				return null;
-
-			default: {
-				// TypeScript exhaustiveness check
-				const _exhaustive: never = parentObj;
-				console.warn(`[Notion Importer] Unexpected parent type for ${context}:`, _exhaustive);
-				return null;
-			}
-		}
-	}
-
-	/**
 	 * Find a node by ID in the tree (recursive search)
 	 */
 	private findNodeById(nodes: NotionTreeNode[], id: string): NotionTreeNode | null {
@@ -572,51 +416,6 @@ export class NotionAPIImporter extends FormatImporter {
 			}
 		}
 		return null;
-	}
-
-	/**
-	 * Build tree structure from flat list
-	 */
-	private buildTree(items: Array<{ id: string, title: string, type: 'page' | 'database', parentId: string | null }>): NotionTreeNode[] {
-		const nodeMap = new Map<string, NotionTreeNode>();
-		const roots: NotionTreeNode[] = [];
-
-		// Create all nodes
-		for (const item of items) {
-			nodeMap.set(item.id, {
-				id: item.id,
-				title: item.title,
-				type: item.type,
-				parentId: item.parentId,
-				children: [],
-				selected: false,
-				disabled: false,
-				collapsed: true, // Default to collapsed
-			});
-		}
-
-		// Build tree relationships
-		for (const node of nodeMap.values()) {
-			if (node.parentId && nodeMap.has(node.parentId)) {
-				const parent = nodeMap.get(node.parentId)!;
-				parent.children.push(node);
-			}
-			else {
-				// No parent or parent not in list -> root node
-				roots.push(node);
-			}
-		}
-
-		// Sort children by title
-		const sortNodes = (nodes: NotionTreeNode[]) => {
-			nodes.sort((a, b) => a.title.localeCompare(b.title));
-			for (const node of nodes) {
-				sortNodes(node.children);
-			}
-		};
-		sortNodes(roots);
-
-		return roots;
 	}
 
 	/**

--- a/src/formats/notion-api/discovery.ts
+++ b/src/formats/notion-api/discovery.ts
@@ -1,0 +1,235 @@
+/**
+ * What the user is offered to import, worked out from a Notion search.
+ *
+ * The importer asks /v1/search for everything the integration can see and gets
+ * back a flat list of pages and data sources, each naming its parent. Turning
+ * that into the tree the picker draws is the whole of this file: decide what
+ * does not belong in it, flatten the rest, then hang each item off its parent.
+ *
+ * It is here rather than on the importer because it needs nothing from the
+ * vault or the network - only a search response, which a test can hold - and
+ * because what it drops is where the reports of missing pages keep landing.
+ */
+
+/** A page or data source's parent, as the API describes it. */
+export type NotionParent =
+	| { type: 'page_id', page_id: string }
+	| { type: 'data_source_id', data_source_id: string, database_id: string }
+	| { type: 'database_id', database_id: string }
+	| { type: 'workspace', workspace: true }
+	| { type: 'block_id', block_id: string };
+
+/** A node in the tree the picker draws. */
+export interface NotionTreeNode {
+	id: string; // For pages: page ID; For databases: data_source ID
+	title: string;
+	type: 'page' | 'database';
+	parentId: string | null;
+	children: NotionTreeNode[];
+	selected: boolean;
+	disabled: boolean; // Disabled when parent is selected
+	collapsed: boolean; // Whether the node's children are collapsed
+}
+
+/** One row of the flat list, before it becomes a tree. */
+export interface NotionItem {
+	id: string;
+	title: string;
+	type: 'page' | 'database';
+	parentId: string | null;
+}
+
+/**
+ * Extract title from a Notion item (page or data_source)
+ * Both use the same title array structure with rich text
+ */
+export function extractItemTitle(item: any, defaultTitle: string = 'Untitled'): string {
+	let titleArray: any[] | undefined;
+
+	// data_source has title directly
+	if (item.title) {
+		titleArray = item.title;
+	}
+	// page has title in properties object
+	// properties is an object where one of the keys has type: 'title'
+	else if (item.properties) {
+		// Find the property with type 'title'
+		for (const key in item.properties) {
+			const prop = item.properties[key];
+			if (prop.type === 'title' && prop.title) {
+				titleArray = prop.title;
+				break;
+			}
+		}
+	}
+
+	if (!titleArray || !Array.isArray(titleArray)) {
+		return defaultTitle;
+	}
+
+	const title = titleArray
+		.map((t: any) => t.text?.content || t.plain_text || '')
+		.join('')
+		.trim();
+
+	return title || defaultTitle;
+}
+
+/**
+ * Extract parent ID from a parent object (used for both page.parent and data_source.database_parent)
+ * Note: Items with block_id parent should be filtered out before calling this
+ */
+export function extractParentId(
+	parentObj: NotionParent | null | undefined,
+	context: 'page' | 'database'
+): string | null {
+	if (!parentObj) {
+		return null;
+	}
+
+	switch (parentObj.type) {
+		case 'page_id':
+			return parentObj.page_id;
+
+		case 'data_source_id':
+			// Pages in a database have data_source_id as parent
+			return parentObj.data_source_id;
+
+		case 'database_id':
+			// Databases can have database_id as parent (nested databases)
+			return parentObj.database_id;
+
+		case 'workspace':
+			// Top-level item
+			return null;
+
+		case 'block_id':
+			// This should have been filtered out before calling this function
+			console.warn('[Notion Importer] block_id parent should be filtered before calling extractParentId');
+			return null;
+
+		default: {
+			// TypeScript exhaustiveness check
+			const _exhaustive: never = parentObj;
+			console.warn(`[Notion Importer] Unexpected parent type for ${context}:`, _exhaustive);
+			return null;
+		}
+	}
+}
+
+/**
+ * The flat list a search response reduces to.
+ *
+ * Two-phase filtering:
+ * Phase 1: Collect all items and identify databases that are inside blocks
+ * Phase 2: Filter out pages that belong to those databases
+ */
+export function collectItems(allRawItems: any[]): NotionItem[] {
+	// Phase 1: Identify items that should be filtered
+	// Collect IDs of pages and databases that won't appear in tree:
+	// - Databases with database_parent.type === 'block_id'
+	// - Pages with parent.type === 'block_id'
+	const filteredIds = new Set<string>();
+
+	for (const item of allRawItems) {
+		if (item.object === 'data_source') {
+			// Databases inside blocks
+			if (item.database_parent && item.database_parent.type === 'block_id') {
+				filteredIds.add(item.id);
+			}
+		}
+		else if (item.object === 'page') {
+			// Pages with block_id parent
+			if (item.parent && item.parent.type === 'block_id') {
+				filteredIds.add(item.id);
+			}
+		}
+	}
+
+	// Phase 2: Process items and filter appropriately
+	const allItems: NotionItem[] = [];
+	for (const item of allRawItems) {
+		// Skip if this item itself is in the filtered list
+		if (filteredIds.has(item.id)) {
+			continue;
+		}
+
+		// Skip databases whose parent page is filtered
+		if (item.object === 'data_source' && item.database_parent && item.database_parent.type === 'page_id') {
+			const parentPageId = item.database_parent.page_id;
+			if (filteredIds.has(parentPageId)) {
+				continue;
+			}
+		}
+
+		// Skip pages that belong to filtered databases
+		if (item.object === 'page' && item.parent && item.parent.type === 'data_source_id') {
+			const dataSourceId = item.parent.data_source_id;
+			if (filteredIds.has(dataSourceId)) {
+				continue;
+			}
+		}
+
+		// Process page or data_source (database)
+		if (item.object === 'page' || item.object === 'data_source') {
+			const isDatabase = item.object === 'data_source';
+			const title = extractItemTitle(item, isDatabase ? 'Untitled Database' : 'Untitled');
+			const parentObj = isDatabase ? item.database_parent : item.parent;
+			const parentId = extractParentId(parentObj, isDatabase ? 'database' : 'page');
+
+			allItems.push({
+				id: item.id,
+				title,
+				type: isDatabase ? 'database' : 'page',
+				parentId,
+			});
+		}
+	}
+
+	return allItems;
+}
+
+/**
+ * Build tree structure from flat list
+ */
+export function buildTree(items: NotionItem[]): NotionTreeNode[] {
+	const nodeMap = new Map<string, NotionTreeNode>();
+	const roots: NotionTreeNode[] = [];
+
+	// Create all nodes
+	for (const item of items) {
+		nodeMap.set(item.id, {
+			id: item.id,
+			title: item.title,
+			type: item.type,
+			parentId: item.parentId,
+			children: [],
+			selected: false,
+			disabled: false,
+			collapsed: true, // Default to collapsed
+		});
+	}
+
+	// Build tree relationships
+	for (const node of nodeMap.values()) {
+		if (node.parentId && nodeMap.has(node.parentId)) {
+			const parent = nodeMap.get(node.parentId)!;
+			parent.children.push(node);
+		}
+		else {
+			// No parent or parent not in list -> root node
+			roots.push(node);
+		}
+	}
+
+	// Sort children by title
+	const sortNodes = (nodes: NotionTreeNode[]) => {
+		nodes.sort((a, b) => a.title.localeCompare(b.title));
+		for (const node of nodes) {
+			sortNodes(node.children);
+		}
+	};
+	sortNodes(roots);
+
+	return roots;
+}

--- a/tests/notion-api/discovery.test.ts
+++ b/tests/notion-api/discovery.test.ts
@@ -1,0 +1,69 @@
+/**
+ * What the page picker offers, given what the API says the integration can see.
+ *
+ * The importer asks /v1/search for everything and turns the flat answer into
+ * the tree the user ticks through. Which items reach that tree is where the
+ * reports of missing pages land - a database that is itself a top-level page
+ * (#590), a database nested in a page, an inline one that should not appear at
+ * all - and none of it could be checked while it lived on the importer.
+ *
+ * Recorded here is the tree, drawn as an outline. A page that stops appearing,
+ * or starts, is a line moving in that outline.
+ */
+import '../shims/runtime';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import * as nodeFs from 'node:fs';
+import * as nodePath from 'node:path';
+
+import { buildTree, collectItems, type NotionTreeNode } from '../../src/formats/notion-api/discovery';
+import { expectFile, expectedFor, type Fixture } from '../helpers';
+
+const FIXTURE: Fixture = { name: 'example-search.json', path: nodePath.join(__dirname, 'example-search.json'), local: false };
+
+const search = JSON.parse(nodeFs.readFileSync(FIXTURE.path, 'utf8')) as { results: any[] };
+
+/** The tree as an outline, which is what makes a change to it readable. */
+function outline(nodes: NotionTreeNode[], depth = 0): string[] {
+	return nodes.flatMap(node => [
+		`${'  '.repeat(depth)}${node.type === 'database' ? 'database' : 'page    '} ${node.title}`,
+		...outline(node.children, depth + 1),
+	]);
+}
+
+test('the fixture carries every parent the search returns', () => {
+	const seen = new Set(search.results.map(item =>
+		`${item.object}/${(item.object === 'data_source' ? item.database_parent : item.parent)?.type}`));
+
+	for (const shape of [
+		'page/workspace', 'page/page_id', 'page/data_source_id', 'page/block_id',
+		'data_source/workspace', 'data_source/page_id', 'data_source/block_id',
+	]) {
+		assert.ok(seen.has(shape), `expected the fixture to include a ${shape}`);
+	}
+});
+
+test('the tree the picker is given', () => {
+	const tree = buildTree(collectItems(search.results));
+
+	expectFile(`${outline(tree).join('\n')}\n`, expectedFor(FIXTURE, 'example-search.txt'), FIXTURE.name);
+});
+
+test('a top-level database is offered, as one inside a page is', () => {
+	const tree = buildTree(collectItems(search.results));
+	const titles = tree.filter(node => node.type === 'database').map(node => node.title);
+
+	// #590: a database that is itself a page in the sidebar reaches the picker
+	// as a root, since a workspace parent is no parent at all.
+	assert.ok(titles.includes('Reading list'), `a top-level database should be a root, got roots: ${titles.join(', ')}`);
+});
+
+test('an inline database and its rows are left out', () => {
+	const items = collectItems(search.results);
+	const titles = items.map(item => item.title);
+
+	assert.ok(!titles.includes('An inline database'), 'a database in a block should be dropped');
+	assert.ok(!titles.includes('A row of the inline database'), "a dropped database's rows should go with it");
+	assert.ok(!titles.includes('A page inside a block'), 'a page in a block should be dropped');
+});

--- a/tests/notion-api/example-page.json
+++ b/tests/notion-api/example-page.json
@@ -101,6 +101,18 @@
 				{
 					"object": "block", "id": "20000000-0000-4000-8000-000000000014", "type": "unsupported", "has_children": false, "archived": false,
 					"unsupported": {}
+				},
+				{
+					"object": "block", "id": "20000000-0000-4000-8000-000000000018", "type": "heading_2", "has_children": false, "archived": false,
+					"heading_2": { "rich_text": [{ "type": "text", "text": { "content": "Indented text", "link": null }, "annotations": { "bold": false, "italic": false, "strikethrough": false, "underline": false, "code": false, "color": "default" }, "plain_text": "Indented text", "href": null }], "color": "default", "is_toggleable": false }
+				},
+				{
+					"object": "block", "id": "20000000-0000-4000-8000-000000000019", "type": "paragraph", "has_children": true, "archived": false,
+					"paragraph": { "color": "default", "rich_text": [{ "type": "text", "text": { "content": "A parent line.", "link": null }, "annotations": { "bold": false, "italic": false, "strikethrough": false, "underline": false, "code": false, "color": "default" }, "plain_text": "A parent line.", "href": null }] }
+				},
+				{
+					"object": "block", "id": "20000000-0000-4000-8000-00000000001b", "type": "paragraph", "has_children": true, "archived": false,
+					"paragraph": { "color": "default", "rich_text": [] }
 				}
 			]
 		},
@@ -138,6 +150,24 @@
 						[{ "type": "text", "text": { "content": "Answer", "link": null }, "annotations": { "bold": false, "italic": false, "strikethrough": false, "underline": false, "code": false, "color": "default" }, "plain_text": "Answer", "href": null }],
 						[{ "type": "text", "text": { "content": "42", "link": null }, "annotations": { "bold": false, "italic": false, "strikethrough": false, "underline": false, "code": false, "color": "default" }, "plain_text": "42", "href": null }]
 					] }
+				}
+			]
+		},
+		"20000000-0000-4000-8000-000000000019": {
+			"object": "list", "has_more": false, "next_cursor": null,
+			"results": [
+				{
+					"object": "block", "id": "20000000-0000-4000-8000-00000000001a", "type": "paragraph", "has_children": false, "archived": false,
+					"paragraph": { "color": "default", "rich_text": [{ "type": "text", "text": { "content": "An indented child line.", "link": null }, "annotations": { "bold": false, "italic": false, "strikethrough": false, "underline": false, "code": false, "color": "default" }, "plain_text": "An indented child line.", "href": null }] }
+				}
+			]
+		},
+		"20000000-0000-4000-8000-00000000001b": {
+			"object": "list", "has_more": false, "next_cursor": null,
+			"results": [
+				{
+					"object": "block", "id": "20000000-0000-4000-8000-00000000001c", "type": "paragraph", "has_children": false, "archived": false,
+					"paragraph": { "color": "default", "rich_text": [{ "type": "text", "text": { "content": "An indented line under an empty parent.", "link": null }, "annotations": { "bold": false, "italic": false, "strikethrough": false, "underline": false, "code": false, "color": "default" }, "plain_text": "An indented line under an empty parent.", "href": null }] }
 				}
 			]
 		}

--- a/tests/notion-api/example-search.json
+++ b/tests/notion-api/example-search.json
@@ -1,0 +1,90 @@
+{
+	"_comment": "A page of GET/POST /v1/search results (https://developers.notion.com/reference/post-search), as the importer's page picker reads it. Hand-written, but every object/parent combination here was observed in a real workspace under Notion-Version 2025-09-03: page/workspace, page/page_id, page/data_source_id, page/block_id, data_source/workspace, data_source/page_id and data_source/block_id. Titles and ids are invented. Only the keys discovery.ts reads are kept - a real result carries far more.",
+	"results": [
+		{
+			"object": "page",
+			"id": "10000000-0000-4000-8000-000000000001",
+			"parent": { "type": "workspace", "workspace": true },
+			"properties": { "title": { "type": "title", "title": [{ "type": "text", "text": { "content": "Getting started" }, "plain_text": "Getting started" }] } }
+		},
+		{
+			"object": "page",
+			"id": "10000000-0000-4000-8000-000000000002",
+			"parent": { "type": "page_id", "page_id": "10000000-0000-4000-8000-000000000001" },
+			"properties": { "title": { "type": "title", "title": [{ "type": "text", "text": { "content": "A nested page" }, "plain_text": "A nested page" }] } }
+		},
+
+		{
+			"_note": "A database that is itself a top-level page in the sidebar - the case reported in #590.",
+			"object": "data_source",
+			"id": "20000000-0000-4000-8000-000000000001",
+			"database_parent": { "type": "workspace", "workspace": true },
+			"title": [{ "type": "text", "text": { "content": "Reading list" }, "plain_text": "Reading list" }]
+		},
+		{
+			"object": "page",
+			"id": "10000000-0000-4000-8000-000000000003",
+			"parent": { "type": "data_source_id", "data_source_id": "20000000-0000-4000-8000-000000000001", "database_id": "30000000-0000-4000-8000-000000000001" },
+			"properties": { "Name": { "type": "title", "title": [{ "type": "text", "text": { "content": "The Long Way" }, "plain_text": "The Long Way" }] } }
+		},
+
+		{
+			"_note": "A database living inside a page, which is the arrangement #590 says does work.",
+			"object": "data_source",
+			"id": "20000000-0000-4000-8000-000000000002",
+			"database_parent": { "type": "page_id", "page_id": "10000000-0000-4000-8000-000000000001" },
+			"title": [{ "type": "text", "text": { "content": "Tasks" }, "plain_text": "Tasks" }]
+		},
+		{
+			"object": "page",
+			"id": "10000000-0000-4000-8000-000000000004",
+			"parent": { "type": "data_source_id", "data_source_id": "20000000-0000-4000-8000-000000000002", "database_id": "30000000-0000-4000-8000-000000000002" },
+			"properties": { "Name": { "type": "title", "title": [{ "type": "text", "text": { "content": "Water the plants" }, "plain_text": "Water the plants" }] } }
+		},
+
+		{
+			"_note": "An inline database, which sits in a block. Dropped, along with its rows.",
+			"object": "data_source",
+			"id": "20000000-0000-4000-8000-000000000003",
+			"database_parent": { "type": "block_id", "block_id": "40000000-0000-4000-8000-000000000001" },
+			"title": [{ "type": "text", "text": { "content": "An inline database" }, "plain_text": "An inline database" }]
+		},
+		{
+			"object": "page",
+			"id": "10000000-0000-4000-8000-000000000005",
+			"parent": { "type": "data_source_id", "data_source_id": "20000000-0000-4000-8000-000000000003", "database_id": "30000000-0000-4000-8000-000000000003" },
+			"properties": { "Name": { "type": "title", "title": [{ "type": "text", "text": { "content": "A row of the inline database" }, "plain_text": "A row of the inline database" }] } }
+		},
+		{
+			"_note": "A page held by a block rather than by a page - a synced block, say. Dropped.",
+			"object": "page",
+			"id": "10000000-0000-4000-8000-000000000006",
+			"parent": { "type": "block_id", "block_id": "40000000-0000-4000-8000-000000000002" },
+			"properties": { "title": { "type": "title", "title": [{ "type": "text", "text": { "content": "A page inside a block" }, "plain_text": "A page inside a block" }] } }
+		},
+
+		{
+			"_note": "No title at all, which the picker still has to name.",
+			"object": "page",
+			"id": "10000000-0000-4000-8000-000000000007",
+			"parent": { "type": "workspace", "workspace": true },
+			"properties": { "title": { "type": "title", "title": [] } }
+		},
+		{
+			"object": "data_source",
+			"id": "20000000-0000-4000-8000-000000000004",
+			"database_parent": { "type": "workspace", "workspace": true },
+			"title": []
+		},
+
+		{
+			"_note": "A page whose parent was shared with nobody, so it is not in these results. It has to stand on its own rather than vanish.",
+			"object": "page",
+			"id": "10000000-0000-4000-8000-000000000008",
+			"parent": { "type": "page_id", "page_id": "10000000-0000-4000-8000-0000000000ff" },
+			"properties": { "title": { "type": "title", "title": [{ "type": "text", "text": { "content": "An orphan" }, "plain_text": "An orphan" }] } }
+		}
+	],
+	"has_more": false,
+	"next_cursor": null
+}

--- a/tests/notion-api/expected/example-page.md
+++ b/tests/notion-api/expected/example-page.md
@@ -37,3 +37,10 @@ $$
 [https://example.com/reading](https://example.com/reading)
 
 A date mention:  2024-06-01 
+
+## Indented text
+
+A parent line.
+    An indented child line.
+
+    An indented line under an empty parent.

--- a/tests/notion-api/expected/example-search.txt
+++ b/tests/notion-api/expected/example-search.txt
@@ -1,0 +1,9 @@
+page     An orphan
+page     Getting started
+  page     A nested page
+  database Tasks
+    page     Water the plants
+database Reading list
+  page     The Long Way
+page     Untitled
+database Untitled Database

--- a/tests/notion-api/live.test.ts
+++ b/tests/notion-api/live.test.ts
@@ -56,17 +56,36 @@ function assertShape(value: any, shape: Record<string, string>, what: string): v
 }
 
 test('the API still returns the shape the fixture is written to', { skip }, async () => {
-	let pageId = env('NOTION_PAGE_ID');
+	const pageId = env('NOTION_PAGE_ID');
 
-	if (!pageId) {
-		const found = await api('/search', { filter: { property: 'object', value: 'page' }, page_size: 5 });
+	/**
+	 * A page with blocks in it, since a page with none says nothing about the
+	 * shape of a block.
+	 *
+	 * Without NOTION_PAGE_ID this has to go looking, and what search returns
+	 * first is whatever the workspace happens to hold - in one with a database
+	 * that is a row, which carries its content in properties and has no blocks
+	 * at all. So it reads candidates until one has some rather than trusting
+	 * the first.
+	 */
+	async function findPageWithBlocks(): Promise<{ id: string, children: any }> {
+		if (pageId) return { id: pageId, children: await api(`/blocks/${pageId}/children?page_size=100`) };
+
+		const found = await api('/search', { filter: { property: 'object', value: 'page' }, page_size: 25 });
 		assert.ok(Array.isArray(found.results), 'search should return a list');
-		pageId = found.results.find((r: any) => r.object === 'page')?.id;
+
+		const pages = found.results.filter((r: any) => r.object === 'page');
+		assert.ok(pages.length > 0, 'no page to read - share one with the integration, or set NOTION_PAGE_ID');
+
+		for (const page of pages) {
+			const children = await api(`/blocks/${page.id}/children?page_size=100`);
+			if (children.results?.length > 0) return { id: page.id, children };
+		}
+
+		assert.fail(`none of the ${pages.length} pages shared with the integration has any blocks - set NOTION_PAGE_ID to one that does`);
 	}
 
-	assert.ok(pageId, 'no page to read - share one with the integration, or set NOTION_PAGE_ID');
-
-	const children = await api(`/blocks/${pageId}/children?page_size=100`);
+	const { children } = await findPageWithBlocks();
 
 	assertShape(children, { object: 'string', results: 'array', has_more: 'boolean' }, 'children');
 	assert.equal(children.object, 'list');

--- a/tests/notion/database-row.html
+++ b/tests/notion/database-row.html
@@ -1,0 +1,22 @@
+<!--
+	A page from a Notion database, as its HTML export writes one.
+
+	Hand-written to the shape the export uses rather than captured from a real
+	workspace: the exports committed here predate Notion's database export and
+	none of them carries a property table, so the markup below follows what
+	src/formats/notion/convert-to-md.ts reads - table.properties > tbody, a row
+	per property classed property-row-<type>, name in the first cell and value
+	in the second. A real export with a database should replace it.
+
+	The properties are chosen for the cases that have gone wrong: a number
+	Notion formatted as currency (#407), a multi-select named Tags, which is the
+	one property title the conversion rewrites, and a date, which it reads out
+	of <time> rather than the cell text.
+
+	Written on one line from <article> on, as the export is: whitespace between
+	those tags is not what Notion emits, and it reaches the markdown.
+-->
+<html>
+<head><meta charset="utf-8"><title>Espresso machine</title></head>
+<body><article id="1590080a-a5a3-8024-88c2-e857dea7aa7e" class="page sans"><header><h1 class="page-title">Espresso machine</h1><p class="page-description"></p><table class="properties"><tbody><tr class="property-row property-row-text"><th><span class="icon property-icon"></span>Notes</th><td>Double boiler, plumbed in.</td></tr><tr class="property-row property-row-number"><th><span class="icon property-icon"></span>Price</th><td>67.3</td></tr><tr class="property-row property-row-number"><th><span class="icon property-icon"></span>Price (BRL)</th><td>R$67.3</td></tr><tr class="property-row property-row-number"><th><span class="icon property-icon"></span>Price (USD)</th><td>$1,234.56</td></tr><tr class="property-row property-row-number"><th><span class="icon property-icon"></span>Discount</th><td>15%</td></tr><tr class="property-row property-row-auto_increment_id"><th><span class="icon property-icon"></span>ID</th><td>12</td></tr><tr class="property-row property-row-select"><th><span class="icon property-icon"></span>Status</th><td><span class="selected-value select-value-color-blue">Owned</span></td></tr><tr class="property-row property-row-multi_select"><th><span class="icon property-icon"></span>Tags</th><td><span class="selected-value select-value-color-green">home office</span><span class="selected-value select-value-color-orange">coffee</span></td></tr><tr class="property-row property-row-checkbox"><th><span class="icon property-icon"></span>Serviced</th><td><div class="checkbox checkbox-on"></div></td></tr><tr class="property-row property-row-checkbox"><th><span class="icon property-icon"></span>Sold</th><td><div class="checkbox checkbox-off"></div></td></tr><tr class="property-row property-row-date"><th><span class="icon property-icon"></span>Bought</th><td><time>@March 1, 2024</time></td></tr><tr class="property-row property-row-url"><th><span class="icon property-icon"></span>Manual</th><td><a href="https://example.com/manual">https://example.com/manual</a></td></tr><tr class="property-row property-row-text"><th><span class="icon property-icon"></span>Empty</th><td></td></tr></tbody></table></header><div class="page-body"><p id="15c0080a-a5a3-80b1-8bf8-d77dc412b120" class="">A row kept for its properties rather than its body.</p></div></article></body>
+</html>

--- a/tests/notion/expected/database-row.md
+++ b/tests/notion/expected/database-row.md
@@ -1,0 +1,17 @@
+---
+Notes: Double boiler, plumbed in.
+Price: 67.3
+Price (BRL): R$67.3
+Price (USD): $1,234.56
+Discount: 15%
+ID: 12
+Status: Owned
+tags:
+  - home-office
+  - coffee
+Serviced: true
+Sold: false
+Bought: 2024-03-01
+Manual: https://example.com/manual
+---
+A row kept for its properties rather than its body.

--- a/tests/notion/page.test.ts
+++ b/tests/notion/page.test.ts
@@ -1,0 +1,47 @@
+/**
+ * One exported Notion page, converted on its own.
+ *
+ * convert.test.ts beside this drives a whole export, which is what catches the
+ * parts that need pages to resolve against each other. A single page needs
+ * none of that, and it is the cheaper way to cover markup an export here does
+ * not happen to contain.
+ *
+ * What it covers today is a database row's properties. The conversion turns
+ * table.properties into frontmatter, reading it through tbody.rows and
+ * tr.cells - neither of which linkedom implements, so tests/shims/dom.ts
+ * supplies them. No committed export carries a property table, so without a
+ * page here the whole path, and the YAML it produces, would go unchecked.
+ *
+ * Drop any exported page in this directory - or in local/, which is
+ * gitignored, for one that cannot be committed - and its markdown is recorded
+ * beside it.
+ */
+import '../shims/dom';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import * as nodeFs from 'node:fs';
+import * as nodePath from 'node:path';
+
+import { convertHtmlToMarkdown } from '../../src/formats/notion/convert-to-md';
+import { NotionResolverInfo } from '../../src/formats/notion/notion-types';
+import { expectFile, expectedFor, fixtures } from '../helpers';
+
+const FIXTURES = __dirname;
+
+const pages = fixtures(FIXTURES, '.html');
+
+test('there are pages to convert', () => {
+	assert.ok(pages.length > 0, 'expected at least one .html in tests/notion');
+});
+
+for (const page of pages) {
+	test(`converts ${page.name}`, () => {
+		// A page on its own resolves no links to other pages, so the info it is
+		// handed is empty - the same one the importer builds before its first
+		// pass has read anything.
+		const markdown = convertHtmlToMarkdown(new NotionResolverInfo('', false), nodeFs.readFileSync(page.path, 'utf8'));
+
+		expectFile(markdown, expectedFor(page, `${nodePath.basename(page.name, '.html')}.md`), page.name);
+	});
+}

--- a/tests/shims/dom.ts
+++ b/tests/shims/dom.ts
@@ -115,6 +115,52 @@ define(elementProto, 'setText', function (this: any, text: unknown) {
 });
 define(elementProto, 'getAttr', function (this: any, name: string) { return this.getAttribute(name); });
 define(elementProto, 'setAttr', function (this: any, name: string, value: string) { this.setAttribute(name, String(value)); });
+
+/**
+ * rows and cells, which linkedom has neither of.
+ *
+ * The Notion conversion reads a page's property table through them - the rows
+ * of the <tbody>, then each row's cells - so without them the whole
+ * property-to-frontmatter path throws before it converts anything.
+ *
+ * linkedom gives every element the plain HTMLElement prototype, so these land
+ * on Element rather than on HTMLTableSectionElement and HTMLTableRowElement
+ * where the DOM puts them. turndown's GFM table rules read .rows as well, so
+ * <table> has to gather the rows of its sections rather than only its own
+ * children, or those rules see an empty table.
+ *
+ * Document order, where the DOM hoists thead first and sinks tfoot last. No
+ * export here writes either, and guessing at more would be inventing rather
+ * than matching.
+ */
+function childElements(el: any, tags: string[]): any[] {
+	return (Array.from(el.children) as any[]).filter(child => tags.includes(child.tagName));
+}
+
+if (!('rows' in elementProto)) {
+	Object.defineProperty(elementProto, 'rows', {
+		get(this: any) {
+			if (this.tagName !== 'TABLE') return childElements(this, ['TR']);
+
+			const rows: any[] = [];
+			for (const child of Array.from(this.children) as any[]) {
+				if (child.tagName === 'TR') rows.push(child);
+				else if (child.tagName === 'THEAD' || child.tagName === 'TBODY' || child.tagName === 'TFOOT') {
+					rows.push(...childElements(child, ['TR']));
+				}
+			}
+			return rows;
+		},
+		configurable: true,
+	});
+}
+
+if (!('cells' in elementProto)) {
+	Object.defineProperty(elementProto, 'cells', {
+		get(this: any) { return childElements(this, ['TD', 'TH']); },
+		configurable: true,
+	});
+}
 define(documentProto, 'find', function (this: any, selector: string) { return this.querySelector(selector); });
 define(documentProto, 'findAll', function (this: any, selector: string) { return Array.from(this.querySelectorAll(selector)); });
 


### PR DESCRIPTION
**`5d42fd3` Cover indented paragraphs in the page fixture** — a paragraph with `has_children` in two shapes: a parent with its own text, and the empty parent Notion writes when a block is indented under a blank line. With #508 reverted the recording keeps only the parent and both children vanish, which is what #492 reported.

**`e33ad1a` Cover a database row's properties** — the conversion reads a property table through `tbody.rows` and `tr.cells`; linkedom has neither, so the path threw before converting anything. The shim supplies both, on `Element`, because linkedom gives every element the plain `HTMLElement` prototype. Measured rather than assumed: no recorded output moves anywhere in the suite, and an Evernote table — the one place turndown's GFM rules read `.rows` — converts byte for byte as before. With #577 reverted the recording loses `Price (BRL)`, `Price (USD)` and `Discount` entirely, which is #407.

**`78b49dd` Let the live check find a page that has blocks** — without `NOTION_PAGE_ID` it read whichever page search returned first and asserted that page had blocks. In a workspace whose first result is a database row — which keeps its content in properties and has none — it failed on the workspace rather than on the API. It now reads candidates until one has blocks. Verified against a real workspace: it passes, so the shapes `example-page.json` is written to are the ones the API still returns.

**`98314ec` Move page discovery off the importer** — turning a search response into the picker's tree needs nothing from the vault or the network, but it sat on the importer where no test could reach it. Diagnosing #590 meant reimplementing the filtering in a scratch script and trusting the copy agreed. Moved as it stands: same code with `this.` dropped. Checked against a real workspace of 1123 search results — same 1064 items, same 7 roots, same children under each.

**`606463b` Record which pages the picker offers** — the search response decides whether a page can be imported at all, and every missing-page report (#590, #512) is a claim about what this drops. The fixture carries each object/parent combination observed in a real workspace; the recording is the tree as an outline, so a page that stops being offered is a line that moves.
