### PR TITLE
Apple Notes highlights

### DIFF
--- a/src/formats/apple-notes/convert-note.ts
+++ b/src/formats/apple-notes/convert-note.ts
@@ -8,6 +8,7 @@ import {
 	ANBaseline,
 	ANConverter,
 	ANDocument,
+	ANEmphasisColor,
 	ANFontWeight,
 	ANFragmentPair,
 	ANMultiRun,
@@ -20,6 +21,20 @@ const FRAGMENT_SPLIT = /(^\s+|(?:\s+)?\n(?:\s+)?|\s+$)/;
 const NOTE_URI = /applenotes:note\/([-0-9a-f]+)(?:\?ownerIdentifier=.*)?/;
 
 const DEFAULT_EMOJI = '.AppleColorEmojiUI';
+
+/**
+ * Obsidian takes a highlight's colour from an emoji leading its content, and has no
+ * pink or mint of its own, so those go to the nearest it does have. An unmarked
+ * highlight is already yellow, which is the colour Apple leaves unset.
+ */
+const EMPHASIS_MARKERS: Record<ANEmphasisColor, string> = {
+	[ANEmphasisColor.Purple]: '🟣',
+	[ANEmphasisColor.Pink]: '🔴',
+	[ANEmphasisColor.Orange]: '🟠',
+	[ANEmphasisColor.Mint]: '🟢',
+	[ANEmphasisColor.Blue]: '🔵'
+};
+
 const LIST_STYLES = [
 	ANStyleType.DottedList, ANStyleType.DashedList, ANStyleType.NumberedList, ANStyleType.Checkbox
 ];
@@ -219,6 +234,8 @@ export class NoteConverter extends ANConverter {
 			attr.fragment = `<span style="${style}">${attr.fragment}</span>`;
 		}
 
+		attr.fragment = emphasise(attr);
+
 		if (attr.atLineStart) {
 			return this.formatParagraph(attr);
 		}
@@ -252,6 +269,8 @@ export class NoteConverter extends ANConverter {
 				attr.fragment = `[${attr.fragment}](${attr.link})`;
 			}
 		}
+
+		attr.fragment = emphasise(attr);
 
 		if (attr.atLineStart) {
 			return this.formatParagraph(attr);
@@ -412,6 +431,12 @@ export class NoteConverter extends ANConverter {
 				return 'justify';
 		}
 	}
+}
+
+/** Wrap a highlighted run, colouring it by the marker Obsidian reads. */
+function emphasise(attr: ANAttributeRun): string {
+	if (!attr.emphasisColor) return attr.fragment;
+	return `==${EMPHASIS_MARKERS[attr.emphasisColor] ?? ''}${attr.fragment}==`;
 }
 
 function isBlockAttachment(attr: ANAttributeRun) {

--- a/src/formats/apple-notes/convert-note.ts
+++ b/src/formats/apple-notes/convert-note.ts
@@ -6,7 +6,6 @@ import {
 	ANAttachment,
 	ANAttributeRun,
 	ANBaseline,
-	ANColor,
 	ANConverter,
 	ANDocument,
 	ANFontWeight,
@@ -106,7 +105,7 @@ export class NoteConverter extends ANConverter {
 			else if (attr.attachmentInfo) {
 				converted += await this.formatAttachment(attr, parentNotePath);
 			}
-			else if (attr.superscript || attr.underlined || attr.color || attr.font || this.multiRun == ANMultiRun.Alignment) {
+			else if (attr.superscript || attr.underlined || attr.font || this.multiRun == ANMultiRun.Alignment) {
 				converted += await this.formatHtmlAttr(attr);
 			}
 			else {
@@ -206,7 +205,6 @@ export class NoteConverter extends ANConverter {
 		}
 
 		if (attr.font?.pointSize) style += `font-size:${attr.font.pointSize}pt;`;
-		if (attr.color) style += `color:${this.convertColor(attr.color)};`;
 
 		if (attr.link && !NOTE_URI.test(attr.link)) {
 			if (style) style = ` style="${style}"`;
@@ -400,16 +398,6 @@ export class NoteConverter extends ANConverter {
 		if (!file) return '(unknown file link)';
 
 		return this.ctx.linkTo(file, parentNotePath, undefined, name);
-	}
-
-	convertColor(color: ANColor): string {
-		let hexcode = '#';
-
-		for (const channel of Object.values(color)) {
-			hexcode += Math.floor(channel * 255).toString(16);
-		}
-
-		return hexcode;
 	}
 
 	convertAlign(alignment: ANAlignment): string {

--- a/src/formats/apple-notes/descriptor.ts
+++ b/src/formats/apple-notes/descriptor.ts
@@ -209,6 +209,10 @@ export const descriptor: any = {
 							'type': 'Color',
 							'id': 10
 						},
+						'emphasisColor': {
+							'type': 'int32',
+							'id': 14
+						},
 						'attachmentInfo': {
 							'type': 'AttachmentInfo',
 							'id': 12

--- a/src/formats/apple-notes/models.ts
+++ b/src/formats/apple-notes/models.ts
@@ -112,6 +112,7 @@ export interface ANAttributeRun extends Message {
 	superscript?: ANBaseline;
 	link?: string;
 	color?: ANColor;
+	emphasisColor?: ANEmphasisColor;
 	attachmentInfo?: ANAttachmentInfo;
 
 	// internal additions, not part of the protobufs
@@ -175,6 +176,18 @@ export interface ANColor extends Message {
 	green: number;
 	blue: number;
 	alpha: number;
+}
+
+/**
+ * The colour of a highlight. Apple's own yellow is the value this is left unset for,
+ * so a yellow highlight is indistinguishable from no highlight at all.
+ */
+export enum ANEmphasisColor {
+	Purple = 1,
+	Pink = 2,
+	Orange = 3,
+	Mint = 4,
+	Blue = 5
 }
 
 export enum ANFolderType {

--- a/tests/apple-notes/convert.test.ts
+++ b/tests/apple-notes/convert.test.ts
@@ -137,7 +137,11 @@ const STORE: StoreSpec = {
 				{ text: ' and H' },
 				{ text: '2', baseline: -1 },
 				{ text: 'O\n' },
-				{ text: 'highlighted', color: { red: 1, green: 0.9, blue: 0.2, alpha: 1 } },
+				// Obsidian has no coloured text, so a colour is dropped rather than
+				// carried over as a style Obsidian would not render
+				{ text: 'coloured text', color: { red: 1, green: 0.9, blue: 0.2, alpha: 1 } },
+				{ text: ' and ' },
+				{ text: 'the default black', color: { red: 0, green: 0, blue: 0, alpha: 1 } },
 			],
 		},
 		{

--- a/tests/apple-notes/convert.test.ts
+++ b/tests/apple-notes/convert.test.ts
@@ -185,6 +185,28 @@ const STORE: StoreSpec = {
 				{ text: '', attachment: { identifier: 'NOTHING-1', uti: 'public.unrecognised' } },
 			],
 		},
+		{
+			title: 'Highlights',
+			runs: [
+				{ text: 'Highlights\n', style: ANStyleType.Title },
+				{ text: 'purple', emphasis: 1 },
+				{ text: ' and ' },
+				{ text: 'pink', emphasis: 2 },
+				{ text: ' and ' },
+				{ text: 'orange', emphasis: 3 },
+				{ text: ' and ' },
+				{ text: 'mint', emphasis: 4 },
+				{ text: ' and ' },
+				{ text: 'blue', emphasis: 5 },
+				{ text: '\n' },
+				// A highlight is markdown, so it wraps whichever way the run is written
+				{ text: 'bold', bold: true, emphasis: 1 },
+				{ text: ' and ' },
+				{ text: 'underlined', underlined: true, emphasis: 5 },
+				{ text: ' and ' },
+				{ text: 'linked', link: 'https://example.com', emphasis: 3 },
+			],
+		},
 	],
 	attachments: [
 		{ identifier: 'HASHTAG-1', uti: ANAttachment.Hashtag, altText: '#a-tag' },

--- a/tests/apple-notes/expected/built-store/Emphasis.md
+++ b/tests/apple-notes/expected/built-store/Emphasis.md
@@ -1,4 +1,4 @@
 **bold** and *italic* and ***both***
 <u>underlined</u> and ~~struck through~~
 x<sup>2</sup> and H<sub>2</sub>O
-<span style="color:#ffe533ff;">highlighted</span>
+coloured text and the default black

--- a/tests/apple-notes/expected/built-store/Highlights.md
+++ b/tests/apple-notes/expected/built-store/Highlights.md
@@ -1,0 +1,2 @@
+==🟣purple== and ==🔴pink== and ==🟠orange== and ==🟢mint== and ==🔵blue==
+==🟣**bold**== and ==🔵<u>underlined</u>== and ==🟠[linked](https://example.com)==

--- a/tests/apple-notes/expected/built-store/Links and attachments.md
+++ b/tests/apple-notes/expected/built-store/Links and attachments.md
@@ -1,7 +1,7 @@
 [A web link](https://example.com)
 #a-tag
 [**Example**](https://example.com)
-[[Apple Notes/Note 13.md]]
+[[Apple Notes/Note 14.md]]
 
 ![[Apple Notes/Attachments/42.png]]
 

--- a/tests/apple-notes/store.ts
+++ b/tests/apple-notes/store.ts
@@ -42,6 +42,8 @@ export interface Run {
 	blockquote?: boolean;
 	link?: string;
 	color?: { red: number, green: number, blue: number, alpha: number };
+	/** A highlight: 1 purple, 2 pink, 3 orange, 4 mint, 5 blue. */
+	emphasis?: number;
 	font?: { fontName?: string, pointSize?: number, fontHints?: number };
 	/** An attachment stands in the text as one character. */
 	attachment?: { identifier: string, uti: string };
@@ -119,6 +121,7 @@ export function encodeNote(note: NoteSpec): Buffer {
 			...(run.baseline !== undefined ? { superscript: run.baseline } : {}),
 			...(run.link ? { link: run.link } : {}),
 			...(run.color ? { color: run.color } : {}),
+			...(run.emphasis !== undefined ? { emphasisColor: run.emphasis } : {}),
 			...(run.font ? { font: run.font } : {}),
 			...(run.attachment
 				? {


### PR DESCRIPTION
Remove colored text, but preserve highlight colors using the `==🔴text==` syntax which will be added to Obsidian 1.14. Supersedes #521