### PR TITLE
Apple notes bug fixes

### DIFF
--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -808,10 +808,15 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 		}
 		catch (e) {
 			// A caller with a fallback has not lost the attachment yet, so this
-			// is not reported: a scan reads the cropped copy first and the raw
-			// image after it, and only the pair failing costs anything (#393).
-			if (!hasFallback) this.ctx.reportFailed(sourcePath);
-			console.error(e);
+			// is neither reported nor logged: a scan reads the cropped copy
+			// first and the raw image after it, and Apple writes the cropped
+			// one when it feels like it. Only the pair failing costs anything,
+			// and that is what the second call reports (#393).
+			if (!hasFallback) {
+				this.ctx.reportFailed(sourcePath, extractErrorMessage(e));
+				console.error(e);
+			}
+
 			return null;
 		}
 
@@ -837,12 +842,26 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 	}
 
 	async getAttachmentSource(account: ANAccount, sourcePath: string): Promise<Buffer<ArrayBuffer>> {
-		try {
-			return await fsPromises.readFile(path.join(account.path, sourcePath));
+		// An attachment sits under the account that owns it, except for the
+		// older ones written before Notes kept them apart, which are loose in
+		// the container
+		const candidates = [
+			path.join(account.path, sourcePath),
+			path.join(os.homedir(), NOTE_FOLDER_PATH, sourcePath),
+		];
+
+		for (const candidate of candidates) {
+			try {
+				return await fsPromises.readFile(candidate);
+			}
+			catch {
+				continue;
+			}
 		}
-		catch {
-			return await fsPromises.readFile(path.join(os.homedir(), NOTE_FOLDER_PATH, sourcePath));
-		}
+
+		// Naming both, since reporting only the second reads as though the
+		// first was never tried
+		throw new Error(`not found at ${candidates.join(' or ')}`);
 	}
 
 	/**

--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -603,15 +603,21 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 		const converter = this.decodeData(row.zhexdata, NoteConverter);
 
 		// Get creation date and format it according to user preference
-		let title = noteTitle(converter.note.noteText, row.ZTITLE1);
+		let prefix = '';
 		if (this.filePrefixFormat) {
 			const creationTimestamp = this.decodeTime(row.ZCREATIONDATE3 || row.ZCREATIONDATE2 || row.ZCREATIONDATE1);
-			const datePrefix = moment(creationTimestamp).format(this.filePrefixFormat);
-			title = `${datePrefix} ${title}`;
+			prefix = `${moment(creationTimestamp).format(this.filePrefixFormat)} `;
 		}
 
-		// Check for duplicate notes based on the selected handling option
-		const existingFile = await this.previouslyImported(folder, `${title}.md`, row.ZIDENTIFIER);
+		const storedTitle = String(row.ZTITLE1);
+		const title = prefix + noteTitle(converter.note.noteText, storedTitle);
+
+		// Check for duplicate notes based on the selected handling option. An
+		// earlier import named the note after ZTITLE1, so a vault one of those
+		// wrote holds it there rather than under the first line.
+		const existingFile = await this.previouslyImported(
+			folder, [`${title}.md`, `${prefix}${storedTitle}.md`], row.ZIDENTIFIER
+		);
 
 		if (existingFile) {
 			if (this.duplicateHandling === DuplicateHandling.Skip) {
@@ -769,11 +775,18 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 		}
 
 		try {
-			// Read before the name is settled: an extension inferred from the
-			// bytes is part of the name the duplicate check looks for (#471).
-			const binary = await this.getAttachmentSource(this.resolvedAccounts[this.owners[row.ZNOTE]], sourcePath);
+			// A name with no extension is settled by reading the file, and that
+			// name is what the duplicate check looks for, so the read comes
+			// first (#471). A name that already says what it is skips that:
+			// Apple can take the source back while the copy the vault holds is
+			// still good, and reading first would lose it.
+			let binary;
 
-			if (!outExt) outExt = extensionFromBytes(binary) ?? '';
+			if (!outExt) {
+				binary = await this.getAttachmentSource(this.resolvedAccounts[this.owners[row.ZNOTE]], sourcePath);
+				outExt = extensionFromBytes(binary) ?? '';
+			}
+
 			const attachmentName = outExt ? `${finalAttachmentName}.${outExt}` : finalAttachmentName;
 
 			// Check for existing attachment based on the selected handling option
@@ -800,6 +813,8 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 				}
 				// For CreateCopy option, we continue without skipping (will create numbered copy)
 			}
+
+			binary ??= await this.getAttachmentSource(this.resolvedAccounts[this.owners[row.ZNOTE]], sourcePath);
 
 			const attachmentPath = await this.getAvailablePathForAttachment(attachmentName, []);
 
@@ -894,25 +909,29 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 	 * Apple Notes reads as a new one. Recognising it properly needs the id the
 	 * source carries, which is not written down yet.
 	 */
-	private async previouslyImported(folder: TFolder, title: string, noteId?: string): Promise<TFile | null> {
+	private async previouslyImported(folder: TFolder, titles: string[], noteId?: string): Promise<TFile | null> {
 		if (this.duplicateHandling === DuplicateHandling.CreateCopy) return null;
 
-		// Normalized, because what it is held against is: the vault's own paths,
-		// and the ones this run has written. At the vault root path.join leaves a
-		// leading slash that neither of those carries.
-		const fullPath = normalizePath(path.join(folder.path, `${sanitizeFileName(title).replace(/\.md$/i, '')}.md`));
-		if (this.claimedPaths.has(fullPath)) return null;
+		for (const title of new Set(titles)) {
+			// Normalized, because what it is held against is: the vault's own
+			// paths, and the ones this run has written. At the vault root
+			// path.join leaves a leading slash that neither of those carries.
+			const fullPath = normalizePath(path.join(folder.path, `${sanitizeFileName(title).replace(/\.md$/i, '')}.md`));
+			if (this.claimedPaths.has(fullPath)) return null;
 
-		const existingFile = this.vault.getAbstractFileByPath(fullPath);
-		if (!(existingFile instanceof TFile)) return null;
+			const existingFile = this.vault.getAbstractFileByPath(fullPath);
+			if (!(existingFile instanceof TFile)) continue;
 
-		// A note that carries an id says which note it is. A different one is a
-		// note of its own however much the titles agree, and one with no id at
-		// all was written before ids were, so the title is all there is to go on.
-		const existingId = await this.sourceIdOf(existingFile, NOTE_ID_PROPERTY);
-		if (existingId && noteId && existingId !== noteId) return null;
+			// A note that carries an id says which note it is. A different one is
+			// a note of its own however much the titles agree, and one with no id
+			// at all was written before ids were, so the title is all there is.
+			const existingId = await this.sourceIdOf(existingFile, NOTE_ID_PROPERTY);
+			if (existingId && noteId && existingId !== noteId) continue;
 
-		return existingFile;
+			return existingFile;
+		}
+
+		return null;
 	}
 
 	/**

--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -706,7 +706,8 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 				row = await this.database.get`
 					SELECT
 						zidentifier, zfallbackimagegeneration, zcreationdate, zmodificationdate,
-						znote, zhandwritingsummary, zsizewidth, zmergeabledata1
+						znote, zhandwritingsummary, zsizewidth,
+					zmergeabledata1 IS NOT NULL AS hasdrawing
 					FROM
 						(SELECT *, NULL AS zfallbackimagegeneration FROM ziccloudsyncingobject)
 					WHERE
@@ -718,7 +719,7 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 
 				// Missing render, drawing data, and dimensions means the drawing
 				// exists only in iCloud.
-				neverDownloaded = !row.ZFALLBACKIMAGEGENERATION && !row.ZMERGEABLEDATA1 && !row.ZSIZEWIDTH;
+				neverDownloaded = !row.ZFALLBACKIMAGEGENERATION && !row.hasdrawing && !row.ZSIZEWIDTH;
 
 				if (row.ZFALLBACKIMAGEGENERATION) {
 					// macOS 14/iOS 17 and above
@@ -746,7 +747,7 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 						AND a.z_pk = b.zmedia
 				`;
 
-				if (!row) break;
+				if (!row || !row.ZFILENAME) break;
 				sourcePath = path.join('Media', row.ZIDENTIFIER, row.ZGENERATION1 || '', row.ZFILENAME);
 				[outName, outExt] = splitext(row.ZFILENAME);
 				break;
@@ -767,42 +768,40 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 			finalAttachmentName = `${datePrefix} ${outName}`;
 		}
 
-		// Check for existing attachment based on the selected handling option
-		// Abuse getAvailablePathForAttachment to get the expected attachment path
-		const uniqueAttachmentPath = await this.getAvailablePathForAttachment(`${finalAttachmentName}.${outExt}`, []);
-		const { parent } = parseFilePath(uniqueAttachmentPath);
-		const expectedAttachmentPath = path.join(parent, `${finalAttachmentName}.${outExt}`);
-		const existingAttachment = this.vault.getAbstractFileByPath(expectedAttachmentPath);
-
-		if (existingAttachment && existingAttachment instanceof TFile) {
-			if (this.duplicateHandling === DuplicateHandling.Skip) {
-				this.ctx.reportSkipped(finalAttachmentName, 'attachment already exists');
-				return existingAttachment;
-			}
-			else if (this.duplicateHandling === DuplicateHandling.ImportUpdated) {
-				// Check modification times for attachments
-				const appleAttachmentModTime = this.decodeTime(row.ZMODIFICATIONDATE);
-				const existingAttachmentModTime = existingAttachment.stat.mtime;
-
-				if (appleAttachmentModTime <= existingAttachmentModTime) {
-					this.ctx.reportSkipped(finalAttachmentName, 'attachment unchanged since last import');
-					return existingAttachment;
-				}
-				// If Apple attachment is newer, continue with import (will overwrite)
-			}
-			// For CreateCopy option, we continue without skipping (will create numbered copy)
-		}
-
 		try {
+			// Read before the name is settled: an extension inferred from the
+			// bytes is part of the name the duplicate check looks for (#471).
 			const binary = await this.getAttachmentSource(this.resolvedAccounts[this.owners[row.ZNOTE]], sourcePath);
 
-			// Obsidian identifies media by extension, so infer one when Apple
-			// provides only a bare file name (#471).
 			if (!outExt) outExt = extensionFromBytes(binary) ?? '';
+			const attachmentName = outExt ? `${finalAttachmentName}.${outExt}` : finalAttachmentName;
 
-			const attachmentPath = await this.getAvailablePathForAttachment(
-				outExt ? `${finalAttachmentName}.${outExt}` : finalAttachmentName, []
-			);
+			// Check for existing attachment based on the selected handling option
+			// Abuse getAvailablePathForAttachment to get the expected attachment path
+			const uniqueAttachmentPath = await this.getAvailablePathForAttachment(attachmentName, []);
+			const { parent } = parseFilePath(uniqueAttachmentPath);
+			const existingAttachment = this.vault.getAbstractFileByPath(path.join(parent, attachmentName));
+
+			if (existingAttachment && existingAttachment instanceof TFile) {
+				if (this.duplicateHandling === DuplicateHandling.Skip) {
+					this.ctx.reportSkipped(finalAttachmentName, 'attachment already exists');
+					return existingAttachment;
+				}
+				else if (this.duplicateHandling === DuplicateHandling.ImportUpdated) {
+					// Check modification times for attachments
+					const appleAttachmentModTime = this.decodeTime(row.ZMODIFICATIONDATE);
+					const existingAttachmentModTime = existingAttachment.stat.mtime;
+
+					if (appleAttachmentModTime <= existingAttachmentModTime) {
+						this.ctx.reportSkipped(finalAttachmentName, 'attachment unchanged since last import');
+						return existingAttachment;
+					}
+					// If Apple attachment is newer, continue with import (will overwrite)
+				}
+				// For CreateCopy option, we continue without skipping (will create numbered copy)
+			}
+
+			const attachmentPath = await this.getAvailablePathForAttachment(attachmentName, []);
 
 			file = await this.vault.createBinary(
 				attachmentPath, nodeBufferToArrayBuffer(binary),

--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -666,6 +666,8 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 		if (id in this.resolvedFiles) return this.resolvedFiles[id];
 
 		let sourcePath, outName, outExt, row, file;
+		/** Whether the attachment was never on this Mac to begin with. */
+		let neverDownloaded = false;
 
 		switch (uti) {
 			case ANAttachment.ModifiedScan:
@@ -711,7 +713,7 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 				row = await this.database.get`
 					SELECT
 						zidentifier, zfallbackimagegeneration, zcreationdate, zmodificationdate,
-						znote, zhandwritingsummary
+						znote, zhandwritingsummary, zsizewidth, zmergeabledata1
 					FROM
 						(SELECT *, NULL AS zfallbackimagegeneration FROM ziccloudsyncingobject)
 					WHERE
@@ -720,6 +722,12 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 				`;
 
 				if (!row) break;
+
+				// A drawing iCloud has never brought down: no rendered copy to
+				// read, no drawing data, and a size Notes never learned. There
+				// is nothing on this Mac to import, which is worth saying
+				// differently from a file that should have been there.
+				neverDownloaded = !row.ZFALLBACKIMAGEGENERATION && !row.ZMERGEABLEDATA1 && !row.ZSIZEWIDTH;
 
 				if (row.ZFALLBACKIMAGEGENERATION) {
 					// macOS 14/iOS 17 and above
@@ -812,11 +820,17 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 			// first and the raw image after it, and Apple writes the cropped
 			// one when it feels like it. Only the pair failing costs anything,
 			// and that is what the second call reports (#393).
-			if (!hasFallback) {
-				this.ctx.reportFailed(sourcePath, extractErrorMessage(e));
-				console.error(e);
+			if (hasFallback) return null;
+
+			// Nothing was lost that this Mac ever had, so it is not a failure
+			// to look into: opening the note in Apple Notes is what fetches it
+			if (neverDownloaded) {
+				this.ctx.reportSkipped(outName, 'not downloaded from iCloud');
+				return null;
 			}
 
+			this.ctx.reportFailed(sourcePath, extractErrorMessage(e));
+			console.error(e);
 			return null;
 		}
 

--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -822,14 +822,20 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 			// and that is what the second call reports (#393).
 			if (hasFallback) return null;
 
-			// Nothing was lost that this Mac ever had, so it is not a failure
-			// to look into: opening the note in Apple Notes is what fetches it
+			// Named after the note holding it, since that is what the user has
+			// to open to do anything about it - the file name on disk is a uuid
+			const label = await this.describeAttachment(outName, Number(row.ZNOTE));
+
+			// Nothing was lost that this Mac ever had, so it is not a failure to
+			// go looking into
 			if (neverDownloaded) {
-				this.ctx.reportSkipped(outName, 'not downloaded from iCloud');
+				this.ctx.reportSkipped(
+					label, 'it has not been downloaded from iCloud - open the note in Apple Notes to fetch it'
+				);
 				return null;
 			}
 
-			this.ctx.reportFailed(sourcePath, extractErrorMessage(e));
+			this.ctx.reportFailed(label, extractErrorMessage(e));
 			console.error(e);
 			return null;
 		}
@@ -855,6 +861,27 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 		return Math.floor((timestamp + CORETIME_OFFSET) * 1000);
 	}
 
+	/**
+	 * How an attachment is named in the import log: what it is, and the note it
+	 * came out of.
+	 *
+	 * On its own it would be "Drawing", which is every drawing in the import,
+	 * and the path it was read from is a uuid. The note is the part the user
+	 * can go and open.
+	 */
+	private async describeAttachment(outName: string, notePk: number): Promise<string> {
+		// The file this run wrote for that note, which is named the way the
+		// user will find it in their vault
+		const imported = this.resolvedFiles[notePk];
+		if (imported) return `${outName} in ${imported.basename}`;
+
+		const note = await this.database.get`
+			SELECT ztitle1 FROM ziccloudsyncingobject WHERE z_pk = ${notePk}
+		`;
+
+		return note?.ZTITLE1 ? `${outName} in ${String(note.ZTITLE1)}` : outName;
+	}
+
 	async getAttachmentSource(account: ANAccount, sourcePath: string): Promise<Buffer<ArrayBuffer>> {
 		// An attachment sits under the account that owns it, except for the
 		// older ones written before Notes kept them apart, which are loose in
@@ -873,9 +900,10 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 			}
 		}
 
-		// Naming both, since reporting only the second reads as though the
-		// first was never tried
-		throw new Error(`not found at ${candidates.join(' or ')}`);
+		// Both are named, since reporting only the second reads as though the
+		// first was never tried. Phrased to follow the "because" the log puts
+		// a reason after.
+		throw new Error(`there is no file at ${candidates.join(' or ')}`);
 	}
 
 	/**

--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -4,7 +4,7 @@ import { ANAccount, ANAttachment, ANContext, ANConverter, ANConverterType, ANFol
 import { descriptor } from './apple-notes/descriptor';
 import { ImportContext } from '../import-context';
 import { fs, fsPromises, nodeBufferToArrayBuffer, os, parseFilePath, path, splitext, zlib } from '../filesystem';
-import { extractErrorMessage, sanitizeFileName, serializeFrontMatter } from '../util';
+import { extensionFromBytes, extractErrorMessage, sanitizeFileName, serializeFrontMatter } from '../util';
 import { DuplicateHandling, FormatImporter } from '../format-importer';
 import { selectedNodes } from '../tree';
 import { TreePicker, ViewableNode } from '../tree-view';
@@ -797,7 +797,15 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 
 		try {
 			const binary = await this.getAttachmentSource(this.resolvedAccounts[this.owners[row.ZNOTE]], sourcePath);
-			const attachmentPath = await this.getAvailablePathForAttachment(`${finalAttachmentName}.${outExt}`, []);
+
+			// A media row can carry a name with no extension - the one the
+			// Evernote web clipper leaves is a bare uuid - and Obsidian goes by
+			// the extension, so the file is asked what it is (#471).
+			if (!outExt) outExt = extensionFromBytes(binary) ?? '';
+
+			const attachmentPath = await this.getAvailablePathForAttachment(
+				outExt ? `${finalAttachmentName}.${outExt}` : finalAttachmentName, []
+			);
 
 			file = await this.vault.createBinary(
 				attachmentPath, nodeBufferToArrayBuffer(binary),
@@ -824,7 +832,7 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 		}
 
 		this.resolvedFiles[id] = file;
-		this.ctx.reportAttachmentSuccess(`${finalAttachmentName}.${outExt}`);
+		this.ctx.reportAttachmentSuccess(file.name);
 		return file;
 	}
 

--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -99,15 +99,11 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 	includeHandwriting = false;
 
 	/**
-	 * The vault's own setting, read rather than asked for: it is what decides
-	 * whether a lone newline renders as the break a soft return meant.
-	 *
-	 * A getter so it is never captured before the vault is there to ask, and
-	 * so a field initialiser cannot throw away what init() would have set.
+	 * A getter rather than a field: a field initialiser runs after init(), and
+	 * the vault is not there to ask at construction. Compared rather than
+	 * defaulted, since getConfig is typed as any.
 	 */
 	get strictLineBreaks(): boolean {
-		// Compared rather than returned: getConfig is typed as any, and a
-		// setting the vault has never been given is undefined
 		return this.vault.getConfig('strictLineBreaks') === true;
 	}
 
@@ -604,8 +600,7 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 
 		const folder = this.resolvedFolders[row.ZFOLDER] || this.rootFolder;
 
-		// Decoded here rather than where it is converted, since the note has to
-		// be named after its own first line and that is only in the text
+		// Decoded before the file is named: the title is the note's first line
 		const converter = this.decodeData(row.zhexdata, NoteConverter);
 
 		// Get creation date and format it according to user preference
@@ -666,7 +661,6 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 		if (id in this.resolvedFiles) return this.resolvedFiles[id];
 
 		let sourcePath, outName, outExt, row, file;
-		/** Whether the attachment was never on this Mac to begin with. */
 		let neverDownloaded = false;
 
 		switch (uti) {
@@ -723,10 +717,8 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 
 				if (!row) break;
 
-				// A drawing iCloud has never brought down: no rendered copy to
-				// read, no drawing data, and a size Notes never learned. There
-				// is nothing on this Mac to import, which is worth saying
-				// differently from a file that should have been there.
+				// No rendered copy, no drawing data, and no size Notes ever
+				// learned: the drawing only exists in iCloud
 				neverDownloaded = !row.ZFALLBACKIMAGEGENERATION && !row.ZMERGEABLEDATA1 && !row.ZSIZEWIDTH;
 
 				if (row.ZFALLBACKIMAGEGENERATION) {
@@ -761,11 +753,9 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 				break;
 		}
 
-		// The row an attachment points at can be gone - one iCloud has not
-		// brought down, typically. Reading a column off it threw, and since a
-		// note's file is created before its body is converted, the note was
-		// left in the vault empty (#218, #391). It costs the attachment now.
-		// Each branch above leaves these unset when its lookup found nothing
+		// A branch leaves these unset when its lookup found nothing. Reading a
+		// column off the missing row threw, and since a note's file is created
+		// before its body, that left the note empty (#218, #391).
 		if (!row || sourcePath === undefined || outName === undefined || outExt === undefined) {
 			if (!hasFallback) this.ctx.reportFailed(`Attachment ${id}`, `no ${uti} row to read it from`);
 			return null;
@@ -815,19 +805,12 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 			);
 		}
 		catch (e) {
-			// A caller with a fallback has not lost the attachment yet, so this
-			// is neither reported nor logged: a scan reads the cropped copy
-			// first and the raw image after it, and Apple writes the cropped
-			// one when it feels like it. Only the pair failing costs anything,
-			// and that is what the second call reports (#393).
+			// Nothing is lost until the fallback fails too, so it is neither
+			// reported nor logged (#393)
 			if (hasFallback) return null;
 
-			// Named after the note holding it, since that is what the user has
-			// to open to do anything about it - the file name on disk is a uuid
 			const label = await this.describeAttachment(outName, Number(row.ZNOTE));
 
-			// Nothing was lost that this Mac ever had, so it is not a failure to
-			// go looking into
 			if (neverDownloaded) {
 				this.ctx.reportSkipped(
 					label, 'it has not been downloaded from iCloud - open the note in Apple Notes to fetch it'
@@ -862,16 +845,11 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 	}
 
 	/**
-	 * How an attachment is named in the import log: what it is, and the note it
-	 * came out of.
-	 *
-	 * On its own it would be "Drawing", which is every drawing in the import,
-	 * and the path it was read from is a uuid. The note is the part the user
-	 * can go and open.
+	 * How an attachment is named in the import log. On its own it would be
+	 * "Drawing", which every drawing in the import is called, and the path it
+	 * was read from is a uuid: the note is the part the user can go and open.
 	 */
 	private async describeAttachment(outName: string, notePk: number): Promise<string> {
-		// The file this run wrote for that note, which is named the way the
-		// user will find it in their vault
 		const imported = this.resolvedFiles[notePk];
 		if (imported) return `${outName} in ${imported.basename}`;
 
@@ -883,9 +861,8 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 	}
 
 	async getAttachmentSource(account: ANAccount, sourcePath: string): Promise<Buffer<ArrayBuffer>> {
-		// An attachment sits under the account that owns it, except for the
-		// older ones written before Notes kept them apart, which are loose in
-		// the container
+		// Under the account that owns it, or loose in the container for the
+		// older ones written before Notes kept accounts apart
 		const candidates = [
 			path.join(account.path, sourcePath),
 			path.join(os.homedir(), NOTE_FOLDER_PATH, sourcePath),
@@ -900,9 +877,8 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 			}
 		}
 
-		// Both are named, since reporting only the second reads as though the
-		// first was never tried. Phrased to follow the "because" the log puts
-		// a reason after.
+		// Both, since naming only the second reads as though the first was
+		// never tried. Worded to follow the "because" the log puts it after.
 		throw new Error(`there is no file at ${candidates.join(' or ')}`);
 	}
 

--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -106,7 +106,9 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 	 * so a field initialiser cannot throw away what init() would have set.
 	 */
 	get strictLineBreaks(): boolean {
-		return this.vault.getConfig('strictLineBreaks') ?? false;
+		// Compared rather than returned: getConfig is typed as any, and a
+		// setting the vault has never been given is undefined
+		return this.vault.getConfig('strictLineBreaks') === true;
 	}
 
 	filePrefixFormat: string;
@@ -658,7 +660,9 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 		return file;
 	}
 
-	async resolveAttachment(id: number, uti: ANAttachment | (string & {})): Promise<TFile | null> {
+	async resolveAttachment(
+		id: number, uti: ANAttachment | (string & {}), hasFallback = false
+	): Promise<TFile | null> {
 		if (id in this.resolvedFiles) return this.resolvedFiles[id];
 
 		let sourcePath, outName, outExt, row, file;
@@ -676,6 +680,7 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 						AND z_pk = ${id}
 				`;
 
+				if (!row) break;
 				sourcePath = path.join('FallbackPDFs', row.ZIDENTIFIER, row.ZFALLBACKPDFGENERATION || '', 'FallbackPDF.pdf');
 				outName = 'Scan';
 				outExt = 'pdf';
@@ -691,6 +696,7 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 						AND z_pk = ${id}
 				`;
 
+				if (!row) break;
 				sourcePath = path.join('Previews', `${row.ZIDENTIFIER}-1-${row.ZSIZEWIDTH}x${row.ZSIZEHEIGHT}-0.jpeg`);
 				outName = 'Scan Page';
 				outExt = 'jpg';
@@ -712,6 +718,8 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 						z_ent = ${this.keys.ICAttachment}
 						AND z_pk = ${id}
 				`;
+
+				if (!row) break;
 
 				if (row.ZFALLBACKIMAGEGENERATION) {
 					// macOS 14/iOS 17 and above
@@ -739,9 +747,20 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 						AND a.z_pk = b.zmedia
 				`;
 
+				if (!row) break;
 				sourcePath = path.join('Media', row.ZIDENTIFIER, row.ZGENERATION1 || '', row.ZFILENAME);
 				[outName, outExt] = splitext(row.ZFILENAME);
 				break;
+		}
+
+		// The row an attachment points at can be gone - one iCloud has not
+		// brought down, typically. Reading a column off it threw, and since a
+		// note's file is created before its body is converted, the note was
+		// left in the vault empty (#218, #391). It costs the attachment now.
+		// Each branch above leaves these unset when its lookup found nothing
+		if (!row || sourcePath === undefined || outName === undefined || outExt === undefined) {
+			if (!hasFallback) this.ctx.reportFailed(`Attachment ${id}`, `no ${uti} row to read it from`);
+			return null;
 		}
 
 		// Apply date prefix to attachment name if configured
@@ -788,7 +807,10 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 			);
 		}
 		catch (e) {
-			this.ctx.reportFailed(sourcePath);
+			// A caller with a fallback has not lost the attachment yet, so this
+			// is not reported: a scan reads the cropped copy first and the raw
+			// image after it, and only the pair failing costs anything (#393).
+			if (!hasFallback) this.ctx.reportFailed(sourcePath);
 			console.error(e);
 			return null;
 		}

--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -97,6 +97,18 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 
 	omitFirstLine = true;
 	includeHandwriting = false;
+
+	/**
+	 * The vault's own setting, read rather than asked for: it is what decides
+	 * whether a lone newline renders as the break a soft return meant.
+	 *
+	 * A getter so it is never captured before the vault is there to ask, and
+	 * so a field initialiser cannot throw away what init() would have set.
+	 */
+	get strictLineBreaks(): boolean {
+		return this.vault.getConfig('strictLineBreaks') ?? false;
+	}
+
 	filePrefixFormat: string;
 	/** Every note path this run has written, to tell a copy from an update. */
 	private claimedPaths = new Set<string>();

--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -616,7 +616,7 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 
 		if (existingFile) {
 			if (this.duplicateHandling === DuplicateHandling.Skip) {
-				this.ctx.reportSkipped(row.ZTITLE1, 'note is a duplicate');
+				this.ctx.reportSkipped(title, 'note is a duplicate');
 				return existingFile;
 			}
 			else if (this.duplicateHandling === DuplicateHandling.ImportUpdated) {
@@ -626,7 +626,7 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 
 				// Only skip if the Apple Note hasn't been modified since the existing file
 				if (appleNoteModTime <= existingFileModTime) {
-					this.ctx.reportSkipped(row.ZTITLE1, 'note unchanged since last import');
+					this.ctx.reportSkipped(title, 'note unchanged since last import');
 					return existingFile;
 				}
 				// If Apple Note is newer, continue with import (will overwrite)

--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -1,5 +1,5 @@
 import { DataWriteOptions, Notice, Platform, TFile, TFolder, moment, normalizePath } from 'obsidian';
-import { NoteConverter } from './apple-notes/convert-note';
+import { NoteConverter, noteTitle } from './apple-notes/convert-note';
 import { ANAccount, ANAttachment, ANContext, ANConverter, ANConverterType, ANFolderType } from './apple-notes/models';
 import { descriptor } from './apple-notes/descriptor';
 import { ImportContext } from '../import-context';
@@ -590,8 +590,12 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 
 		const folder = this.resolvedFolders[row.ZFOLDER] || this.rootFolder;
 
+		// Decoded here rather than where it is converted, since the note has to
+		// be named after its own first line and that is only in the text
+		const converter = this.decodeData(row.zhexdata, NoteConverter);
+
 		// Get creation date and format it according to user preference
-		let title = row.ZTITLE1;
+		let title = noteTitle(converter.note.noteText, row.ZTITLE1);
 		if (this.filePrefixFormat) {
 			const creationTimestamp = this.decodeTime(row.ZCREATIONDATE3 || row.ZCREATIONDATE2 || row.ZCREATIONDATE1);
 			const datePrefix = moment(creationTimestamp).format(this.filePrefixFormat);
@@ -629,8 +633,6 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 		this.owners[id] = this.owners[row.ZFOLDER];
 
 		// Notes may reference other notes, so we want them in resolvedFiles before we parse to avoid cycles
-		const converter = this.decodeData(row.zhexdata, NoteConverter);
-
 		const body = await converter.format(false, file.path);
 
 		await this.vault.modify(file, this.noteIdFrontMatter(row.ZIDENTIFIER) + body, {

--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -99,9 +99,9 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 	includeHandwriting = false;
 
 	/**
-	 * A getter rather than a field: a field initialiser runs after init(), and
-	 * the vault is not there to ask at construction. Compared rather than
-	 * defaulted, since getConfig is typed as any.
+	 * This must remain a getter: the vault is unavailable during construction,
+	 * and field initialisers run after init(). The explicit comparison narrows
+	 * getConfig's `any` return value to boolean.
 	 */
 	get strictLineBreaks(): boolean {
 		return this.vault.getConfig('strictLineBreaks') === true;
@@ -600,7 +600,6 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 
 		const folder = this.resolvedFolders[row.ZFOLDER] || this.rootFolder;
 
-		// Decoded before the file is named: the title is the note's first line
 		const converter = this.decodeData(row.zhexdata, NoteConverter);
 
 		// Get creation date and format it according to user preference
@@ -717,8 +716,8 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 
 				if (!row) break;
 
-				// No rendered copy, no drawing data, and no size Notes ever
-				// learned: the drawing only exists in iCloud
+				// Missing render, drawing data, and dimensions means the drawing
+				// exists only in iCloud.
 				neverDownloaded = !row.ZFALLBACKIMAGEGENERATION && !row.ZMERGEABLEDATA1 && !row.ZSIZEWIDTH;
 
 				if (row.ZFALLBACKIMAGEGENERATION) {
@@ -753,9 +752,8 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 				break;
 		}
 
-		// A branch leaves these unset when its lookup found nothing. Reading a
-		// column off the missing row threw, and since a note's file is created
-		// before its body, that left the note empty (#218, #391).
+		// A missing attachment row must not abort conversion after the empty note
+		// file has already been created (#218, #391).
 		if (!row || sourcePath === undefined || outName === undefined || outExt === undefined) {
 			if (!hasFallback) this.ctx.reportFailed(`Attachment ${id}`, `no ${uti} row to read it from`);
 			return null;
@@ -798,9 +796,8 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 		try {
 			const binary = await this.getAttachmentSource(this.resolvedAccounts[this.owners[row.ZNOTE]], sourcePath);
 
-			// A media row can carry a name with no extension - the one the
-			// Evernote web clipper leaves is a bare uuid - and Obsidian goes by
-			// the extension, so the file is asked what it is (#471).
+			// Obsidian identifies media by extension, so infer one when Apple
+			// provides only a bare file name (#471).
 			if (!outExt) outExt = extensionFromBytes(binary) ?? '';
 
 			const attachmentPath = await this.getAvailablePathForAttachment(
@@ -813,8 +810,8 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 			);
 		}
 		catch (e) {
-			// Nothing is lost until the fallback fails too, so it is neither
-			// reported nor logged (#393)
+			// Suppress an expected failed probe; the caller reports only if its
+			// fallback also fails (#393).
 			if (hasFallback) return null;
 
 			const label = await this.describeAttachment(outName, Number(row.ZNOTE));
@@ -852,11 +849,7 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 		return Math.floor((timestamp + CORETIME_OFFSET) * 1000);
 	}
 
-	/**
-	 * How an attachment is named in the import log. On its own it would be
-	 * "Drawing", which every drawing in the import is called, and the path it
-	 * was read from is a uuid: the note is the part the user can go and open.
-	 */
+	/** Identify an attachment in the log by the note the user can locate. */
 	private async describeAttachment(outName: string, notePk: number): Promise<string> {
 		const imported = this.resolvedFiles[notePk];
 		if (imported) return `${outName} in ${imported.basename}`;
@@ -869,8 +862,8 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 	}
 
 	async getAttachmentSource(account: ANAccount, sourcePath: string): Promise<Buffer<ArrayBuffer>> {
-		// Under the account that owns it, or loose in the container for the
-		// older ones written before Notes kept accounts apart
+		// Older attachments predate per-account storage and remain loose in the
+		// Notes container.
 		const candidates = [
 			path.join(account.path, sourcePath),
 			path.join(os.homedir(), NOTE_FOLDER_PATH, sourcePath),
@@ -885,8 +878,8 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 			}
 		}
 
-		// Both, since naming only the second reads as though the first was
-		// never tried. Worded to follow the "because" the log puts it after.
+		// Include both attempted paths and phrase the message to follow the
+		// import log's "because".
 		throw new Error(`there is no file at ${candidates.join(' or ')}`);
 	}
 

--- a/src/formats/apple-notes/convert-note.ts
+++ b/src/formats/apple-notes/convert-note.ts
@@ -18,6 +18,8 @@ import {
 } from './models';
 
 const FRAGMENT_SPLIT = /(^\s+|(?:\s+)?\n(?:\s+)?|\s+$)/;
+/** What Shift-Return puts in the text: a line separator, not a paragraph end. */
+const SOFT_RETURN = '\u2028';
 const NOTE_URI = /applenotes:note\/([-0-9a-f]+)(?:\?ownerIdentifier=.*)?/;
 
 const DEFAULT_EMOJI = '.AppleColorEmojiUI';
@@ -113,6 +115,16 @@ export class NoteConverter extends ANConverter {
 			attr.atLineStart = j == 0 ? true : fragments[j - 1]?.fragment.contains('\n');
 
 			converted += this.formatMultiRun(attr);
+
+			// Shift-Return writes a line separator rather than ending the
+			// paragraph, so the break belongs to the line it is on: a new
+			// bullet must not start. Markdown has no character for that, so it
+			// takes a <br> - except inside a code block, where the newline it
+			// stands for is what the text already means.
+			if (attr.fragment.contains(SOFT_RETURN)) {
+				attr.fragment = attr.fragment.split(SOFT_RETURN)
+					.join(this.multiRun == ANMultiRun.Monospaced ? '\n' : '<br>');
+			}
 
 			if (!/\S/.test(attr.fragment) || this.multiRun == ANMultiRun.Monospaced) {
 				converted += attr.fragment;

--- a/src/formats/apple-notes/convert-note.ts
+++ b/src/formats/apple-notes/convert-note.ts
@@ -133,15 +133,29 @@ export class NoteConverter extends ANConverter {
 			&& this.note.noteText.contains('\n')
 			&& !URL_LINE.test(firstLine(this.note.noteText));
 		let converted = '';
+		/** Whether the line being skipped has had anything on it yet. */
+		let titleStarted = false;
 
 		for (let j = 0; j < fragments.length; j++) {
 			let { attr, fragment } = fragments[j];
 
 			if (firstLineSkip) {
-				if (fragment.contains('\n') || attr.attachmentInfo) {
+				// An attachment is content rather than a title, so it stops the
+				// skip and is kept
+				if (attr.attachmentInfo) {
+					firstLineSkip = false;
+				}
+				else if (!titleStarted && /\S/.test(fragment) && this.leadsNestedList(fragments, j)) {
 					firstLineSkip = false;
 				}
 				else {
+					// Apple takes the title from the first line with anything on
+					// it, so a note starting with blank lines has its title
+					// further down. Stopping at the first newline would stop on a
+					// blank one and leave the title in the body as well as in the
+					// file name.
+					if (/\S/.test(fragment)) titleStarted = true;
+					if (titleStarted && fragment.contains('\n')) firstLineSkip = false;
 					continue;
 				}
 			}
@@ -184,6 +198,28 @@ export class NoteConverter extends ANConverter {
 		if (table) converted = converted.replace(/\n/g, '<br>').replace(/\|/g, '&#124;');
 
 		return converted;
+	}
+
+	/**
+	 * Whether the fragment at `from` is a list item with items nested under it.
+	 *
+	 * Those items are written relative to their parent, so dropping it as the
+	 * title leaves them with nothing to hang off and the list gains an empty
+	 * item where it was. A first item whose next item is a sibling loses
+	 * nothing that way, so that one is still dropped.
+	 */
+	leadsNestedList(fragments: ANFragmentPair[], from: number): boolean {
+		const style = fragments[from].attr.paragraphStyle;
+		if (style?.styleType === undefined || !LIST_STYLES.includes(style.styleType)) return false;
+
+		const indent = style.indentAmount ?? 0;
+
+		for (let k = from + 1; k < fragments.length; k++) {
+			if (!/\S/.test(fragments[k].fragment)) continue;
+			return (fragments[k].attr.paragraphStyle?.indentAmount ?? 0) > indent;
+		}
+
+		return false;
 	}
 
 	/** Format things that cover multiple ANAttributeRuns. */

--- a/src/formats/apple-notes/convert-note.ts
+++ b/src/formats/apple-notes/convert-note.ts
@@ -129,9 +129,14 @@ export class NoteConverter extends ANConverter {
 		}
 
 		if (this.multiRun != ANMultiRun.None) converted += this.formatMultiRun({} as ANAttributeRun);
-		if (table) converted.replace('\n', '<br>').replace('|', '&#124;');
+		converted = converted.trim();
 
-		return converted.trim();
+		// Trimmed first, so the newlines a cell is padded with do not each
+		// become a <br>. Every one after that has to go: a row ends at the
+		// first newline, and an unescaped pipe starts the next cell.
+		if (table) converted = converted.replace(/\n/g, '<br>').replace(/\|/g, '&#124;');
+
+		return converted;
 	}
 
 	/** Format things that cover multiple ANAttributeRuns. */

--- a/src/formats/apple-notes/convert-note.ts
+++ b/src/formats/apple-notes/convert-note.ts
@@ -37,6 +37,36 @@ const EMPHASIS_MARKERS: Record<ANEmphasisColor, string> = {
 	[ANEmphasisColor.Blue]: '🔵'
 };
 
+/** How long a title may get before the file name it becomes is at risk. */
+const TITLE_LIMIT = 200;
+
+/** A first line holding nothing but a URL, which no file name can keep. */
+const URL_LINE = /^https?:\/\/\S+$/;
+
+/** The note's first line with anything on it, which is the title Apple shows. */
+export function firstLine(noteText: string): string {
+	return noteText.split('\n').find(line => line.trim() !== '')?.trim() ?? '';
+}
+
+/**
+ * What to name a note.
+ *
+ * ZTITLE1 holds an abbreviation of the first line rather than the line itself:
+ * past about eighty characters Apple cuts it short and puts an ellipsis in
+ * place of the rest, and that ellipsis went into the file name (#541). The
+ * line is in the note text, so that is what to read it from.
+ *
+ * `stored` is what to fall back on when there is no text to read a title from,
+ * which is the case for a note holding nothing but an attachment.
+ */
+export function noteTitle(noteText: string, stored: string): string {
+	const line = firstLine(noteText ?? '');
+	if (!line) return stored;
+
+	// A file name has a length limit; a first line has none
+	return line.length > TITLE_LIMIT ? line.slice(0, TITLE_LIMIT).trimEnd() : line;
+}
+
 const LIST_STYLES = [
 	ANStyleType.DottedList, ANStyleType.DashedList, ANStyleType.NumberedList, ANStyleType.Checkbox
 ];
@@ -96,7 +126,12 @@ export class NoteConverter extends ANConverter {
 
 	async format(table = false, parentNotePath = ''): Promise<string> {
 		let fragments = this.parseTokens();
-		let firstLineSkip = !table && this.ctx.omitFirstLine && this.note.noteText.contains('\n');
+		// The first line is dropped because the file name keeps it. A URL is the
+		// case where it cannot: the slashes become dashes and the colon goes, so
+		// dropping it would leave the note with no working link anywhere (#591).
+		let firstLineSkip = !table && this.ctx.omitFirstLine
+			&& this.note.noteText.contains('\n')
+			&& !URL_LINE.test(firstLine(this.note.noteText));
 		let converted = '';
 
 		for (let j = 0; j < fragments.length; j++) {

--- a/src/formats/apple-notes/convert-note.ts
+++ b/src/formats/apple-notes/convert-note.ts
@@ -165,14 +165,8 @@ export class NoteConverter extends ANConverter {
 
 			converted += this.formatMultiRun(attr);
 
-			// Shift-Return writes a line separator rather than ending the
-			// paragraph, so the break belongs to the line it is on: a new
-			// bullet must not start. Markdown has no character for that, so it
-			// takes a <br> - except inside a code block, where the newline it
-			// stands for is what the text already means.
 			if (attr.fragment.contains(SOFT_RETURN)) {
-				attr.fragment = attr.fragment.split(SOFT_RETURN)
-					.join(this.multiRun == ANMultiRun.Monospaced ? '\n' : '<br>');
+				attr.fragment = this.expandSoftReturns(attr, converted);
 			}
 
 			if (!/\S/.test(attr.fragment) || this.multiRun == ANMultiRun.Monospaced) {
@@ -198,6 +192,49 @@ export class NoteConverter extends ANConverter {
 		if (table) converted = converted.replace(/\n/g, '<br>').replace(/\|/g, '&#124;');
 
 		return converted;
+	}
+
+	/**
+	 * A fragment's soft returns written out as line breaks.
+	 *
+	 * Shift-Return breaks the line without ending the paragraph, and a newline
+	 * is what that is in markdown - Obsidian renders one as a line break unless
+	 * strict line breaks are turned on. Inside a list item the line has to be
+	 * indented as well, or it reads as the end of the item rather than more of
+	 * it; the indent is a tab, which is what nesting an item uses.
+	 *
+	 * A soft return with nothing before it on its line has no item to continue,
+	 * so it stays a bare newline. Indenting there would leave a line standing
+	 * on its own after a blank one, which markdown reads as a code block.
+	 */
+	expandSoftReturns(attr: ANAttributeRun, converted: string): string {
+		const style = attr.paragraphStyle;
+		let indent = '\n';
+
+		if (
+			this.multiRun != ANMultiRun.Monospaced
+			&& style?.styleType !== undefined
+			&& LIST_STYLES.includes(style.styleType)
+		) {
+			indent += '\t'.repeat((style.indentAmount ?? 0) + 1);
+		}
+
+		// What has been written of the line the fragment starts on
+		let onALine = /\S/.test(converted.slice(converted.lastIndexOf('\n') + 1));
+		let out = '';
+
+		for (const char of attr.fragment) {
+			if (char == SOFT_RETURN) {
+				out += onALine ? indent : '\n';
+				onALine = false;
+			}
+			else {
+				out += char;
+				onALine = char == '\n' ? false : onALine || /\S/.test(char);
+			}
+		}
+
+		return out;
 	}
 
 	/**

--- a/src/formats/apple-notes/convert-note.ts
+++ b/src/formats/apple-notes/convert-note.ts
@@ -364,6 +364,16 @@ export class NoteConverter extends ANConverter {
 		// Escape square brackets.
 		attr.fragment = attr.fragment.replace(/([[\]])/g, '\\$1');
 
+		// And a hash Obsidian would read as a tag: one starting a word, with a
+		// non-digit somewhere in what follows. Apple marks a real tag as an
+		// attachment, so a hash left in the text is not one (#471).
+		//
+		// Narrow on purpose. "C#" keeps its hash because a tag has to start a
+		// word, and "## Heading" keeps both because that is not a tag either -
+		// whether text a note wrote as markdown should stay markdown is a
+		// different question from this one.
+		attr.fragment = attr.fragment.replace(/(^|\s)#(?=[\w/-]*[A-Za-z_/-])/g, '$1\\#');
+
 		switch (attr.fontWeight) {
 			case ANFontWeight.Bold:
 				attr.fragment = `**${attr.fragment}**`;

--- a/src/formats/apple-notes/convert-note.ts
+++ b/src/formats/apple-notes/convert-note.ts
@@ -49,21 +49,15 @@ export function firstLine(noteText: string): string {
 }
 
 /**
- * What to name a note.
- *
- * ZTITLE1 holds an abbreviation of the first line rather than the line itself:
- * past about eighty characters Apple cuts it short and puts an ellipsis in
- * place of the rest, and that ellipsis went into the file name (#541). The
- * line is in the note text, so that is what to read it from.
- *
- * `stored` is what to fall back on when there is no text to read a title from,
- * which is the case for a note holding nothing but an attachment.
+ * What to name a note. ZTITLE1 is an abbreviation Apple stores, cut short with
+ * an ellipsis past about eighty characters (#541), so the first line itself is
+ * what to read it from. `stored` is the fallback for a note with no text, which
+ * is one holding nothing but an attachment.
  */
 export function noteTitle(noteText: string, stored: string): string {
 	const line = firstLine(noteText ?? '');
 	if (!line) return stored;
 
-	// A file name has a length limit; a first line has none
 	return line.length > TITLE_LIMIT ? line.slice(0, TITLE_LIMIT).trimEnd() : line;
 }
 
@@ -126,22 +120,19 @@ export class NoteConverter extends ANConverter {
 
 	async format(table = false, parentNotePath = ''): Promise<string> {
 		let fragments = this.parseTokens();
-		// The first line is dropped because the file name keeps it. A URL is the
-		// case where it cannot: the slashes become dashes and the colon goes, so
-		// dropping it would leave the note with no working link anywhere (#591).
+		// The first line goes because the file name keeps it - which a URL does
+		// not survive, so that one stays in the body (#591)
 		let firstLineSkip = !table && this.ctx.omitFirstLine
 			&& this.note.noteText.contains('\n')
 			&& !URL_LINE.test(firstLine(this.note.noteText));
 		let converted = '';
-		/** Whether the line being skipped has had anything on it yet. */
 		let titleStarted = false;
 
 		for (let j = 0; j < fragments.length; j++) {
 			let { attr, fragment } = fragments[j];
 
 			if (firstLineSkip) {
-				// An attachment is content rather than a title, so it stops the
-				// skip and is kept
+				// An attachment is content rather than a title
 				if (attr.attachmentInfo) {
 					firstLineSkip = false;
 				}
@@ -149,11 +140,9 @@ export class NoteConverter extends ANConverter {
 					firstLineSkip = false;
 				}
 				else {
-					// Apple takes the title from the first line with anything on
-					// it, so a note starting with blank lines has its title
-					// further down. Stopping at the first newline would stop on a
-					// blank one and leave the title in the body as well as in the
-					// file name.
+					// The title is the first line with anything on it, so a note
+					// starting with blank lines has it further down: stopping at
+					// the first newline would leave the title in the body too
 					if (/\S/.test(fragment)) titleStarted = true;
 					if (titleStarted && fragment.contains('\n')) firstLineSkip = false;
 					continue;
@@ -186,11 +175,9 @@ export class NoteConverter extends ANConverter {
 		if (this.multiRun != ANMultiRun.None) converted += this.formatMultiRun({} as ANAttributeRun);
 		converted = converted.trim();
 
-		// Trimmed first, so the newlines a cell is padded with do not each
-		// become a <br>. Every one after that has to go: a row ends at the
-		// first newline, and an unescaped pipe starts the next cell. The <br>
-		// is the break itself, so the spaces a hard break is spelled with are
-		// dropped rather than left stranded in front of it.
+		// Trimmed first, so a cell's padding does not become <br>s. A row ends
+		// at the first newline and an unescaped pipe starts the next cell; the
+		// <br> is the break, so a hard break's spaces go with it.
 		if (table) {
 			converted = converted.replace(/ *\n/g, '<br>').replace(/\|/g, '&#124;');
 		}
@@ -201,19 +188,10 @@ export class NoteConverter extends ANConverter {
 	/**
 	 * A fragment's soft returns written out as line breaks.
 	 *
-	 * Shift-Return breaks the line without ending the paragraph, and a newline
-	 * is what that is in markdown - Obsidian renders one as a line break, which
-	 * is all it takes unless the vault has strict line breaks turned on. Where
-	 * it does, the break has to be spelled out, and two trailing spaces are how
-	 * markdown says it.
-	 *
-	 * Inside a list item the line is indented as well, or it reads as the end
-	 * of the item rather than more of it; the indent is a tab, which is what
-	 * nesting an item uses.
-	 *
-	 * A soft return with nothing before it on its line has no item to continue,
-	 * so it stays a bare newline. Indenting there would leave a line standing
-	 * on its own after a blank one, which markdown reads as a code block.
+	 * A newline is one, unless the vault has strict line breaks on and it has
+	 * to be spelled with two trailing spaces. Inside a list item it is indented
+	 * too, or it reads as the end of the item - but not when nothing precedes
+	 * it on the line, where an indent after a blank line reads as a code block.
 	 */
 	expandSoftReturns(attr: ANAttributeRun, converted: string): string {
 		const style = attr.paragraphStyle;
@@ -227,7 +205,6 @@ export class NoteConverter extends ANConverter {
 			indent += '\t'.repeat((style.indentAmount ?? 0) + 1);
 		}
 
-		// What has been written of the line the fragment starts on
 		let onALine = /\S/.test(converted.slice(converted.lastIndexOf('\n') + 1));
 		let out = '';
 
@@ -246,12 +223,10 @@ export class NoteConverter extends ANConverter {
 	}
 
 	/**
-	 * Whether the fragment at `from` is a list item with items nested under it.
-	 *
-	 * Those items are written relative to their parent, so dropping it as the
-	 * title leaves them with nothing to hang off and the list gains an empty
-	 * item where it was. A first item whose next item is a sibling loses
-	 * nothing that way, so that one is still dropped.
+	 * Whether the fragment at `from` is a list item with items nested under it,
+	 * which are written relative to it: dropping it as the title would leave
+	 * them orphaned and the list with an empty item where it was. A first item
+	 * the rest are siblings of loses nothing, so that one still goes.
 	 */
 	leadsNestedList(fragments: ANFragmentPair[], from: number): boolean {
 		const style = fragments[from].attr.paragraphStyle;

--- a/src/formats/apple-notes/convert-note.ts
+++ b/src/formats/apple-notes/convert-note.ts
@@ -188,8 +188,12 @@ export class NoteConverter extends ANConverter {
 
 		// Trimmed first, so the newlines a cell is padded with do not each
 		// become a <br>. Every one after that has to go: a row ends at the
-		// first newline, and an unescaped pipe starts the next cell.
-		if (table) converted = converted.replace(/\n/g, '<br>').replace(/\|/g, '&#124;');
+		// first newline, and an unescaped pipe starts the next cell. The <br>
+		// is the break itself, so the spaces a hard break is spelled with are
+		// dropped rather than left stranded in front of it.
+		if (table) {
+			converted = converted.replace(/ *\n/g, '<br>').replace(/\|/g, '&#124;');
+		}
 
 		return converted;
 	}
@@ -198,10 +202,14 @@ export class NoteConverter extends ANConverter {
 	 * A fragment's soft returns written out as line breaks.
 	 *
 	 * Shift-Return breaks the line without ending the paragraph, and a newline
-	 * is what that is in markdown - Obsidian renders one as a line break unless
-	 * strict line breaks are turned on. Inside a list item the line has to be
-	 * indented as well, or it reads as the end of the item rather than more of
-	 * it; the indent is a tab, which is what nesting an item uses.
+	 * is what that is in markdown - Obsidian renders one as a line break, which
+	 * is all it takes unless the vault has strict line breaks turned on. Where
+	 * it does, the break has to be spelled out, and two trailing spaces are how
+	 * markdown says it.
+	 *
+	 * Inside a list item the line is indented as well, or it reads as the end
+	 * of the item rather than more of it; the indent is a tab, which is what
+	 * nesting an item uses.
 	 *
 	 * A soft return with nothing before it on its line has no item to continue,
 	 * so it stays a bare newline. Indenting there would leave a line standing
@@ -209,7 +217,7 @@ export class NoteConverter extends ANConverter {
 	 */
 	expandSoftReturns(attr: ANAttributeRun, converted: string): string {
 		const style = attr.paragraphStyle;
-		let indent = '\n';
+		let indent = this.ctx.strictLineBreaks ? '  \n' : '\n';
 
 		if (
 			this.multiRun != ANMultiRun.Monospaced

--- a/src/formats/apple-notes/convert-note.ts
+++ b/src/formats/apple-notes/convert-note.ts
@@ -162,7 +162,15 @@ export class NoteConverter extends ANConverter {
 				converted += attr.fragment;
 			}
 			else if (attr.attachmentInfo) {
-				converted += await this.formatAttachment(attr, parentNotePath);
+				attr.fragment = await this.formatAttachment(attr, parentNotePath);
+
+				// An inline attachment is the line's first content when it leads
+				// one, so it takes the prefix that line calls for - a checkbox
+				// was lost on an item starting with a link (#471). A block one
+				// stands on its own and takes none.
+				converted += attr.atLineStart && !isBlockAttachment(attr)
+					? this.formatParagraph(attr)
+					: attr.fragment;
 			}
 			else if (attr.superscript || attr.underlined || attr.font || this.multiRun == ANMultiRun.Alignment) {
 				converted += await this.formatHtmlAttr(attr);

--- a/src/formats/apple-notes/convert-note.ts
+++ b/src/formats/apple-notes/convert-note.ts
@@ -37,22 +37,19 @@ const EMPHASIS_MARKERS: Record<ANEmphasisColor, string> = {
 	[ANEmphasisColor.Blue]: '🔵'
 };
 
-/** How long a title may get before the file name it becomes is at risk. */
+/** Keep generated file names within practical filesystem limits. */
 const TITLE_LIMIT = 200;
 
-/** A first line holding nothing but a URL, which no file name can keep. */
 const URL_LINE = /^https?:\/\/\S+$/;
 
-/** The note's first line with anything on it, which is the title Apple shows. */
+/** Return the first non-blank line, which Apple displays as the note title. */
 export function firstLine(noteText: string): string {
 	return noteText.split('\n').find(line => line.trim() !== '')?.trim() ?? '';
 }
 
 /**
- * What to name a note. ZTITLE1 is an abbreviation Apple stores, cut short with
- * an ellipsis past about eighty characters (#541), so the first line itself is
- * what to read it from. `stored` is the fallback for a note with no text, which
- * is one holding nothing but an attachment.
+ * Derive a title from the note text because Apple truncates ZTITLE1 at roughly
+ * 80 characters (#541). Fall back to ZTITLE1 for attachment-only notes.
  */
 export function noteTitle(noteText: string, stored: string): string {
 	const line = firstLine(noteText ?? '');
@@ -120,8 +117,8 @@ export class NoteConverter extends ANConverter {
 
 	async format(table = false, parentNotePath = ''): Promise<string> {
 		let fragments = this.parseTokens();
-		// The first line goes because the file name keeps it - which a URL does
-		// not survive, so that one stays in the body (#591)
+		// Keep URL-only titles in the body because sanitising them for a file name
+		// would destroy the working URL (#591).
 		let firstLineSkip = !table && this.ctx.omitFirstLine
 			&& this.note.noteText.contains('\n')
 			&& !URL_LINE.test(firstLine(this.note.noteText));
@@ -132,7 +129,7 @@ export class NoteConverter extends ANConverter {
 			let { attr, fragment } = fragments[j];
 
 			if (firstLineSkip) {
-				// An attachment is content rather than a title
+				// Do not treat an attachment as part of the title.
 				if (attr.attachmentInfo) {
 					firstLineSkip = false;
 				}
@@ -140,9 +137,8 @@ export class NoteConverter extends ANConverter {
 					firstLineSkip = false;
 				}
 				else {
-					// The title is the first line with anything on it, so a note
-					// starting with blank lines has it further down: stopping at
-					// the first newline would leave the title in the body too
+					// Skip through leading blank lines, then stop after the first
+					// non-blank line so the title is not repeated in the body.
 					if (/\S/.test(fragment)) titleStarted = true;
 					if (titleStarted && fragment.contains('\n')) firstLineSkip = false;
 					continue;
@@ -164,10 +160,8 @@ export class NoteConverter extends ANConverter {
 			else if (attr.attachmentInfo) {
 				attr.fragment = await this.formatAttachment(attr, parentNotePath);
 
-				// An inline attachment is the line's first content when it leads
-				// one, so it takes the prefix that line calls for - a checkbox
-				// was lost on an item starting with a link (#471). A block one
-				// stands on its own and takes none.
+				// An inline attachment can be the first content in a list item and
+				// must receive that item's prefix. Block attachments stand alone.
 				converted += attr.atLineStart && !isBlockAttachment(attr)
 					? this.formatParagraph(attr)
 					: attr.fragment;
@@ -183,9 +177,8 @@ export class NoteConverter extends ANConverter {
 		if (this.multiRun != ANMultiRun.None) converted += this.formatMultiRun({} as ANAttributeRun);
 		converted = converted.trim();
 
-		// Trimmed first, so a cell's padding does not become <br>s. A row ends
-		// at the first newline and an unescaped pipe starts the next cell; the
-		// <br> is the break, so a hard break's spaces go with it.
+		// Inside a table cell, raw newlines end the row and raw pipes start a new
+		// cell. Remove hard-break spaces before replacing the newline.
 		if (table) {
 			converted = converted.replace(/ *\n/g, '<br>').replace(/\|/g, '&#124;');
 		}
@@ -194,12 +187,11 @@ export class NoteConverter extends ANConverter {
 	}
 
 	/**
-	 * A fragment's soft returns written out as line breaks.
+	 * Convert a fragment's soft returns to Markdown line breaks.
 	 *
-	 * A newline is one, unless the vault has strict line breaks on and it has
-	 * to be spelled with two trailing spaces. Inside a list item it is indented
-	 * too, or it reads as the end of the item - but not when nothing precedes
-	 * it on the line, where an indent after a blank line reads as a code block.
+	 * Strict line breaks require two trailing spaces. List continuations also
+	 * require indentation, except after an empty line where indentation would
+	 * create a code block.
 	 */
 	expandSoftReturns(attr: ANAttributeRun, converted: string): string {
 		const style = attr.paragraphStyle;
@@ -231,10 +223,8 @@ export class NoteConverter extends ANConverter {
 	}
 
 	/**
-	 * Whether the fragment at `from` is a list item with items nested under it,
-	 * which are written relative to it: dropping it as the title would leave
-	 * them orphaned and the list with an empty item where it was. A first item
-	 * the rest are siblings of loses nothing, so that one still goes.
+	 * Whether the fragment at `from` is the parent of a nested list. Removing a
+	 * parent used as the title would orphan its children and leave an empty item.
 	 */
 	leadsNestedList(fragments: ANFragmentPair[], from: number): boolean {
 		const style = fragments[from].attr.paragraphStyle;
@@ -364,14 +354,11 @@ export class NoteConverter extends ANConverter {
 		// Escape square brackets.
 		attr.fragment = attr.fragment.replace(/([[\]])/g, '\\$1');
 
-		// And a hash Obsidian would read as a tag: one starting a word, with a
-		// non-digit somewhere in what follows. Apple marks a real tag as an
-		// attachment, so a hash left in the text is not one (#471).
+		// Apple represents real tags as attachments. Escape tag-shaped hashes that
+		// remain in plain text so Obsidian does not reinterpret them (#471).
 		//
-		// Narrow on purpose. "C#" keeps its hash because a tag has to start a
-		// word, and "## Heading" keeps both because that is not a tag either -
-		// whether text a note wrote as markdown should stay markdown is a
-		// different question from this one.
+		// Limit this to a hash at a word boundary followed by at least one
+		// non-digit tag character. This preserves C#, F#, and Markdown headings.
 		attr.fragment = attr.fragment.replace(/(^|\s)#(?=[\w/-]*[A-Za-z_/-])/g, '$1\\#');
 
 		switch (attr.fontWeight) {

--- a/src/formats/apple-notes/convert-note.ts
+++ b/src/formats/apple-notes/convert-note.ts
@@ -42,9 +42,16 @@ const TITLE_LIMIT = 200;
 
 const URL_LINE = /^https?:\/\/\S+$/;
 
-/** Return the first non-blank line, which Apple displays as the note title. */
+/**
+ * Return the first line with text on it, which Apple displays as the note
+ * title. A line holding only attachments is not one, and a soft return within
+ * the line is a space rather than a character no file name should carry.
+ */
 export function firstLine(noteText: string): string {
-	return noteText.split('\n').find(line => line.trim() !== '')?.trim() ?? '';
+	return noteText
+		.split('\n')
+		.map(line => line.replace(/\uFFFC/g, '').replace(/[\u2028\u2029]/g, ' ').trim())
+		.find(line => line !== '') ?? '';
 }
 
 /**
@@ -191,17 +198,14 @@ export class NoteConverter extends ANConverter {
 	 *
 	 * Strict line breaks require two trailing spaces. List continuations also
 	 * require indentation, except after an empty line where indentation would
-	 * create a code block.
+	 * create a code block. Inside one, a newline is already the break.
 	 */
 	expandSoftReturns(attr: ANAttributeRun, converted: string): string {
 		const style = attr.paragraphStyle;
-		let indent = this.ctx.strictLineBreaks ? '  \n' : '\n';
+		const inCode = this.multiRun == ANMultiRun.Monospaced;
+		let indent = this.ctx.strictLineBreaks && !inCode ? '  \n' : '\n';
 
-		if (
-			this.multiRun != ANMultiRun.Monospaced
-			&& style?.styleType !== undefined
-			&& LIST_STYLES.includes(style.styleType)
-		) {
+		if (!inCode && style?.styleType !== undefined && LIST_STYLES.includes(style.styleType)) {
 			indent += '\t'.repeat((style.indentAmount ?? 0) + 1);
 		}
 

--- a/src/formats/apple-notes/convert-scan.ts
+++ b/src/formats/apple-notes/convert-scan.ts
@@ -27,13 +27,11 @@ export class ScanConverter extends ANConverter {
 				SELECT z_pk, zmedia, ztypeuti FROM ziccloudsyncingobject
 				WHERE zidentifier = ${imageUuid}`;
 
-			// The page the scan names may not be in the database at all
 			if (!row) return '**Cannot decode scan**';
 
 			// Try to get the nicely cropped version, but fallback to the raw image
-			// if that fails. The cropped copy is often not on disk - Apple writes
-			// it when it feels like it - so the first attempt does not report a
-			// failure: the page is only lost if the raw image fails as well.
+			// if that fails. The cropped copy is often not on disk, so the first
+			// attempt reports nothing: the page is lost only if both fail (#393).
 			let file = await this.ctx.resolveAttachment(row.Z_PK, ANAttachment.Scan, true);
 			if (!file) file = await this.ctx.resolveAttachment(row.ZMEDIA, row.ZTYPEUTI);
 

--- a/src/formats/apple-notes/convert-scan.ts
+++ b/src/formats/apple-notes/convert-scan.ts
@@ -24,11 +24,17 @@ export class ScanConverter extends ANConverter {
 			const imageUuid = object.customMap.mapEntry[0].value.stringValue;
 
 			const row = await this.ctx.database.get`
-				SELECT z_pk, zmedia, ztypeuti FROM ziccloudsyncingobject 
+				SELECT z_pk, zmedia, ztypeuti FROM ziccloudsyncingobject
 				WHERE zidentifier = ${imageUuid}`;
 
-			// Try to get the nicely cropped version, but fallback to the raw image if that fails
-			let file = await this.ctx.resolveAttachment(row.Z_PK, ANAttachment.Scan);
+			// The page the scan names may not be in the database at all
+			if (!row) return '**Cannot decode scan**';
+
+			// Try to get the nicely cropped version, but fallback to the raw image
+			// if that fails. The cropped copy is often not on disk - Apple writes
+			// it when it feels like it - so the first attempt does not report a
+			// failure: the page is only lost if the raw image fails as well.
+			let file = await this.ctx.resolveAttachment(row.Z_PK, ANAttachment.Scan, true);
 			if (!file) file = await this.ctx.resolveAttachment(row.ZMEDIA, row.ZTYPEUTI);
 
 			if (file) {

--- a/src/formats/apple-notes/convert-scan.ts
+++ b/src/formats/apple-notes/convert-scan.ts
@@ -29,9 +29,8 @@ export class ScanConverter extends ANConverter {
 
 			if (!row) return '**Cannot decode scan**';
 
-			// Try to get the nicely cropped version, but fallback to the raw image
-			// if that fails. The cropped copy is often not on disk, so the first
-			// attempt reports nothing: the page is lost only if both fail (#393).
+			// Missing cropped previews are expected. Report a failure only if the
+			// raw image is also unavailable (#393).
 			let file = await this.ctx.resolveAttachment(row.Z_PK, ANAttachment.Scan, true);
 			if (!file) file = await this.ctx.resolveAttachment(row.ZMEDIA, row.ZTYPEUTI);
 

--- a/src/formats/apple-notes/models.ts
+++ b/src/formats/apple-notes/models.ts
@@ -22,6 +22,11 @@ export interface ANContext<F extends ANFile = ANFile> {
 	omitFirstLine: boolean;
 	/** Whether a drawing's transcription is kept as a callout. */
 	includeHandwriting: boolean;
+	/**
+	 * The vault's own setting, which decides what a soft return has to be
+	 * written as: with strict line breaks on, a lone newline is not a break.
+	 */
+	strictLineBreaks: boolean;
 	database: SQLiteTagSpawned;
 
 	/** Gunzip and decode one of the protobufs a note refers to. */

--- a/src/formats/apple-notes/models.ts
+++ b/src/formats/apple-notes/models.ts
@@ -22,10 +22,7 @@ export interface ANContext<F extends ANFile = ANFile> {
 	omitFirstLine: boolean;
 	/** Whether a drawing's transcription is kept as a callout. */
 	includeHandwriting: boolean;
-	/**
-	 * The vault's own setting, which decides what a soft return has to be
-	 * written as: with strict line breaks on, a lone newline is not a break.
-	 */
+	/** With strict line breaks on, a lone newline is not one: see #328. */
 	strictLineBreaks: boolean;
 	database: SQLiteTagSpawned;
 
@@ -33,10 +30,8 @@ export interface ANContext<F extends ANFile = ANFile> {
 	decodeData<T extends ANConverter>(hexdata: string, converterType: ANConverterType<T>): T;
 	/**
 	 * Bring an attachment into the vault, or null if it cannot be read.
-	 *
-	 * `hasFallback` is for a caller with something else to try: the failure is
-	 * still a null, but it is not reported, since the attachment is only lost
-	 * if what comes after fails too.
+	 * `hasFallback` is for a caller with something else to try: still a null,
+	 * but nothing is reported, since only both failing loses the attachment.
 	 */
 	resolveAttachment(id: number, uti: string, hasFallback?: boolean): Promise<F | null>;
 	/** Import a note this one links to, so the link has something to point at. */

--- a/src/formats/apple-notes/models.ts
+++ b/src/formats/apple-notes/models.ts
@@ -22,7 +22,7 @@ export interface ANContext<F extends ANFile = ANFile> {
 	omitFirstLine: boolean;
 	/** Whether a drawing's transcription is kept as a callout. */
 	includeHandwriting: boolean;
-	/** With strict line breaks on, a lone newline is not one: see #328. */
+	/** Whether the vault requires explicit Markdown line breaks. */
 	strictLineBreaks: boolean;
 	database: SQLiteTagSpawned;
 
@@ -30,8 +30,8 @@ export interface ANContext<F extends ANFile = ANFile> {
 	decodeData<T extends ANConverter>(hexdata: string, converterType: ANConverterType<T>): T;
 	/**
 	 * Bring an attachment into the vault, or null if it cannot be read.
-	 * `hasFallback` is for a caller with something else to try: still a null,
-	 * but nothing is reported, since only both failing loses the attachment.
+	 * Suppress reporting when `hasFallback` is true; the caller reports only if
+	 * the fallback also fails.
 	 */
 	resolveAttachment(id: number, uti: string, hasFallback?: boolean): Promise<F | null>;
 	/** Import a note this one links to, so the link has something to point at. */

--- a/src/formats/apple-notes/models.ts
+++ b/src/formats/apple-notes/models.ts
@@ -31,8 +31,14 @@ export interface ANContext<F extends ANFile = ANFile> {
 
 	/** Gunzip and decode one of the protobufs a note refers to. */
 	decodeData<T extends ANConverter>(hexdata: string, converterType: ANConverterType<T>): T;
-	/** Bring an attachment into the vault, or null if it cannot be read. */
-	resolveAttachment(id: number, uti: string): Promise<F | null>;
+	/**
+	 * Bring an attachment into the vault, or null if it cannot be read.
+	 *
+	 * `hasFallback` is for a caller with something else to try: the failure is
+	 * still a null, but it is not reported, since the attachment is only lost
+	 * if what comes after fails too.
+	 */
+	resolveAttachment(id: number, uti: string, hasFallback?: boolean): Promise<F | null>;
 	/** Import a note this one links to, so the link has something to point at. */
 	resolveNote(id: number): Promise<F | null>;
 	/** A link to a file, in whichever form the vault is set to write. */

--- a/src/util.ts
+++ b/src/util.ts
@@ -244,9 +244,12 @@ export function extensionFromBytes(bytes: Uint8Array): string | null {
 	}
 
 	// ISO base media files identify their format with the brand after "ftyp".
+	// Most of those are not video, and naming an image mp4 leaves Obsidian
+	// treating it as one, which does not embed.
 	if (tag(4) === 'ftyp') {
 		const brand = tag(8);
-		if (brand.startsWith('hei') || brand === 'mif1') return 'heic';
+		if (brand.startsWith('avi')) return 'avif';
+		if (brand.startsWith('hei') || brand === 'mif1' || brand === 'msf1') return 'heic';
 		if (brand.startsWith('qt')) return 'mov';
 		return 'mp4';
 	}

--- a/src/util.ts
+++ b/src/util.ts
@@ -220,3 +220,47 @@ export function extractErrorMessage(error: unknown): string | undefined {
 	}
 	return undefined;
 }
+
+/**
+ * The extension a file's own first bytes call for, or null when they say
+ * nothing recognisable.
+ *
+ * A media file can arrive with no extension - one the Evernote web clipper
+ * left behind is a bare uuid - and Obsidian goes by the extension, so the copy
+ * in the vault is a file it will not open and a link that does not resolve.
+ */
+export function extensionFromBytes(bytes: Uint8Array): string | null {
+	const magic = (offset: number, ...signature: number[]) =>
+		signature.every((byte, i) => bytes[offset + i] === byte);
+
+	/** The four characters at an offset, which is how a container names itself. */
+	const tag = (offset: number) =>
+		String.fromCharCode(...bytes.subarray(offset, offset + 4));
+
+	if (magic(0, 0x89, 0x50, 0x4e, 0x47)) return 'png';
+	if (magic(0, 0xff, 0xd8, 0xff)) return 'jpg';
+	if (magic(0, 0x47, 0x49, 0x46, 0x38)) return 'gif';
+	if (magic(0, 0x25, 0x50, 0x44, 0x46)) return 'pdf';
+	if (magic(0, 0x49, 0x49, 0x2a, 0x00) || magic(0, 0x4d, 0x4d, 0x00, 0x2a)) return 'tiff';
+	if (magic(0, 0x42, 0x4d)) return 'bmp';
+	if (magic(0, 0x1f, 0x8b)) return 'gz';
+	if (magic(0, 0x49, 0x44, 0x33)) return 'mp3';
+
+	if (tag(0) === 'RIFF') {
+		if (tag(8) === 'WEBP') return 'webp';
+		if (tag(8) === 'WAVE') return 'wav';
+	}
+
+	// An ISO base media file names its flavour in the brand after "ftyp"
+	if (tag(4) === 'ftyp') {
+		const brand = tag(8);
+		if (brand.startsWith('hei') || brand === 'mif1') return 'heic';
+		if (brand.startsWith('qt')) return 'mov';
+		return 'mp4';
+	}
+
+	// A zip, which is also what every Office document is inside
+	if (magic(0, 0x50, 0x4b, 0x03, 0x04)) return 'zip';
+
+	return null;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -221,19 +221,11 @@ export function extractErrorMessage(error: unknown): string | undefined {
 	return undefined;
 }
 
-/**
- * The extension a file's own first bytes call for, or null when they say
- * nothing recognisable.
- *
- * A media file can arrive with no extension - one the Evernote web clipper
- * left behind is a bare uuid - and Obsidian goes by the extension, so the copy
- * in the vault is a file it will not open and a link that does not resolve.
- */
+/** Infer a common media extension from a file signature. */
 export function extensionFromBytes(bytes: Uint8Array): string | null {
 	const magic = (offset: number, ...signature: number[]) =>
 		signature.every((byte, i) => bytes[offset + i] === byte);
 
-	/** The four characters at an offset, which is how a container names itself. */
 	const tag = (offset: number) =>
 		String.fromCharCode(...bytes.subarray(offset, offset + 4));
 
@@ -251,7 +243,7 @@ export function extensionFromBytes(bytes: Uint8Array): string | null {
 		if (tag(8) === 'WAVE') return 'wav';
 	}
 
-	// An ISO base media file names its flavour in the brand after "ftyp"
+	// ISO base media files identify their format with the brand after "ftyp".
 	if (tag(4) === 'ftyp') {
 		const brand = tag(8);
 		if (brand.startsWith('hei') || brand === 'mif1') return 'heic';
@@ -259,7 +251,7 @@ export function extensionFromBytes(bytes: Uint8Array): string | null {
 		return 'mp4';
 	}
 
-	// A zip, which is also what every Office document is inside
+	// Office documents share ZIP's signature, so leave them as ZIP archives.
 	if (magic(0, 0x50, 0x4b, 0x03, 0x04)) return 'zip';
 
 	return null;

--- a/tests/apple-notes/attachments.test.ts
+++ b/tests/apple-notes/attachments.test.ts
@@ -183,8 +183,10 @@ test('an attachment that is at neither path says where it looked', async () => {
 		assert.equal(body.match(/\*\*\(error reading attachment\)\*\*/g)?.length, 1);
 
 		assert.deepEqual(run.skipped, [], 'the drawing was rendered, so this is a failure');
-		assert.equal(run.failed.length, 1);
-		assert.match(String(run.reasons[0]), /not found at .*Accounts.*FallbackImages/);
+
+		// Named after the note it is in, since that is what the user can open
+		assert.deepEqual(run.failed, ['Drawing in Sketch']);
+		assert.match(String(run.reasons[0]), /^there is no file at .*Accounts.*FallbackImages/);
 		assert.match(String(run.reasons[0]), / or .*group\.com\.apple\.notes\/FallbackImages/);
 	}
 	finally {
@@ -208,8 +210,13 @@ test('a drawing that was never downloaded is skipped, not failed', async () => {
 
 		assert.ok(note, 'the note should be imported');
 		assert.deepEqual(run.failed, [], 'there is no file to have failed to read');
-		assert.deepEqual(run.skipped, ['Drawing', 'Drawing', 'Drawing']);
-		assert.deepEqual([...new Set(run.reasons)], ['not downloaded from iCloud']);
+		assert.deepEqual(run.skipped, ['Drawing in Sketches', 'Drawing in Sketches', 'Drawing in Sketches']);
+
+		// The log reads "Skipped: <name> because <reason>", so the reason has
+		// to carry on from the because, and say what to do about it
+		assert.deepEqual([...new Set(run.reasons)], [
+			'it has not been downloaded from iCloud - open the note in Apple Notes to fetch it',
+		]);
 	}
 	finally {
 		run.close();

--- a/tests/apple-notes/attachments.test.ts
+++ b/tests/apple-notes/attachments.test.ts
@@ -31,6 +31,13 @@ import { buildStore, StoreSpec } from './store';
 
 provideNodeModules({ fs: nodeFs as never, os: nodeOs, path: nodePath, zlib: nodeZlib });
 
+/** A one-pixel PNG, so what is written is something a sniffer could recognise. */
+const PNG_BYTES = Buffer.from(
+	'89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000a4944415478' +
+	'9c6300010000050001' + '0d0a2db4' + '0000000049454e44ae426082',
+	'hex'
+);
+
 /** One drawing per UTI Apple has used for one, all in a single note. */
 const DRAWINGS: StoreSpec = {
 	notes: [{
@@ -67,6 +74,13 @@ async function importing(spec: StoreSpec, writeFiles = true) {
 	if (writeFiles) {
 		for (const attachment of spec.attachments ?? []) {
 			nodeFs.writeFileSync(nodePath.join(account, 'FallbackImages', `${attachment.identifier}.jpg`), attachment.identifier);
+		}
+
+		// A media attachment is read from Media/<media uuid>//<file name>
+		for (const [identifier, name] of store.mediaFiles) {
+			const into = nodePath.join(account, 'Media', identifier, '');
+			nodeFs.mkdirSync(into, { recursive: true });
+			nodeFs.writeFileSync(nodePath.join(into, name), PNG_BYTES);
 		}
 	}
 
@@ -136,6 +150,42 @@ test('a note keeps its text when an attachment it points at is gone', async () =
 		const body = String(run.vault.contents.get(note.path));
 		assert.ok(body.contains('Text that should survive.'), `the note is empty: ${JSON.stringify(body)}`);
 		assert.equal(run.failed.length, 1, 'the attachment is what failed, and it is reported');
+	}
+	finally {
+		run.close();
+	}
+});
+
+/**
+ * A media file whose name carries no extension, which the Evernote web clipper
+ * leaves behind: a bare uuid. Obsidian goes by the extension, so the copy in
+ * the vault is a file it will not open and the link does not resolve (#471.1).
+ */
+const NO_EXTENSION: StoreSpec = {
+	notes: [{
+		title: 'Clipped',
+		runs: [
+			{ text: 'Clipped\n' },
+			{ text: '', attachment: { identifier: 'CLIP-1', uti: 'public.png' } },
+		],
+	}],
+	attachments: [{
+		identifier: 'CLIP-1', uti: 'public.png', note: 0,
+		mediaFilename: '0A32B83C-3BCC-4F65-B77D-B2EA8D76B37B',
+	}],
+};
+
+test('a media file with no extension is named for what it holds', async () => {
+	const run = await importing(NO_EXTENSION);
+
+	try {
+		const note = await run.resolve(run.notePks[0]);
+
+		assert.ok(note, 'the note should be imported');
+		assert.deepEqual(run.failed, [], 'nothing should have failed');
+		assert.deepEqual(run.vault.paths(), [
+			'Clipped.md', '0A32B83C-3BCC-4F65-B77D-B2EA8D76B37B.png',
+		]);
 	}
 	finally {
 		run.close();

--- a/tests/apple-notes/attachments.test.ts
+++ b/tests/apple-notes/attachments.test.ts
@@ -102,6 +102,48 @@ async function importing(spec: StoreSpec) {
 	};
 }
 
+/**
+ * A file attachment whose media row is not there.
+ *
+ * resolveAttachment reads a column off whatever the lookup returned, without
+ * checking that it returned anything. A note pointing at a row that is gone -
+ * an attachment iCloud has not brought down, say - throws "Cannot read
+ * properties of undefined (reading 'ZIDENTIFIER')" (#218).
+ *
+ * The note is worse off than the attachment: its file is created empty before
+ * the conversion runs, so a throw leaves it in the vault with nothing in it
+ * (#391). One bad attachment should cost that attachment, not the note.
+ */
+const MISSING_MEDIA: StoreSpec = {
+	notes: [{
+		title: 'Holiday',
+		runs: [
+			{ text: 'Holiday\n' },
+			{ text: 'Text that should survive.\n' },
+			{ text: '', attachment: { identifier: 'PHOTO-1', uti: 'public.jpeg' } },
+		],
+	}],
+	// ZMEDIA points at a primary key no ICMedia row was written for
+	attachments: [{ identifier: 'PHOTO-1', uti: 'public.jpeg', media: 9999, note: 0 }],
+};
+
+test('a note keeps its text when an attachment it points at is gone', async () => {
+	const run = await importing(MISSING_MEDIA);
+
+	try {
+		const note = await run.resolve(run.notePks[0]);
+
+		assert.ok(note, 'the note should be imported');
+
+		const body = String(run.vault.contents.get(note.path));
+		assert.ok(body.contains('Text that should survive.'), `the note is empty: ${JSON.stringify(body)}`);
+		assert.equal(run.failed.length, 1, 'the attachment is what failed, and it is reported');
+	}
+	finally {
+		run.close();
+	}
+});
+
 test('a drawing is imported whichever UTI it carries', async () => {
 	const run = await importing(DRAWINGS);
 	try {

--- a/tests/apple-notes/attachments.test.ts
+++ b/tests/apple-notes/attachments.test.ts
@@ -10,9 +10,11 @@ import * as nodeZlib from 'node:zlib';
 import { Root } from 'protobufjs';
 
 import { provideNodeModules } from '../../src/filesystem';
+import { DuplicateHandling } from '../../src/format-importer';
 import { AppleNotesImporter } from '../../src/formats/apple-notes';
 import { descriptor } from '../../src/formats/apple-notes/descriptor';
 import { ANAttachment } from '../../src/formats/apple-notes/models';
+import { TFile } from '../shims/obsidian';
 import { MemoryVault, memoryApp } from '../shims/vault';
 import { buildStore, StoreSpec } from './store';
 
@@ -66,33 +68,46 @@ async function importing(spec: StoreSpec, writeFiles = true) {
 
 	const vault = new MemoryVault();
 	const failed: string[] = [];
-	const subject = new AppleNotesImporter(memoryApp(vault), { sourceEl: null, optionsEl: null } as never);
-
 	const skipped: string[] = [];
 	const reasons: (string | undefined)[] = [];
-	subject.ctx = {
-		isCancelled: () => false,
-		shouldStop: async () => false,
-		status: () => {},
-		reportProgress: () => {},
-		reportNoteSuccess: () => {},
-		reportAttachmentSuccess: () => {},
-		reportSkipped: (name: string, reason?: string) => { skipped.push(name); reasons.push(reason); },
-		reportFailed: (name: string, reason?: string) => { failed.push(name); reasons.push(reason); },
-	} as never;
-	subject.vault = vault as never;
-	subject.rootFolder = vault.root;
-	subject.protobufRoot = Root.fromJSON(descriptor);
-	subject.keys = Object.fromEntries(
+	const keys = Object.fromEntries(
 		(await store.database.all`SELECT z_ent, z_name FROM z_primarykey`).map(k => [k.Z_NAME, k.Z_ENT])
 	);
-	subject.database = store.database;
-	subject.resolvedAccounts = { 1: { name: 'Test account', uuid: 'ACCOUNT-1', path: account } };
-	subject.owners = { [store.folderPk]: 1 };
+
+	// One importer per run over the same vault, so a second run sees what the
+	// first one wrote - which is what duplicate handling reads
+	const run = (mode = DuplicateHandling.CreateCopy) => {
+		const subject = new AppleNotesImporter(memoryApp(vault), { sourceEl: null, optionsEl: null } as never);
+
+		subject.ctx = {
+			isCancelled: () => false,
+			shouldStop: async () => false,
+			status: () => {},
+			reportProgress: () => {},
+			reportNoteSuccess: () => {},
+			reportAttachmentSuccess: () => {},
+			reportSkipped: (name: string, reason?: string) => { skipped.push(name); reasons.push(reason); },
+			reportFailed: (name: string, reason?: string) => { failed.push(name); reasons.push(reason); },
+		} as never;
+		subject.vault = vault as never;
+		subject.rootFolder = vault.root;
+		subject.protobufRoot = Root.fromJSON(descriptor);
+		subject.keys = keys;
+		subject.duplicateHandling = mode;
+		subject.database = store.database;
+		subject.resolvedAccounts = { 1: { name: 'Test account', uuid: 'ACCOUNT-1', path: account } };
+		subject.owners = { [store.folderPk]: 1 };
+
+		return (pk: number) => subject.resolveNote(pk);
+	};
+
+	const first = run();
 
 	return {
 		vault, failed, skipped, reasons, notePks: store.notePks,
-		resolve: (pk: number) => subject.resolveNote(pk),
+		resolve: (pk: number) => first(pk),
+		/** A later import into the same vault, as a second run of the importer. */
+		reimport: (mode: DuplicateHandling) => run(mode),
 		close: () => {
 			store.close();
 			nodeFs.rmSync(dir, { recursive: true, force: true });
@@ -154,6 +169,64 @@ test('a media file with no extension is named for what it holds', async () => {
 
 		assert.ok(note, 'the note should be imported');
 		assert.deepEqual(run.failed, [], 'nothing should have failed');
+		assert.deepEqual(run.vault.paths(), [
+			'Clipped.md', '0A32B83C-3BCC-4F65-B77D-B2EA8D76B37B.png',
+		]);
+	}
+	finally {
+		run.close();
+	}
+});
+
+/** A media row that is there but carries no name for the file. */
+const NULL_FILENAME: StoreSpec = {
+	notes: [{
+		title: 'Holiday',
+		runs: [
+			{ text: 'Holiday\n' },
+			{ text: 'Text that should survive.\n' },
+			{ text: '', attachment: { identifier: 'PHOTO-2', uti: 'public.jpeg' } },
+		],
+	}],
+	attachments: [{ identifier: 'PHOTO-2', uti: 'public.jpeg', note: 0, mediaFilename: null }],
+};
+
+test('a note keeps its text when a media row carries no file name', async () => {
+	const run = await importing(NULL_FILENAME);
+
+	try {
+		const note = await run.resolve(run.notePks[0]);
+
+		assert.ok(note, 'the note should be imported');
+
+		const body = String(run.vault.contents.get(note.path));
+		assert.ok(body.contains('Text that should survive.'), `the note is empty: ${JSON.stringify(body)}`);
+		assert.equal(run.failed.length, 1);
+	}
+	finally {
+		run.close();
+	}
+});
+
+test('an extensionless attachment is recognised again on a later import', async () => {
+	const run = await importing(NO_EXTENSION);
+
+	try {
+		await run.resolve(run.notePks[0]);
+		assert.deepEqual(run.vault.paths(), [
+			'Clipped.md', '0A32B83C-3BCC-4F65-B77D-B2EA8D76B37B.png',
+		]);
+
+		// Age the note so the second run reimports it rather than skipping it,
+		// which is what brings the attachment back through resolveAttachment
+		const note = run.vault.getAbstractFileByPath('Clipped.md');
+		assert.ok(note instanceof TFile);
+		note.stat.mtime = 0;
+
+		// The attachment is already there under the name its bytes gave it, so
+		// no second copy is written
+		await run.reimport(DuplicateHandling.ImportUpdated)(run.notePks[0]);
+
 		assert.deepEqual(run.vault.paths(), [
 			'Clipped.md', '0A32B83C-3BCC-4F65-B77D-B2EA8D76B37B.png',
 		]);

--- a/tests/apple-notes/attachments.test.ts
+++ b/tests/apple-notes/attachments.test.ts
@@ -1,16 +1,3 @@
-/**
- * A drawing, from a note that carries one, into the vault.
- *
- * Apple has used three UTIs for a drawing: com.apple.drawing, its .2 successor,
- * and com.apple.paper. The converter has known all three since #183, and it
- * hands each of them to resolveAttachment - which knew only the newest, so an
- * older one fell through to the branch for a file attachment, found no media
- * row at that key, and threw reading a column of the row that was not there.
- * The note it was in failed with it.
- *
- * The drawings here are made up, and so is the account directory they are read
- * from: what is being checked is that all three UTIs take the same path out.
- */
 import '../shims/runtime';
 
 import { test } from 'node:test';
@@ -31,14 +18,13 @@ import { buildStore, StoreSpec } from './store';
 
 provideNodeModules({ fs: nodeFs as never, os: nodeOs, path: nodePath, zlib: nodeZlib });
 
-/** A one-pixel PNG, so what is written is something a sniffer could recognise. */
+/** Minimal PNG used to test file-signature detection. */
 const PNG_BYTES = Buffer.from(
 	'89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000a4944415478' +
 	'9c6300010000050001' + '0d0a2db4' + '0000000049454e44ae426082',
 	'hex'
 );
 
-/** One drawing per UTI Apple has used for one, all in a single note. */
 const DRAWINGS: StoreSpec = {
 	notes: [{
 		title: 'Sketches',
@@ -58,17 +44,12 @@ const DRAWINGS: StoreSpec = {
 	],
 };
 
-/**
- * An importer pointed at a built database and an account directory holding the
- * drawings, ready for resolveNote. See duplicates.test.ts: import() would ask
- * for a folder through a dialog, so what it sets up is set up here.
- */
+/** Build an importer with a fixture database and attachment directory. */
 async function importing(spec: StoreSpec, writeFiles = true) {
 	const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'importer-apple-notes-'));
 	const store = buildStore(nodePath.join(dir, 'NoteStore.sqlite'), spec);
 
-	// Where Apple keeps the rendered copy of a drawing, which is what the
-	// importer reads: no generation directory, since none of these have one
+	// Mirror Apple's attachment directory under the owning account.
 	const account = nodePath.join(dir, 'Accounts', 'ACCOUNT-1');
 	nodeFs.mkdirSync(nodePath.join(account, 'FallbackImages'), { recursive: true });
 	if (writeFiles) {
@@ -76,7 +57,6 @@ async function importing(spec: StoreSpec, writeFiles = true) {
 			nodeFs.writeFileSync(nodePath.join(account, 'FallbackImages', `${attachment.identifier}.jpg`), attachment.identifier);
 		}
 
-		// A media attachment is read from Media/<media uuid>//<file name>
 		for (const [identifier, name] of store.mediaFiles) {
 			const into = nodePath.join(account, 'Media', identifier, '');
 			nodeFs.mkdirSync(into, { recursive: true });
@@ -120,12 +100,6 @@ async function importing(spec: StoreSpec, writeFiles = true) {
 	};
 }
 
-/**
- * A file attachment whose media row is not there, which threw reading a column
- * off the row that was not returned (#218). The note's file is created empty
- * before the conversion runs, so that left it in the vault with nothing in it
- * (#391): one bad attachment should cost the attachment, not the note.
- */
 const MISSING_MEDIA: StoreSpec = {
 	notes: [{
 		title: 'Holiday',
@@ -135,7 +109,8 @@ const MISSING_MEDIA: StoreSpec = {
 			{ text: '', attachment: { identifier: 'PHOTO-1', uti: 'public.jpeg' } },
 		],
 	}],
-	// ZMEDIA points at a primary key no ICMedia row was written for
+	// Reproduce #218 with a ZMEDIA key that has no ICMedia row. The note body
+	// must still survive (#391).
 	attachments: [{ identifier: 'PHOTO-1', uti: 'public.jpeg', media: 9999, note: 0 }],
 };
 
@@ -156,11 +131,7 @@ test('a note keeps its text when an attachment it points at is gone', async () =
 	}
 });
 
-/**
- * A media file whose name carries no extension, which the Evernote web clipper
- * leaves behind: a bare uuid. Obsidian goes by the extension, so the copy in
- * the vault is a file it will not open and the link does not resolve (#471.1).
- */
+/** Evernote clips can leave media named with a bare UUID (#471.1). */
 const NO_EXTENSION: StoreSpec = {
 	notes: [{
 		title: 'Clipped',
@@ -192,7 +163,6 @@ test('a media file with no extension is named for what it holds', async () => {
 	}
 });
 
-/** A drawing Apple has rendered, whose copy is not where the row says it is. */
 const RENDERED: StoreSpec = {
 	notes: [{
 		title: 'Sketch',
@@ -207,11 +177,6 @@ const RENDERED: StoreSpec = {
 	}],
 };
 
-/**
- * A file that should have been there. It is read from under the account that
- * owns it and from the container, and naming only the second in the failure
- * reads as though the first was never tried.
- */
 test('an attachment that is at neither path says where it looked', async () => {
 	const run = await importing(RENDERED, false);
 
@@ -220,7 +185,6 @@ test('an attachment that is at neither path says where it looked', async () => {
 
 		assert.ok(note, 'the note should be imported');
 
-		// The conversion ran to the end rather than throwing part way through
 		const body = String(run.vault.contents.get(note.path));
 		assert.equal(body.match(/\*\*\(error reading attachment\)\*\*/g)?.length, 1);
 
@@ -234,11 +198,6 @@ test('an attachment that is at neither path says where it looked', async () => {
 	}
 });
 
-/**
- * A drawing this Mac never had: nothing rendered, no drawing data, and no size
- * Notes ever learned. Nothing was lost that was ever here and no path is worth
- * printing, so it is skipped rather than reported as a failure to look into.
- */
 test('a drawing that was never downloaded is skipped, not failed', async () => {
 	const run = await importing(DRAWINGS, false);
 
@@ -249,7 +208,6 @@ test('a drawing that was never downloaded is skipped, not failed', async () => {
 		assert.deepEqual(run.failed, [], 'there is no file to have failed to read');
 		assert.deepEqual(run.skipped, ['Drawing in Sketches', 'Drawing in Sketches', 'Drawing in Sketches']);
 
-		// The log reads: Skipped: "<name>" because <reason>
 		assert.deepEqual([...new Set(run.reasons)], [
 			'it has not been downloaded from iCloud - open the note in Apple Notes to fetch it',
 		]);
@@ -266,15 +224,12 @@ test('a drawing is imported whichever UTI it carries', async () => {
 		assert.ok(note, 'the note should be imported');
 		assert.deepEqual(run.failed, [], 'nothing should have failed');
 
-		// One file per drawing, each linked from the note it came out of
 		const drawings = run.vault.paths().filter(path => path.endsWith('.png'));
 		assert.deepEqual(drawings, ['Drawing.png', 'Drawing 1.png', 'Drawing 2.png']);
 
 		const body = String(run.vault.contents.get(note.path));
 		for (const drawing of drawings) assert.ok(body.includes(`![[${drawing}]]`), `${drawing} is not linked`);
 
-		// Read from the account directory rather than made up: each file holds
-		// what was written under the identifier the row carries
 		const held = (path: string) => Buffer.from(run.vault.contents.get(path) as ArrayBuffer).toString();
 		assert.equal(held('Drawing.png'), 'DRAWING-PAPER');
 		assert.equal(held('Drawing 1.png'), 'DRAWING-LEGACY');

--- a/tests/apple-notes/attachments.test.ts
+++ b/tests/apple-notes/attachments.test.ts
@@ -56,7 +56,7 @@ const DRAWINGS: StoreSpec = {
  * drawings, ready for resolveNote. See duplicates.test.ts: import() would ask
  * for a folder through a dialog, so what it sets up is set up here.
  */
-async function importing(spec: StoreSpec) {
+async function importing(spec: StoreSpec, writeFiles = true) {
 	const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'importer-apple-notes-'));
 	const store = buildStore(nodePath.join(dir, 'NoteStore.sqlite'), spec);
 
@@ -64,14 +64,17 @@ async function importing(spec: StoreSpec) {
 	// importer reads: no generation directory, since none of these have one
 	const account = nodePath.join(dir, 'Accounts', 'ACCOUNT-1');
 	nodeFs.mkdirSync(nodePath.join(account, 'FallbackImages'), { recursive: true });
-	for (const attachment of spec.attachments ?? []) {
-		nodeFs.writeFileSync(nodePath.join(account, 'FallbackImages', `${attachment.identifier}.jpg`), attachment.identifier);
+	if (writeFiles) {
+		for (const attachment of spec.attachments ?? []) {
+			nodeFs.writeFileSync(nodePath.join(account, 'FallbackImages', `${attachment.identifier}.jpg`), attachment.identifier);
+		}
 	}
 
 	const vault = new MemoryVault();
 	const failed: string[] = [];
 	const subject = new AppleNotesImporter(memoryApp(vault), { sourceEl: null, optionsEl: null } as never);
 
+	const reasons: (string | undefined)[] = [];
 	subject.ctx = {
 		isCancelled: () => false,
 		shouldStop: async () => false,
@@ -80,7 +83,7 @@ async function importing(spec: StoreSpec) {
 		reportNoteSuccess: () => {},
 		reportAttachmentSuccess: () => {},
 		reportSkipped: (name: string) => failed.push(name),
-		reportFailed: (name: string) => failed.push(name),
+		reportFailed: (name: string, reason?: string) => { failed.push(name); reasons.push(reason); },
 	} as never;
 	subject.vault = vault as never;
 	subject.rootFolder = vault.root;
@@ -93,7 +96,7 @@ async function importing(spec: StoreSpec) {
 	subject.owners = { [store.folderPk]: 1 };
 
 	return {
-		vault, failed, notePks: store.notePks,
+		vault, failed, reasons, notePks: store.notePks,
 		resolve: (pk: number) => subject.resolveNote(pk),
 		close: () => {
 			store.close();
@@ -138,6 +141,35 @@ test('a note keeps its text when an attachment it points at is gone', async () =
 		const body = String(run.vault.contents.get(note.path));
 		assert.ok(body.contains('Text that should survive.'), `the note is empty: ${JSON.stringify(body)}`);
 		assert.equal(run.failed.length, 1, 'the attachment is what failed, and it is reported');
+	}
+	finally {
+		run.close();
+	}
+});
+
+/**
+ * A drawing Apple has not rendered a copy of.
+ *
+ * It is read from under the account that owns it, and from the container for
+ * the older ones that predate accounts being kept apart. Reporting only the
+ * second reads as though the first was never tried, which is what the ENOENT
+ * from a failed import looked like.
+ */
+test('an attachment that is at neither path says so', async () => {
+	const run = await importing(DRAWINGS, false);
+
+	try {
+		const note = await run.resolve(run.notePks[0]);
+
+		assert.ok(note, 'the note should be imported');
+
+		// The conversion ran to the end rather than throwing part way through it
+		const body = String(run.vault.contents.get(note.path));
+		assert.equal(body.match(/\*\*\(error reading attachment\)\*\*/g)?.length, 3);
+
+		assert.equal(run.failed.length, 3, 'one failure per drawing');
+		assert.match(String(run.reasons[0]), /not found at .*Accounts.*FallbackImages/);
+		assert.match(String(run.reasons[0]), / or .*group\.com\.apple\.notes\/FallbackImages/);
 	}
 	finally {
 		run.close();

--- a/tests/apple-notes/attachments.test.ts
+++ b/tests/apple-notes/attachments.test.ts
@@ -105,6 +105,8 @@ async function importing(spec: StoreSpec, writeFiles = true) {
 
 	return {
 		vault, failed, skipped, reasons, notePks: store.notePks,
+		/** Where the source files are, so a test can take one away. */
+		account,
 		resolve: (pk: number) => first(pk),
 		/** A later import into the same vault, as a second run of the importer. */
 		reimport: (mode: DuplicateHandling) => run(mode),
@@ -230,6 +232,49 @@ test('an extensionless attachment is recognised again on a later import', async 
 		assert.deepEqual(run.vault.paths(), [
 			'Clipped.md', '0A32B83C-3BCC-4F65-B77D-B2EA8D76B37B.png',
 		]);
+	}
+	finally {
+		run.close();
+	}
+});
+
+/** An attachment whose name already says what it is. */
+const NAMED_MEDIA: StoreSpec = {
+	notes: [{
+		title: 'Trip',
+		runs: [
+			{ text: 'Trip\n' },
+			{ text: '', attachment: { identifier: 'PHOTO-3', uti: 'public.png' } },
+		],
+	}],
+	attachments: [{ identifier: 'PHOTO-3', uti: 'public.png', note: 0, mediaFilename: 'photo.png' }],
+};
+
+/**
+ * Apple can take the source file back - offloaded, or the note edited on
+ * another device - while the copy this vault already holds is still good. The
+ * attachment is already known by name, so it is reused rather than re-read.
+ */
+test('an attachment already in the vault survives its source going away', async () => {
+	const run = await importing(NAMED_MEDIA);
+
+	try {
+		await run.resolve(run.notePks[0]);
+		assert.deepEqual(run.vault.paths(), ['Trip.md', 'photo.png']);
+
+		nodeFs.rmSync(nodePath.join(run.account, 'Media'), { recursive: true, force: true });
+
+		const note = run.vault.getAbstractFileByPath('Trip.md');
+		assert.ok(note instanceof TFile);
+		note.stat.mtime = 0;
+
+		await run.reimport(DuplicateHandling.ImportUpdated)(run.notePks[0]);
+
+		assert.deepEqual(run.failed, [], 'the vault still has the attachment');
+		assert.ok(
+			String(run.vault.contents.get('Trip.md')).contains('photo.png'),
+			`the link was replaced: ${JSON.stringify(run.vault.contents.get('Trip.md'))}`
+		);
 	}
 	finally {
 		run.close();

--- a/tests/apple-notes/attachments.test.ts
+++ b/tests/apple-notes/attachments.test.ts
@@ -107,16 +107,10 @@ async function importing(spec: StoreSpec, writeFiles = true) {
 }
 
 /**
- * A file attachment whose media row is not there.
- *
- * resolveAttachment reads a column off whatever the lookup returned, without
- * checking that it returned anything. A note pointing at a row that is gone -
- * an attachment iCloud has not brought down, say - throws "Cannot read
- * properties of undefined (reading 'ZIDENTIFIER')" (#218).
- *
- * The note is worse off than the attachment: its file is created empty before
- * the conversion runs, so a throw leaves it in the vault with nothing in it
- * (#391). One bad attachment should cost that attachment, not the note.
+ * A file attachment whose media row is not there, which threw reading a column
+ * off the row that was not returned (#218). The note's file is created empty
+ * before the conversion runs, so that left it in the vault with nothing in it
+ * (#391): one bad attachment should cost the attachment, not the note.
  */
 const MISSING_MEDIA: StoreSpec = {
 	notes: [{
@@ -164,11 +158,9 @@ const RENDERED: StoreSpec = {
 };
 
 /**
- * A file that should have been there.
- *
- * It is read from under the account that owns it, and from the container for
- * the older ones that predate accounts being kept apart. Naming only the
- * second reads as though the first was never tried.
+ * A file that should have been there. It is read from under the account that
+ * owns it and from the container, and naming only the second in the failure
+ * reads as though the first was never tried.
  */
 test('an attachment that is at neither path says where it looked', async () => {
 	const run = await importing(RENDERED, false);
@@ -178,13 +170,11 @@ test('an attachment that is at neither path says where it looked', async () => {
 
 		assert.ok(note, 'the note should be imported');
 
-		// The conversion ran to the end rather than throwing part way through it
+		// The conversion ran to the end rather than throwing part way through
 		const body = String(run.vault.contents.get(note.path));
 		assert.equal(body.match(/\*\*\(error reading attachment\)\*\*/g)?.length, 1);
 
 		assert.deepEqual(run.skipped, [], 'the drawing was rendered, so this is a failure');
-
-		// Named after the note it is in, since that is what the user can open
 		assert.deepEqual(run.failed, ['Drawing in Sketch']);
 		assert.match(String(run.reasons[0]), /^there is no file at .*Accounts.*FallbackImages/);
 		assert.match(String(run.reasons[0]), / or .*group\.com\.apple\.notes\/FallbackImages/);
@@ -195,12 +185,9 @@ test('an attachment that is at neither path says where it looked', async () => {
 });
 
 /**
- * A drawing this Mac never had.
- *
- * Nothing rendered, no drawing data, and a size Notes never learned: the note
- * refers to a drawing that only exists in iCloud. Nothing was lost that was
- * ever here, and no path is worth printing, so it is skipped rather than
- * reported as a failure the user could go and look into.
+ * A drawing this Mac never had: nothing rendered, no drawing data, and no size
+ * Notes ever learned. Nothing was lost that was ever here and no path is worth
+ * printing, so it is skipped rather than reported as a failure to look into.
  */
 test('a drawing that was never downloaded is skipped, not failed', async () => {
 	const run = await importing(DRAWINGS, false);
@@ -212,8 +199,7 @@ test('a drawing that was never downloaded is skipped, not failed', async () => {
 		assert.deepEqual(run.failed, [], 'there is no file to have failed to read');
 		assert.deepEqual(run.skipped, ['Drawing in Sketches', 'Drawing in Sketches', 'Drawing in Sketches']);
 
-		// The log reads "Skipped: <name> because <reason>", so the reason has
-		// to carry on from the because, and say what to do about it
+		// The log reads: Skipped: "<name>" because <reason>
 		assert.deepEqual([...new Set(run.reasons)], [
 			'it has not been downloaded from iCloud - open the note in Apple Notes to fetch it',
 		]);

--- a/tests/apple-notes/attachments.test.ts
+++ b/tests/apple-notes/attachments.test.ts
@@ -74,6 +74,7 @@ async function importing(spec: StoreSpec, writeFiles = true) {
 	const failed: string[] = [];
 	const subject = new AppleNotesImporter(memoryApp(vault), { sourceEl: null, optionsEl: null } as never);
 
+	const skipped: string[] = [];
 	const reasons: (string | undefined)[] = [];
 	subject.ctx = {
 		isCancelled: () => false,
@@ -82,7 +83,7 @@ async function importing(spec: StoreSpec, writeFiles = true) {
 		reportProgress: () => {},
 		reportNoteSuccess: () => {},
 		reportAttachmentSuccess: () => {},
-		reportSkipped: (name: string) => failed.push(name),
+		reportSkipped: (name: string, reason?: string) => { skipped.push(name); reasons.push(reason); },
 		reportFailed: (name: string, reason?: string) => { failed.push(name); reasons.push(reason); },
 	} as never;
 	subject.vault = vault as never;
@@ -96,7 +97,7 @@ async function importing(spec: StoreSpec, writeFiles = true) {
 	subject.owners = { [store.folderPk]: 1 };
 
 	return {
-		vault, failed, reasons, notePks: store.notePks,
+		vault, failed, skipped, reasons, notePks: store.notePks,
 		resolve: (pk: number) => subject.resolveNote(pk),
 		close: () => {
 			store.close();
@@ -147,16 +148,30 @@ test('a note keeps its text when an attachment it points at is gone', async () =
 	}
 });
 
+/** A drawing Apple has rendered, whose copy is not where the row says it is. */
+const RENDERED: StoreSpec = {
+	notes: [{
+		title: 'Sketch',
+		runs: [
+			{ text: 'Sketch\n' },
+			{ text: '', attachment: { identifier: 'DRAWING-1', uti: ANAttachment.DrawingLegacy2 } },
+		],
+	}],
+	attachments: [{
+		identifier: 'DRAWING-1', uti: ANAttachment.DrawingLegacy2, note: 0,
+		fallbackImageGeneration: '1_FF5E5DAE', size: { width: 1536, height: 836 },
+	}],
+};
+
 /**
- * A drawing Apple has not rendered a copy of.
+ * A file that should have been there.
  *
  * It is read from under the account that owns it, and from the container for
- * the older ones that predate accounts being kept apart. Reporting only the
- * second reads as though the first was never tried, which is what the ENOENT
- * from a failed import looked like.
+ * the older ones that predate accounts being kept apart. Naming only the
+ * second reads as though the first was never tried.
  */
-test('an attachment that is at neither path says so', async () => {
-	const run = await importing(DRAWINGS, false);
+test('an attachment that is at neither path says where it looked', async () => {
+	const run = await importing(RENDERED, false);
 
 	try {
 		const note = await run.resolve(run.notePks[0]);
@@ -165,11 +180,36 @@ test('an attachment that is at neither path says so', async () => {
 
 		// The conversion ran to the end rather than throwing part way through it
 		const body = String(run.vault.contents.get(note.path));
-		assert.equal(body.match(/\*\*\(error reading attachment\)\*\*/g)?.length, 3);
+		assert.equal(body.match(/\*\*\(error reading attachment\)\*\*/g)?.length, 1);
 
-		assert.equal(run.failed.length, 3, 'one failure per drawing');
+		assert.deepEqual(run.skipped, [], 'the drawing was rendered, so this is a failure');
+		assert.equal(run.failed.length, 1);
 		assert.match(String(run.reasons[0]), /not found at .*Accounts.*FallbackImages/);
 		assert.match(String(run.reasons[0]), / or .*group\.com\.apple\.notes\/FallbackImages/);
+	}
+	finally {
+		run.close();
+	}
+});
+
+/**
+ * A drawing this Mac never had.
+ *
+ * Nothing rendered, no drawing data, and a size Notes never learned: the note
+ * refers to a drawing that only exists in iCloud. Nothing was lost that was
+ * ever here, and no path is worth printing, so it is skipped rather than
+ * reported as a failure the user could go and look into.
+ */
+test('a drawing that was never downloaded is skipped, not failed', async () => {
+	const run = await importing(DRAWINGS, false);
+
+	try {
+		const note = await run.resolve(run.notePks[0]);
+
+		assert.ok(note, 'the note should be imported');
+		assert.deepEqual(run.failed, [], 'there is no file to have failed to read');
+		assert.deepEqual(run.skipped, ['Drawing', 'Drawing', 'Drawing']);
+		assert.deepEqual([...new Set(run.reasons)], ['not downloaded from iCloud']);
 	}
 	finally {
 		run.close();

--- a/tests/apple-notes/convert.test.ts
+++ b/tests/apple-notes/convert.test.ts
@@ -44,7 +44,6 @@ const FIXTURES = __dirname;
 
 const protobufRoot = Root.fromJSON(descriptor);
 
-/** What Shift-Return puts in the text: a line separator, not a paragraph end. */
 const SOFT_RETURN = '\u2028';
 
 /**
@@ -211,11 +210,9 @@ const STORE: StoreSpec = {
 				{ text: 'linked', link: 'https://example.com', emphasis: 3 },
 			],
 		},
-		// Last, so adding it leaves the primary keys the notes above were given:
-		// an internal link is recorded as the key it points at
+		// Keep this last because internal links store the target note's generated
+		// primary key.
 		{
-			// A soft return breaks the line without starting a new bullet, so it
-			// has to survive as a break rather than as the literal character
 			title: 'Soft returns',
 			runs: [
 				{ text: 'Soft returns\n', style: ANStyleType.Title },
@@ -285,11 +282,6 @@ test('keeps the first line when asked to', async () => {
 	}
 });
 
-/**
- * The title is the first line with anything on it, so a note starting with
- * blank lines has it further down. Omitting "the first line" omitted a blank
- * one and left the title in the body as well as in the file name.
- */
 test('a note starting with blank lines does not repeat its title', async () => {
 	const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'importer-apple-notes-'));
 	const store = buildStore(nodePath.join(dir, 'NoteStore.sqlite'), { notes: [] });
@@ -314,10 +306,6 @@ test('a note starting with blank lines does not repeat its title', async () => {
 	}
 });
 
-/**
- * A newline is the break a soft return meant, until the vault turns strict
- * line breaks on and it stops being one. Then it is spelled out.
- */
 test('a soft return is spelled out when the vault has strict line breaks on', async () => {
 	const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'importer-apple-notes-'));
 	const store = buildStore(nodePath.join(dir, 'NoteStore.sqlite'), { notes: [] });
@@ -349,11 +337,7 @@ test('a soft return is spelled out when the vault has strict line breaks on', as
 	}
 });
 
-/**
- * A title that is the first item of a list is the parent of what follows it.
- * Dropping it leaves those items with nothing to hang off, and the list with
- * an empty item in its place.
- */
+/** Keep a title that parents nested list items so they are not orphaned. */
 test('a first line with a list nested under it is kept', async () => {
 	const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'importer-apple-notes-'));
 	const store = buildStore(nodePath.join(dir, 'NoteStore.sqlite'), { notes: [] });
@@ -374,7 +358,6 @@ test('a first line with a list nested under it is kept', async () => {
 
 		assert.equal(await nested.format(false, 'Airtable is for.md'), '- Airtable is for\n\t- databases');
 
-		// A first item the rest are siblings of loses nothing by going
 		const flat = ctx.decodeData(
 			encodeNote({
 				title: 'Price',
@@ -394,12 +377,7 @@ test('a first line with a list nested under it is kept', async () => {
 	}
 });
 
-/**
- * A real tag, as Apple hands it over. Apple Notes allows a space in a tag name
- * and a tag that is only digits; Obsidian allows neither, so "#gift ideas"
- * becomes the tag #gift with stray text after it, and #2024 is not a tag at
- * all (#471.4, #471.6).
- */
+/** Apple allows spaces and all-digit tag names; Obsidian does not (#471.4, #471.6). */
 test('what a tag with a space or only digits converts to today', async () => {
 	const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'importer-apple-notes-'));
 	const store = buildStore(nodePath.join(dir, 'NoteStore.sqlite'), {
@@ -421,7 +399,6 @@ test('what a tag with a space or only digits converts to today', async () => {
 	try {
 		const converted = await convertStore(store.database, context(store.database));
 
-		// Recorded as it stands: neither survives as the tag it was
 		assert.equal(converted.get('Tagged'), '#gift ideas\n#2024');
 	}
 	finally {
@@ -430,11 +407,7 @@ test('what a tag with a space or only digits converts to today', async () => {
 	}
 });
 
-/**
- * Apple marks a real tag as an attachment, so a # left in the text is not one:
- * a Slack channel, a hashtag in some copy, "#s" for numbers. Obsidian reads it
- * as a tag all the same (#471.5).
- */
+/** Apple encodes real tags as attachments; tag-shaped plain text is not a tag. */
 test('a hash in the text is escaped, and a real tag is not', async () => {
 	const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'importer-apple-notes-'));
 	const store = buildStore(nodePath.join(dir, 'NoteStore.sqlite'), {
@@ -443,8 +416,6 @@ test('a hash in the text is escaped, and a real tag is not', async () => {
 			runs: [
 				{ text: 'Tags\n' },
 				{ text: 'Bugs go in Slack #web-issues, and #s means numbers.\n' },
-				// Neither is a tag in Obsidian, so both are left as they are: a
-				// hash mid-word, and one leading a heading the note typed out
 				{ text: 'Written in C# and F#.\n' },
 				{ text: '## Not a tag\n' },
 				{ text: '', attachment: { identifier: 'HASHTAG-1', uti: ANAttachment.Hashtag } },
@@ -470,10 +441,6 @@ test('a hash in the text is escaped, and a real tag is not', async () => {
 	}
 });
 
-/**
- * A link is an attachment, and an attachment was written without the prefix
- * its line calls for, so an item starting with one lost its checkbox (#471.8).
- */
 test('a list item starting with a link keeps its checkbox', async () => {
 	const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'importer-apple-notes-'));
 	const store = buildStore(nodePath.join(dir, 'NoteStore.sqlite'), {
@@ -506,11 +473,6 @@ test('a list item starting with a link keeps its checkbox', async () => {
 	}
 });
 
-/**
- * A cell's result has to survive inside a `|`-delimited row: a line break
- * becomes a `<br>` and a pipe an entity, or the row ends early and everything
- * after it lands outside the table.
- */
 test('a table cell keeps its line breaks and pipes', async () => {
 	const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'importer-apple-notes-'));
 	const store = buildStore(nodePath.join(dir, 'NoteStore.sqlite'), { notes: [] });

--- a/tests/apple-notes/convert.test.ts
+++ b/tests/apple-notes/convert.test.ts
@@ -395,9 +395,45 @@ test('a first line with a list nested under it is kept', async () => {
 });
 
 /**
+ * A real tag, as Apple hands it over. Apple Notes allows a space in a tag name
+ * and a tag that is only digits; Obsidian allows neither, so "#gift ideas"
+ * becomes the tag #gift with stray text after it, and #2024 is not a tag at
+ * all (#471.4, #471.6).
+ */
+test('what a tag with a space or only digits converts to today', async () => {
+	const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'importer-apple-notes-'));
+	const store = buildStore(nodePath.join(dir, 'NoteStore.sqlite'), {
+		notes: [{
+			title: 'Tagged',
+			runs: [
+				{ text: 'Tagged\n' },
+				{ text: '', attachment: { identifier: 'TAG-SPACE', uti: ANAttachment.Hashtag } },
+				{ text: '\n' },
+				{ text: '', attachment: { identifier: 'TAG-DIGITS', uti: ANAttachment.Hashtag } },
+			],
+		}],
+		attachments: [
+			{ identifier: 'TAG-SPACE', uti: ANAttachment.Hashtag, altText: '#gift ideas' },
+			{ identifier: 'TAG-DIGITS', uti: ANAttachment.Hashtag, altText: '#2024' },
+		],
+	});
+
+	try {
+		const converted = await convertStore(store.database, context(store.database));
+
+		// Recorded as it stands: neither survives as the tag it was
+		assert.equal(converted.get('Tagged'), '#gift ideas\n#2024');
+	}
+	finally {
+		store.close();
+		nodeFs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+/**
  * Apple marks a real tag as an attachment, so a # left in the text is not one:
  * a Slack channel, a hashtag in some copy, "#s" for numbers. Obsidian reads it
- * as a tag all the same, and as a heading at the start of a line (#471.5).
+ * as a tag all the same (#471.5).
  */
 test('a hash in the text is escaped, and a real tag is not', async () => {
 	const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'importer-apple-notes-'));

--- a/tests/apple-notes/convert.test.ts
+++ b/tests/apple-notes/convert.test.ts
@@ -211,13 +211,11 @@ const STORE: StoreSpec = {
 				{ text: 'linked', link: 'https://example.com', emphasis: 3 },
 			],
 		},
-		// Last, so that adding it leaves the primary keys the notes above were
-		// given - an internal link is recorded as the key it points at
+		// Last, so adding it leaves the primary keys the notes above were given:
+		// an internal link is recorded as the key it points at
 		{
-			// Shift-Return in Apple Notes writes U+2028, a line separator, rather
-			// than ending the paragraph. It breaks the line without starting a new
-			// bullet, so it has to survive as a break rather than as the literal
-			// character, which renders as nothing.
+			// A soft return breaks the line without starting a new bullet, so it
+			// has to survive as a break rather than as the literal character
 			title: 'Soft returns',
 			runs: [
 				{ text: 'Soft returns\n', style: ANStyleType.Title },
@@ -288,10 +286,9 @@ test('keeps the first line when asked to', async () => {
 });
 
 /**
- * Apple takes the title from the first line with anything on it, so a note
- * starting with blank lines has its title further down. Omitting "the first
- * line" omitted a blank one and stopped there, leaving the title in the body -
- * written twice, once as the file name and once at the top of the note.
+ * The title is the first line with anything on it, so a note starting with
+ * blank lines has it further down. Omitting "the first line" omitted a blank
+ * one and left the title in the body as well as in the file name.
  */
 test('a note starting with blank lines does not repeat its title', async () => {
 	const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'importer-apple-notes-'));
@@ -318,10 +315,8 @@ test('a note starting with blank lines does not repeat its title', async () => {
 });
 
 /**
- * A soft return is a newline, which Obsidian renders as the break it meant -
- * until the vault turns strict line breaks on, where a lone newline is no
- * longer one. The setting is the vault's rather than the importer's, so it is
- * read rather than asked for, and the break is spelled out where it has to be.
+ * A newline is the break a soft return meant, until the vault turns strict
+ * line breaks on and it stops being one. Then it is spelled out.
  */
 test('a soft return is spelled out when the vault has strict line breaks on', async () => {
 	const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'importer-apple-notes-'));
@@ -355,9 +350,9 @@ test('a soft return is spelled out when the vault has strict line breaks on', as
 });
 
 /**
- * A title that is the first item of a list is the parent of what follows it,
- * and those items are written relative to it. Dropping it leaves them with
- * nothing to hang off, and the list gains an empty item in its place.
+ * A title that is the first item of a list is the parent of what follows it.
+ * Dropping it leaves those items with nothing to hang off, and the list with
+ * an empty item in its place.
  */
 test('a first line with a list nested under it is kept', async () => {
 	const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'importer-apple-notes-'));
@@ -379,8 +374,7 @@ test('a first line with a list nested under it is kept', async () => {
 
 		assert.equal(await nested.format(false, 'Airtable is for.md'), '- Airtable is for\n\t- databases');
 
-		// A first item the rest are siblings of loses nothing by going, so it
-		// still goes - the file name holds it
+		// A first item the rest are siblings of loses nothing by going
 		const flat = ctx.decodeData(
 			encodeNote({
 				title: 'Price',
@@ -401,9 +395,8 @@ test('a first line with a list nested under it is kept', async () => {
 });
 
 /**
- * A cell is converted with `table` set, which is what tells the converter that
- * its result has to survive inside a `|`-delimited row. A line break has to
- * become a `<br>` and a pipe an entity, or the row ends early and everything
+ * A cell's result has to survive inside a `|`-delimited row: a line break
+ * becomes a `<br>` and a pipe an entity, or the row ends early and everything
  * after it lands outside the table.
  */
 test('a table cell keeps its line breaks and pipes', async () => {

--- a/tests/apple-notes/convert.test.ts
+++ b/tests/apple-notes/convert.test.ts
@@ -395,6 +395,46 @@ test('a first line with a list nested under it is kept', async () => {
 });
 
 /**
+ * Apple marks a real tag as an attachment, so a # left in the text is not one:
+ * a Slack channel, a hashtag in some copy, "#s" for numbers. Obsidian reads it
+ * as a tag all the same, and as a heading at the start of a line (#471.5).
+ */
+test('a hash in the text is escaped, and a real tag is not', async () => {
+	const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'importer-apple-notes-'));
+	const store = buildStore(nodePath.join(dir, 'NoteStore.sqlite'), {
+		notes: [{
+			title: 'Tags',
+			runs: [
+				{ text: 'Tags\n' },
+				{ text: 'Bugs go in Slack #web-issues, and #s means numbers.\n' },
+				// Neither is a tag in Obsidian, so both are left as they are: a
+				// hash mid-word, and one leading a heading the note typed out
+				{ text: 'Written in C# and F#.\n' },
+				{ text: '## Not a tag\n' },
+				{ text: '', attachment: { identifier: 'HASHTAG-1', uti: ANAttachment.Hashtag } },
+			],
+		}],
+		attachments: [{ identifier: 'HASHTAG-1', uti: ANAttachment.Hashtag, altText: '#a-real-tag' }],
+	});
+
+	try {
+		const converted = await convertStore(store.database, context(store.database));
+
+		assert.equal(
+			converted.get('Tags'),
+			'Bugs go in Slack \\#web-issues, and \\#s means numbers.\n'
+			+ 'Written in C# and F#.\n'
+			+ '## Not a tag\n'
+			+ '#a-real-tag'
+		);
+	}
+	finally {
+		store.close();
+		nodeFs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+/**
  * A link is an attachment, and an attachment was written without the prefix
  * its line calls for, so an item starting with one lost its checkbox (#471.8).
  */

--- a/tests/apple-notes/convert.test.ts
+++ b/tests/apple-notes/convert.test.ts
@@ -330,6 +330,21 @@ test('a soft return is spelled out when the vault has strict line breaks on', as
 			await strict.decodeData(note, NoteConverter).format(false, 'Soft returns.md'),
 			'A paragraph  \nbroken by a soft return.\n- First bullet  \n\tstill the first bullet'
 		);
+
+		// A newline is already the break inside a code block, so nothing is
+		// spelled out there and no spaces land in the user's code
+		const code = encodeNote({
+			title: 'Code',
+			runs: [
+				{ text: `const a = 1;${SOFT_RETURN}const b = 2;\n`, style: ANStyleType.Monospaced },
+				{ text: 'After.', style: ANStyleType.Default },
+			],
+		}).toString('hex');
+
+		assert.equal(
+			await strict.decodeData(code, NoteConverter).format(false, 'Code.md'),
+			'```\nconst a = 1;\nconst b = 2;\n```\nAfter.'
+		);
 	}
 	finally {
 		store.close();

--- a/tests/apple-notes/convert.test.ts
+++ b/tests/apple-notes/convert.test.ts
@@ -44,6 +44,9 @@ const FIXTURES = __dirname;
 
 const protobufRoot = Root.fromJSON(descriptor);
 
+/** What Shift-Return puts in the text: a line separator, not a paragraph end. */
+const SOFT_RETURN = '\u2028';
+
 /**
  * What the converter needs from outside the note: the database it came from,
  * and a vault. The vault here writes nothing - an attachment resolves to where
@@ -205,6 +208,21 @@ const STORE: StoreSpec = {
 				{ text: 'underlined', underlined: true, emphasis: 5 },
 				{ text: ' and ' },
 				{ text: 'linked', link: 'https://example.com', emphasis: 3 },
+			],
+		},
+		// Last, so that adding it leaves the primary keys the notes above were
+		// given - an internal link is recorded as the key it points at
+		{
+			// Shift-Return in Apple Notes writes U+2028, a line separator, rather
+			// than ending the paragraph. It breaks the line without starting a new
+			// bullet, so it has to survive as a break rather than as the literal
+			// character, which renders as nothing.
+			title: 'Soft returns',
+			runs: [
+				{ text: 'Soft returns\n', style: ANStyleType.Title },
+				{ text: `A paragraph${SOFT_RETURN}broken by a soft return.\n` },
+				{ text: `First bullet${SOFT_RETURN}still the first bullet\n`, style: ANStyleType.DottedList },
+				{ text: 'Second bullet', style: ANStyleType.DottedList },
 			],
 		},
 	],

--- a/tests/apple-notes/convert.test.ts
+++ b/tests/apple-notes/convert.test.ts
@@ -36,7 +36,7 @@ import {
 	SQLiteTagSpawned,
 } from '../../src/formats/apple-notes/models';
 import { expectedFor, expectTree, fixtures } from '../helpers';
-import { buildStore, NoteSpec, StoreSpec } from './store';
+import { buildStore, encodeNote, NoteSpec, StoreSpec } from './store';
 
 provideNodeModules({ zlib: nodeZlib });
 
@@ -261,6 +261,34 @@ test('keeps the first line when asked to', async () => {
 
 		assert.match(kept.get('Headings')!, /^# Headings/);
 		assert.doesNotMatch(dropped.get('Headings')!, /^# Headings/);
+	}
+	finally {
+		store.close();
+		nodeFs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+/**
+ * A cell is converted with `table` set, which is what tells the converter that
+ * its result has to survive inside a `|`-delimited row. A line break has to
+ * become a `<br>` and a pipe an entity, or the row ends early and everything
+ * after it lands outside the table.
+ */
+test('a table cell keeps its line breaks and pipes', async () => {
+	const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'importer-apple-notes-'));
+	const store = buildStore(nodePath.join(dir, 'NoteStore.sqlite'), { notes: [] });
+
+	try {
+		const cell = context(store.database).decodeData(
+			encodeNote({ title: 'Cell', runs: [{ text: 'first\nsecond\nthird | fourth' }] }).toString('hex'),
+			NoteConverter
+		);
+
+		const formatted = await cell.format(true);
+
+		assert.doesNotMatch(formatted, /\n/, 'a newline would end the table row');
+		assert.doesNotMatch(formatted, /(?<!&#124;)\|/, 'a bare pipe would split the cell');
+		assert.equal(formatted, 'first<br>second<br>third &#124; fourth');
 	}
 	finally {
 		store.close();

--- a/tests/apple-notes/convert.test.ts
+++ b/tests/apple-notes/convert.test.ts
@@ -395,6 +395,42 @@ test('a first line with a list nested under it is kept', async () => {
 });
 
 /**
+ * A link is an attachment, and an attachment was written without the prefix
+ * its line calls for, so an item starting with one lost its checkbox (#471.8).
+ */
+test('a list item starting with a link keeps its checkbox', async () => {
+	const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'importer-apple-notes-'));
+	const store = buildStore(nodePath.join(dir, 'NoteStore.sqlite'), {
+		notes: [{
+			title: 'Tasks',
+			runs: [
+				{ text: 'Tasks\n' },
+				{ text: 'Write the notes\n', style: ANStyleType.Checkbox, checked: false },
+				{ text: '', attachment: { identifier: 'LINK-1', uti: ANAttachment.InternalLink }, style: ANStyleType.Checkbox, checked: false },
+				{ text: ', and the rest of the item', style: ANStyleType.Checkbox, checked: false },
+			],
+		}],
+		attachments: [
+			{ identifier: 'LINK-1', uti: ANAttachment.InternalLink, tokenContentIdentifier: 'applenotes:note/00000000-0000-0000-0000-000000000001' },
+			{ identifier: '00000000-0000-0000-0000-000000000001', uti: 'note' },
+		],
+	});
+
+	try {
+		const converted = await convertStore(store.database, context(store.database));
+
+		assert.equal(
+			converted.get('Tasks'),
+			'- [ ] Write the notes\n- [ ] [[Apple Notes/Note 5.md]], and the rest of the item'
+		);
+	}
+	finally {
+		store.close();
+		nodeFs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+/**
  * A cell's result has to survive inside a `|`-delimited row: a line break
  * becomes a `<br>` and a pipe an entity, or the row ends early and everything
  * after it lands outside the table.

--- a/tests/apple-notes/convert.test.ts
+++ b/tests/apple-notes/convert.test.ts
@@ -56,6 +56,7 @@ function context(database: SQLiteTagSpawned, options: Partial<ANContext> = {}): 
 	const ctx: ANContext = {
 		omitFirstLine: true,
 		includeHandwriting: false,
+		strictLineBreaks: false,
 		database,
 
 		decodeData<T extends ANConverter>(hexdata: string, converterType: ANConverterType<T>): T {
@@ -309,6 +310,43 @@ test('a note starting with blank lines does not repeat its title', async () => {
 
 		assert.doesNotMatch(body, /Android reviews/, 'the file name holds the title; the body repeated it');
 		assert.equal(body, 'Obsidian is a small team.');
+	}
+	finally {
+		store.close();
+		nodeFs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+/**
+ * A soft return is a newline, which Obsidian renders as the break it meant -
+ * until the vault turns strict line breaks on, where a lone newline is no
+ * longer one. The setting is the vault's rather than the importer's, so it is
+ * read rather than asked for, and the break is spelled out where it has to be.
+ */
+test('a soft return is spelled out when the vault has strict line breaks on', async () => {
+	const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'importer-apple-notes-'));
+	const store = buildStore(nodePath.join(dir, 'NoteStore.sqlite'), { notes: [] });
+
+	const note = encodeNote({
+		title: 'Soft returns',
+		runs: [
+			{ text: `A paragraph${SOFT_RETURN}broken by a soft return.\n` },
+			{ text: `First bullet${SOFT_RETURN}still the first bullet`, style: ANStyleType.DottedList },
+		],
+	}).toString('hex');
+
+	try {
+		const relaxed = context(store.database, { omitFirstLine: false });
+		assert.equal(
+			await relaxed.decodeData(note, NoteConverter).format(false, 'Soft returns.md'),
+			'A paragraph\nbroken by a soft return.\n- First bullet\n\tstill the first bullet'
+		);
+
+		const strict = context(store.database, { omitFirstLine: false, strictLineBreaks: true });
+		assert.equal(
+			await strict.decodeData(note, NoteConverter).format(false, 'Soft returns.md'),
+			'A paragraph  \nbroken by a soft return.\n- First bullet  \n\tstill the first bullet'
+		);
 	}
 	finally {
 		store.close();

--- a/tests/apple-notes/convert.test.ts
+++ b/tests/apple-notes/convert.test.ts
@@ -287,6 +287,82 @@ test('keeps the first line when asked to', async () => {
 });
 
 /**
+ * Apple takes the title from the first line with anything on it, so a note
+ * starting with blank lines has its title further down. Omitting "the first
+ * line" omitted a blank one and stopped there, leaving the title in the body -
+ * written twice, once as the file name and once at the top of the note.
+ */
+test('a note starting with blank lines does not repeat its title', async () => {
+	const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'importer-apple-notes-'));
+	const store = buildStore(nodePath.join(dir, 'NoteStore.sqlite'), { notes: [] });
+
+	try {
+		const converter = context(store.database).decodeData(
+			encodeNote({
+				title: 'Android reviews',
+				runs: [{ text: '\n\nAndroid reviews\n\nObsidian is a small team.' }],
+			}).toString('hex'),
+			NoteConverter
+		);
+
+		const body = await converter.format(false, 'Android reviews.md');
+
+		assert.doesNotMatch(body, /Android reviews/, 'the file name holds the title; the body repeated it');
+		assert.equal(body, 'Obsidian is a small team.');
+	}
+	finally {
+		store.close();
+		nodeFs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+/**
+ * A title that is the first item of a list is the parent of what follows it,
+ * and those items are written relative to it. Dropping it leaves them with
+ * nothing to hang off, and the list gains an empty item in its place.
+ */
+test('a first line with a list nested under it is kept', async () => {
+	const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'importer-apple-notes-'));
+	const store = buildStore(nodePath.join(dir, 'NoteStore.sqlite'), { notes: [] });
+
+	try {
+		const ctx = context(store.database);
+
+		const nested = ctx.decodeData(
+			encodeNote({
+				title: 'Airtable is for',
+				runs: [
+					{ text: 'Airtable is for\n', style: ANStyleType.DashedList, indent: 0 },
+					{ text: 'databases', style: ANStyleType.DashedList, indent: 1 },
+				],
+			}).toString('hex'),
+			NoteConverter
+		);
+
+		assert.equal(await nested.format(false, 'Airtable is for.md'), '- Airtable is for\n\t- databases');
+
+		// A first item the rest are siblings of loses nothing by going, so it
+		// still goes - the file name holds it
+		const flat = ctx.decodeData(
+			encodeNote({
+				title: 'Price',
+				runs: [
+					{ text: 'Price\n', style: ANStyleType.NumberedList, indent: 0 },
+					{ text: 'Quality', style: ANStyleType.NumberedList, indent: 0 },
+				],
+			}).toString('hex'),
+			NoteConverter
+		);
+
+		assert.equal(await flat.format(false, 'Price.md'), '1. Quality');
+	}
+	finally {
+		store.close();
+		nodeFs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+/**
  * A cell is converted with `table` set, which is what tells the converter that
  * its result has to survive inside a `|`-delimited row. A line break has to
  * become a `<br>` and a pipe an entity, or the row ends early and everything

--- a/tests/apple-notes/duplicates.test.ts
+++ b/tests/apple-notes/duplicates.test.ts
@@ -20,75 +20,16 @@ import * as nodeOs from 'node:os';
 import * as nodePath from 'node:path';
 import * as nodeZlib from 'node:zlib';
 
-import { Root } from 'protobufjs';
-
 import { provideNodeModules } from '../../src/filesystem';
 import { DuplicateHandling } from '../../src/format-importer';
-import { AppleNotesImporter } from '../../src/formats/apple-notes';
-import { descriptor } from '../../src/formats/apple-notes/descriptor';
-import { MemoryVault } from '../shims/vault';
-import { buildStore, NoteSpec } from './store';
+import { importing } from './importing';
+import { NoteSpec } from './store';
 
 provideNodeModules({ fs: nodeFs as never, os: nodeOs, path: nodePath, zlib: nodeZlib });
 
-/** Reports everything, so a test can see what the import decided. */
-function reporter() {
-	const skipped: string[] = [];
-	return {
-		skipped,
-		ctx: {
-			isCancelled: () => false,
-			shouldStop: async () => false,
-			status: () => {},
-			reportProgress: () => {},
-			reportNoteSuccess: () => {},
-			reportAttachmentSuccess: () => {},
-			reportSkipped: (name: string) => skipped.push(name),
-			reportFailed: (name: string, reason?: unknown) => assert.fail(`${name}: ${String(reason)}`),
-		},
-	};
-}
-
-/**
- * An importer pointed at a built database, ready for resolveNote.
- *
- * import() picks a folder through a dialog and opens the real Notes database,
- * so what it sets up is set up here instead.
- */
-async function importing(notes: NoteSpec[], mode: DuplicateHandling) {
-	const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'importer-apple-notes-'));
-	const store = buildStore(nodePath.join(dir, 'NoteStore.sqlite'), { notes });
-
-	const vault = new MemoryVault();
-	const { ctx, skipped } = reporter();
-	const subject = new AppleNotesImporter(
-		{ vault, loadLocalStorage: () => null, saveLocalStorage: () => {} } as never,
-		{ sourceEl: null, optionsEl: null } as never
-	);
-
-	subject.ctx = ctx as never;
-	subject.vault = vault as never;
-	subject.rootFolder = vault.root;
-	subject.protobufRoot = Root.fromJSON(descriptor);
-	subject.duplicateHandling = mode;
-	subject.keys = Object.fromEntries(
-		(await store.database.all`SELECT z_ent, z_name FROM z_primarykey`).map(k => [k.Z_NAME, k.Z_ENT])
-	);
-	subject.database = store.database;
-
-	return {
-		vault, skipped, notePks: store.notePks,
-		resolve: (pk: number) => subject.resolveNote(pk),
-		close: () => {
-			store.close();
-			nodeFs.rmSync(dir, { recursive: true, force: true });
-		},
-	};
-}
-
 const SAME_TITLE: NoteSpec[] = [
-	{ title: 'Groceries', runs: [{ text: 'Groceries' }, { text: 'Milk' }] },
-	{ title: 'Groceries', runs: [{ text: 'Groceries' }, { text: 'Bread' }] },
+	{ title: 'Groceries', runs: [{ text: 'Groceries\n' }, { text: 'Milk' }] },
+	{ title: 'Groceries', runs: [{ text: 'Groceries\n' }, { text: 'Bread' }] },
 ];
 
 for (const mode of [DuplicateHandling.ImportUpdated, DuplicateHandling.Skip, DuplicateHandling.CreateCopy]) {
@@ -139,8 +80,8 @@ test('two notes of one title stay two notes even with no id to tell them apart',
 	// back on the file name, and every name this run has written is a note of
 	// its own rather than one an earlier import left.
 	const run = await importing([
-		{ title: 'Groceries', runs: [{ text: 'Groceries' }, { text: 'Milk' }], identifier: null },
-		{ title: 'Groceries', runs: [{ text: 'Groceries' }, { text: 'Bread' }], identifier: null },
+		{ title: 'Groceries', runs: [{ text: 'Groceries\n' }, { text: 'Milk' }], identifier: null },
+		{ title: 'Groceries', runs: [{ text: 'Groceries\n' }, { text: 'Bread' }], identifier: null },
 	], DuplicateHandling.ImportUpdated);
 
 	try {

--- a/tests/apple-notes/expected/built-store/Links and attachments.md
+++ b/tests/apple-notes/expected/built-store/Links and attachments.md
@@ -1,7 +1,7 @@
 [A web link](https://example.com)
 #a-tag
 [**Example**](https://example.com)
-[[Apple Notes/Note 14.md]]
+[[Apple Notes/Note 15.md]]
 
 ![[Apple Notes/Attachments/42.png]]
 

--- a/tests/apple-notes/expected/built-store/Soft returns.md
+++ b/tests/apple-notes/expected/built-store/Soft returns.md
@@ -1,3 +1,5 @@
-A paragraph<br>broken by a soft return.
-- First bullet<br>still the first bullet
+A paragraph
+broken by a soft return.
+- First bullet
+	still the first bullet
 - Second bullet

--- a/tests/apple-notes/expected/built-store/Soft returns.md
+++ b/tests/apple-notes/expected/built-store/Soft returns.md
@@ -1,0 +1,3 @@
+A paragraph<br>broken by a soft return.
+- First bullet<br>still the first bullet
+- Second bullet

--- a/tests/apple-notes/importing.ts
+++ b/tests/apple-notes/importing.ts
@@ -1,0 +1,68 @@
+/**
+ * An Apple Notes importer pointed at a built database, ready for resolveNote.
+ *
+ * import() picks a folder through a dialog and opens the real Notes database,
+ * so what it sets up is set up here instead. Shared by the tests that check
+ * what the importer writes rather than what the conversion produces.
+ */
+import assert from 'node:assert/strict';
+import * as nodeFs from 'node:fs';
+import * as nodeOs from 'node:os';
+import * as nodePath from 'node:path';
+
+import { Root } from 'protobufjs';
+
+import { DuplicateHandling } from '../../src/format-importer';
+import { AppleNotesImporter } from '../../src/formats/apple-notes';
+import { descriptor } from '../../src/formats/apple-notes/descriptor';
+import { MemoryVault } from '../shims/vault';
+import { buildStore, NoteSpec } from './store';
+
+/** Reports everything, so a test can see what the import decided. */
+export function reporter() {
+	const skipped: string[] = [];
+	return {
+		skipped,
+		ctx: {
+			isCancelled: () => false,
+			shouldStop: async () => false,
+			status: () => {},
+			reportProgress: () => {},
+			reportNoteSuccess: () => {},
+			reportAttachmentSuccess: () => {},
+			reportSkipped: (name: string) => skipped.push(name),
+			reportFailed: (name: string, reason?: unknown) => assert.fail(`${name}: ${String(reason)}`),
+		},
+	};
+}
+
+export async function importing(notes: NoteSpec[], mode: DuplicateHandling) {
+	const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'importer-apple-notes-'));
+	const store = buildStore(nodePath.join(dir, 'NoteStore.sqlite'), { notes });
+
+	const vault = new MemoryVault();
+	const { ctx, skipped } = reporter();
+	const subject = new AppleNotesImporter(
+		{ vault, loadLocalStorage: () => null, saveLocalStorage: () => {} } as never,
+		{ sourceEl: null, optionsEl: null } as never
+	);
+
+	subject.ctx = ctx as never;
+	subject.vault = vault as never;
+	subject.rootFolder = vault.root;
+	subject.protobufRoot = Root.fromJSON(descriptor);
+	subject.duplicateHandling = mode;
+	subject.keys = Object.fromEntries(
+		(await store.database.all`SELECT z_ent, z_name FROM z_primarykey`).map(k => [k.Z_NAME, k.Z_ENT])
+	);
+	subject.database = store.database;
+
+	return {
+		vault, skipped, notePks: store.notePks, subject,
+		resolve: (pk: number) => subject.resolveNote(pk),
+		close: () => {
+			store.close();
+			nodeFs.rmSync(dir, { recursive: true, force: true });
+		},
+	};
+}

--- a/tests/apple-notes/importing.ts
+++ b/tests/apple-notes/importing.ts
@@ -1,9 +1,7 @@
 /**
  * An Apple Notes importer pointed at a built database, ready for resolveNote.
- *
  * import() picks a folder through a dialog and opens the real Notes database,
- * so what it sets up is set up here instead. Shared by the tests that check
- * what the importer writes rather than what the conversion produces.
+ * so what it sets up is set up here instead.
  */
 import assert from 'node:assert/strict';
 import * as nodeFs from 'node:fs';

--- a/tests/apple-notes/importing.ts
+++ b/tests/apple-notes/importing.ts
@@ -1,8 +1,4 @@
-/**
- * An Apple Notes importer pointed at a built database, ready for resolveNote.
- * import() picks a folder through a dialog and opens the real Notes database,
- * so what it sets up is set up here instead.
- */
+/** Build an importer around a fixture database without invoking its dialog. */
 import assert from 'node:assert/strict';
 import * as nodeFs from 'node:fs';
 import * as nodeOs from 'node:os';
@@ -16,7 +12,6 @@ import { descriptor } from '../../src/formats/apple-notes/descriptor';
 import { MemoryVault } from '../shims/vault';
 import { buildStore, NoteSpec } from './store';
 
-/** Reports everything, so a test can see what the import decided. */
 export function reporter() {
 	const skipped: string[] = [];
 	return {

--- a/tests/apple-notes/settings.test.ts
+++ b/tests/apple-notes/settings.test.ts
@@ -1,8 +1,3 @@
-/**
- * Settings the importer reads from the vault rather than asking for. The
- * conversion tests hand the converter a context of their own, so they cannot
- * tell whether the importer fills it in from the right place.
- */
 import '../shims/runtime';
 
 import { test } from 'node:test';
@@ -18,7 +13,6 @@ import { importing } from './importing';
 
 provideNodeModules({ fs: nodeFs as never, os: nodeOs, path: nodePath, zlib: nodeZlib });
 
-/** What Shift-Return puts in the text: a line separator, not a paragraph end. */
 const SOFT_RETURN = '\u2028';
 
 const NOTE = [{
@@ -26,7 +20,6 @@ const NOTE = [{
 	runs: [{ text: `Soft returns\nA paragraph${SOFT_RETURN}broken by a soft return.` }],
 }];
 
-/** Off, which is the default: a newline already renders as the break. */
 test('a soft return is a bare newline when the vault leaves strict line breaks off', async () => {
 	const run = await importing(NOTE, DuplicateHandling.CreateCopy);
 
@@ -41,7 +34,6 @@ test('a soft return is a bare newline when the vault leaves strict line breaks o
 	}
 });
 
-/** On: a lone newline is no longer a break, so it is spelled out. */
 test('a soft return is spelled out when the vault has strict line breaks on', async () => {
 	const run = await importing(NOTE, DuplicateHandling.CreateCopy);
 	run.vault.config.set('strictLineBreaks', true);

--- a/tests/apple-notes/settings.test.ts
+++ b/tests/apple-notes/settings.test.ts
@@ -1,9 +1,7 @@
 /**
- * Settings the importer reads from the vault rather than asking for.
- *
- * The conversion tests hand the converter a context of their own, so they
- * cannot tell whether the importer fills it in from the right place. These
- * drive the importer, which is where a setting is read.
+ * Settings the importer reads from the vault rather than asking for. The
+ * conversion tests hand the converter a context of their own, so they cannot
+ * tell whether the importer fills it in from the right place.
  */
 import '../shims/runtime';
 
@@ -28,10 +26,7 @@ const NOTE = [{
 	runs: [{ text: `Soft returns\nA paragraph${SOFT_RETURN}broken by a soft return.` }],
 }];
 
-/**
- * With strict line breaks off - Obsidian's default - a newline already renders
- * as the break the soft return meant, so that is all the markdown needs.
- */
+/** Off, which is the default: a newline already renders as the break. */
 test('a soft return is a bare newline when the vault leaves strict line breaks off', async () => {
 	const run = await importing(NOTE, DuplicateHandling.CreateCopy);
 
@@ -46,7 +41,7 @@ test('a soft return is a bare newline when the vault leaves strict line breaks o
 	}
 });
 
-/** With it on, a lone newline is no longer a break, so the break is spelled out. */
+/** On: a lone newline is no longer a break, so it is spelled out. */
 test('a soft return is spelled out when the vault has strict line breaks on', async () => {
 	const run = await importing(NOTE, DuplicateHandling.CreateCopy);
 	run.vault.config.set('strictLineBreaks', true);

--- a/tests/apple-notes/settings.test.ts
+++ b/tests/apple-notes/settings.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Settings the importer reads from the vault rather than asking for.
+ *
+ * The conversion tests hand the converter a context of their own, so they
+ * cannot tell whether the importer fills it in from the right place. These
+ * drive the importer, which is where a setting is read.
+ */
+import '../shims/runtime';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import * as nodeFs from 'node:fs';
+import * as nodeOs from 'node:os';
+import * as nodePath from 'node:path';
+import * as nodeZlib from 'node:zlib';
+
+import { provideNodeModules } from '../../src/filesystem';
+import { DuplicateHandling } from '../../src/format-importer';
+import { importing } from './importing';
+
+provideNodeModules({ fs: nodeFs as never, os: nodeOs, path: nodePath, zlib: nodeZlib });
+
+/** What Shift-Return puts in the text: a line separator, not a paragraph end. */
+const SOFT_RETURN = '\u2028';
+
+const NOTE = [{
+	title: 'Soft returns',
+	runs: [{ text: `Soft returns\nA paragraph${SOFT_RETURN}broken by a soft return.` }],
+}];
+
+/**
+ * With strict line breaks off - Obsidian's default - a newline already renders
+ * as the break the soft return meant, so that is all the markdown needs.
+ */
+test('a soft return is a bare newline when the vault leaves strict line breaks off', async () => {
+	const run = await importing(NOTE, DuplicateHandling.CreateCopy);
+
+	try {
+		const file = await run.resolve(run.notePks[0]);
+		const body = String(run.vault.contents.get(file!.path));
+
+		assert.ok(body.contains('A paragraph\nbroken'), `got ${JSON.stringify(body)}`);
+	}
+	finally {
+		run.close();
+	}
+});
+
+/** With it on, a lone newline is no longer a break, so the break is spelled out. */
+test('a soft return is spelled out when the vault has strict line breaks on', async () => {
+	const run = await importing(NOTE, DuplicateHandling.CreateCopy);
+	run.vault.config.set('strictLineBreaks', true);
+
+	try {
+		const file = await run.resolve(run.notePks[0]);
+		const body = String(run.vault.contents.get(file!.path));
+
+		assert.ok(body.contains('A paragraph  \nbroken'), `got ${JSON.stringify(body)}`);
+	}
+	finally {
+		run.close();
+	}
+});

--- a/tests/apple-notes/store.ts
+++ b/tests/apple-notes/store.ts
@@ -77,7 +77,7 @@ export interface AttachmentSpec {
 	 * Create a media row with this file name and point the attachment to it.
 	 * Use `media` directly to reference a missing or separately defined row.
 	 */
-	mediaFilename?: string;
+	mediaFilename?: string | null;
 	/**
 	 * Which note it hangs off, as an index into the spec's notes.
 	 *
@@ -254,7 +254,7 @@ export function buildStore(filepath: string, spec: StoreSpec): BuiltStore {
 		if (attachment.mediaFilename !== undefined) {
 			media = pk++;
 			insertMedia.run(media, entity.ICMedia, `MEDIA-${media}`, attachment.mediaFilename);
-			mediaFiles.push([`MEDIA-${media}`, attachment.mediaFilename]);
+			if (attachment.mediaFilename !== null) mediaFiles.push([`MEDIA-${media}`, attachment.mediaFilename]);
 		}
 
 		insertAttachment.run(

--- a/tests/apple-notes/store.ts
+++ b/tests/apple-notes/store.ts
@@ -74,9 +74,8 @@ export interface AttachmentSpec {
 	/** A file on disk, which the importer would copy into the vault. */
 	media?: number;
 	/**
-	 * The name the media row carries, which the copy in the vault is named
-	 * after. Given one, a media row is written and the attachment points at
-	 * it; `media` sets the key directly, for when there is to be no row.
+	 * Create a media row with this file name and point the attachment to it.
+	 * Use `media` directly to reference a missing or separately defined row.
 	 */
 	mediaFilename?: string;
 	/**
@@ -92,8 +91,8 @@ export interface AttachmentSpec {
 	/** A table or scan, as its own protobuf. */
 	mergeableData?: Uint8Array;
 	/**
-	 * The generation directory a rendered drawing is kept under. Left out, with
-	 * no size either, the row looks like a drawing iCloud never brought down.
+	 * Directory containing a rendered drawing. Omitting this and `size` models
+	 * a drawing that iCloud has not downloaded.
 	 */
 	fallbackImageGeneration?: string;
 	size?: { width: number, height: number };
@@ -242,10 +241,8 @@ export function buildStore(filepath: string, spec: StoreSpec): BuiltStore {
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`);
 
-	/** Each media row's directory and file name, for a test to write the file. */
 	const mediaFiles: [string, string][] = [];
 
-	// ICMedia is the row carrying the file name, which an attachment points at
 	const insertMedia = db.prepare(`
 		INSERT INTO ziccloudsyncingobject (Z_PK, Z_ENT, ZIDENTIFIER, ZFILENAME)
 		VALUES (?, ?, ?, ?)

--- a/tests/apple-notes/store.ts
+++ b/tests/apple-notes/store.ts
@@ -86,13 +86,10 @@ export interface AttachmentSpec {
 	/** A table or scan, as its own protobuf. */
 	mergeableData?: Uint8Array;
 	/**
-	 * The generation directory a rendered drawing is kept under, which only a
-	 * drawing Apple has drawn a copy of has. Left out, the row looks like one
-	 * iCloud has never brought down: nothing rendered, and no size Notes ever
-	 * learned.
+	 * The generation directory a rendered drawing is kept under. Left out, with
+	 * no size either, the row looks like a drawing iCloud never brought down.
 	 */
 	fallbackImageGeneration?: string;
-	/** What Notes measured the attachment at, which it only knows once it has it. */
 	size?: { width: number, height: number };
 }
 

--- a/tests/apple-notes/store.ts
+++ b/tests/apple-notes/store.ts
@@ -85,6 +85,15 @@ export interface AttachmentSpec {
 	handwriting?: string;
 	/** A table or scan, as its own protobuf. */
 	mergeableData?: Uint8Array;
+	/**
+	 * The generation directory a rendered drawing is kept under, which only a
+	 * drawing Apple has drawn a copy of has. Left out, the row looks like one
+	 * iCloud has never brought down: nothing rendered, and no size Notes ever
+	 * learned.
+	 */
+	fallbackImageGeneration?: string;
+	/** What Notes measured the attachment at, which it only knows once it has it. */
+	size?: { width: number, height: number };
 }
 
 const root = Root.fromJSON(descriptor);
@@ -162,7 +171,8 @@ const SCHEMA = `
 		ZFILENAME TEXT, ZTYPEUTI TEXT, ZIDENTIFIER1 TEXT,
 		ZCREATIONDATE INTEGER, ZMODIFICATIONDATE INTEGER,
 		ZCREATIONDATE1 INTEGER, ZMODIFICATIONDATE1 INTEGER,
-		ZISPASSWORDPROTECTED INTEGER, ZMARKEDFORDELETION INTEGER
+		ZISPASSWORDPROTECTED INTEGER, ZMARKEDFORDELETION INTEGER,
+		ZFALLBACKIMAGEGENERATION TEXT, ZSIZEWIDTH INTEGER, ZSIZEHEIGHT INTEGER
 	);
 
 	CREATE TABLE zicnotedata (
@@ -222,8 +232,9 @@ export function buildStore(filepath: string, spec: StoreSpec): BuiltStore {
 		INSERT INTO ziccloudsyncingobject (
 			Z_PK, Z_ENT, ZIDENTIFIER, ZALTTEXT, ZTOKENCONTENTIDENTIFIER,
 			ZURLSTRING, ZTITLE, ZTYPEUTI, ZMEDIA, ZMERGEABLEDATA1,
-			ZHANDWRITINGSUMMARY, ZNOTE, ZCREATIONDATE, ZMODIFICATIONDATE
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			ZHANDWRITINGSUMMARY, ZNOTE, ZCREATIONDATE, ZMODIFICATIONDATE,
+			ZFALLBACKIMAGEGENERATION, ZSIZEWIDTH, ZSIZEHEIGHT
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`);
 
 	for (const attachment of spec.attachments ?? []) {
@@ -234,7 +245,9 @@ export function buildStore(filepath: string, spec: StoreSpec): BuiltStore {
 			attachment.media ?? null, attachment.mergeableData ?? null,
 			attachment.handwriting ?? null,
 			attachment.note === undefined ? null : notePks[attachment.note],
-			created, created);
+			created, created,
+			attachment.fallbackImageGeneration ?? null,
+			attachment.size?.width ?? 0, attachment.size?.height ?? 0);
 	}
 
 	return { database: tagged(db), notePks, folderPk, close: () => db.close() };

--- a/tests/apple-notes/store.ts
+++ b/tests/apple-notes/store.ts
@@ -74,6 +74,12 @@ export interface AttachmentSpec {
 	/** A file on disk, which the importer would copy into the vault. */
 	media?: number;
 	/**
+	 * The name the media row carries, which the copy in the vault is named
+	 * after. Given one, a media row is written and the attachment points at
+	 * it; `media` sets the key directly, for when there is to be no row.
+	 */
+	mediaFilename?: string;
+	/**
 	 * Which note it hangs off, as an index into the spec's notes.
 	 *
 	 * The importer reads it to know whose account the file sits under, so an
@@ -185,6 +191,8 @@ export interface BuiltStore {
 	notePks: number[];
 	/** Primary key of the one folder every note is in, which owns the account. */
 	folderPk: number;
+	/** Each media row's directory and file name, for a test to write the file. */
+	mediaFiles: [string, string][];
 	close(): void;
 }
 
@@ -234,12 +242,29 @@ export function buildStore(filepath: string, spec: StoreSpec): BuiltStore {
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`);
 
+	/** Each media row's directory and file name, for a test to write the file. */
+	const mediaFiles: [string, string][] = [];
+
+	// ICMedia is the row carrying the file name, which an attachment points at
+	const insertMedia = db.prepare(`
+		INSERT INTO ziccloudsyncingobject (Z_PK, Z_ENT, ZIDENTIFIER, ZFILENAME)
+		VALUES (?, ?, ?, ?)
+	`);
+
 	for (const attachment of spec.attachments ?? []) {
+		let media = attachment.media ?? null;
+
+		if (attachment.mediaFilename !== undefined) {
+			media = pk++;
+			insertMedia.run(media, entity.ICMedia, `MEDIA-${media}`, attachment.mediaFilename);
+			mediaFiles.push([`MEDIA-${media}`, attachment.mediaFilename]);
+		}
+
 		insertAttachment.run(
 			pk++, entity.ICAttachment, attachment.identifier,
 			attachment.altText ?? null, attachment.tokenContentIdentifier ?? null,
 			attachment.url ?? null, attachment.title ?? null, attachment.uti,
-			attachment.media ?? null, attachment.mergeableData ?? null,
+			media, attachment.mergeableData ?? null,
 			attachment.handwriting ?? null,
 			attachment.note === undefined ? null : notePks[attachment.note],
 			created, created,
@@ -247,7 +272,7 @@ export function buildStore(filepath: string, spec: StoreSpec): BuiltStore {
 			attachment.size?.width ?? 0, attachment.size?.height ?? 0);
 	}
 
-	return { database: tagged(db), notePks, folderPk, close: () => db.close() };
+	return { database: tagged(db), notePks, folderPk, mediaFiles, close: () => db.close() };
 }
 
 /**

--- a/tests/apple-notes/titles.test.ts
+++ b/tests/apple-notes/titles.test.ts
@@ -44,6 +44,34 @@ test('a soft return in the first line does not reach the file name', () => {
 	assert.doesNotMatch(sanitizeFileName(title), /[\u2028\u2029]/);
 });
 
+/**
+ * A vault an older importer wrote holds the note under the abbreviated title it
+ * used. Recognising a note is by path, so naming it from the first line now
+ * looks somewhere the old file is not, and the note is imported twice.
+ */
+test('a note an older import named after ZTITLE1 is still recognised', async () => {
+	const run = await importing(
+		[{
+			title: ABBREVIATED,
+			runs: [{ text: `${LONG_LINE}\n` }, { text: 'And the rest of the note.' }],
+		}],
+		DuplicateHandling.Skip
+	);
+
+	try {
+		// What the previous importer left behind
+		await run.vault.create(`${ABBREVIATED}.md`, 'The note as it was imported before.');
+
+		await run.resolve(run.notePks[0]);
+
+		assert.deepEqual(run.vault.paths(), [`${ABBREVIATED}.md`], 'the note was imported a second time');
+		assert.equal(run.skipped.length, 1, 'it should have been recognised as already imported');
+	}
+	finally {
+		run.close();
+	}
+});
+
 const LONG_LINE = 'The reason we moved buttons to the bottom is to improve accessibility for one-handed use';
 const ABBREVIATED = 'The reason we moved buttons to the bottom is to improve accessibility…';
 

--- a/tests/apple-notes/titles.test.ts
+++ b/tests/apple-notes/titles.test.ts
@@ -1,0 +1,74 @@
+/**
+ * What an imported note is named.
+ *
+ * Apple shows a note's first line as its title, but ZTITLE1 holds only an
+ * abbreviation of it: past about eighty characters it is cut short and an
+ * ellipsis put in place of the rest (#541). The line itself is in the note
+ * text, and is what the note should be named after.
+ *
+ * A first line that is a URL cannot survive as a file name - a slash is a path
+ * separator and a colon is not allowed - so naming the note after it and then
+ * dropping it from the body loses the URL altogether (#591). It stays.
+ */
+import '../shims/runtime';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import * as nodeFs from 'node:fs';
+import * as nodeOs from 'node:os';
+import * as nodePath from 'node:path';
+import * as nodeZlib from 'node:zlib';
+
+import { provideNodeModules } from '../../src/filesystem';
+import { DuplicateHandling } from '../../src/format-importer';
+import { importing } from './importing';
+
+provideNodeModules({ fs: nodeFs as never, os: nodeOs, path: nodePath, zlib: nodeZlib });
+
+/** A first line long enough that Apple stores an abbreviation of it. */
+const LONG_LINE = 'The reason we moved buttons to the bottom is to improve accessibility for one-handed use';
+const ABBREVIATED = 'The reason we moved buttons to the bottom is to improve accessibility…';
+
+test('a note is named after its first line, not the abbreviation Apple stores', async () => {
+	const run = await importing(
+		[{
+			title: ABBREVIATED,
+			runs: [{ text: `${LONG_LINE}\n` }, { text: 'And the rest of the note.' }],
+		}],
+		DuplicateHandling.CreateCopy
+	);
+
+	try {
+		const file = await run.resolve(run.notePks[0]);
+
+		assert.ok(file, 'the note should be imported');
+		assert.doesNotMatch(file.path, /…/, 'the name was cut short with an ellipsis');
+		assert.deepEqual(run.vault.paths(), [`${LONG_LINE}.md`]);
+	}
+	finally {
+		run.close();
+	}
+});
+
+const URL = 'https://en.wikipedia.org/wiki/Jhumpa_Lahiri';
+
+test('a first line that is a URL is kept in the note', async () => {
+	const run = await importing(
+		[{ title: URL, runs: [{ text: `${URL}\n` }, { text: 'A writer.' }] }],
+		DuplicateHandling.CreateCopy
+	);
+
+	try {
+		const file = await run.resolve(run.notePks[0]);
+
+		assert.ok(file, 'the note should be imported');
+
+		// The file name cannot hold it - that is the reason it has to stay in
+		// the body, where it is still a URL that works
+		const body = String(run.vault.contents.get(file.path));
+		assert.ok(body.contains(URL), `the URL was lost; the note holds ${JSON.stringify(body)}`);
+	}
+	finally {
+		run.close();
+	}
+});

--- a/tests/apple-notes/titles.test.ts
+++ b/tests/apple-notes/titles.test.ts
@@ -1,14 +1,10 @@
 /**
- * What an imported note is named.
+ * What an imported note is named. ZTITLE1 holds an abbreviation of the first
+ * line, cut short with an ellipsis past about eighty characters (#541), so the
+ * line itself is what to name the note after.
  *
- * Apple shows a note's first line as its title, but ZTITLE1 holds only an
- * abbreviation of it: past about eighty characters it is cut short and an
- * ellipsis put in place of the rest (#541). The line itself is in the note
- * text, and is what the note should be named after.
- *
- * A first line that is a URL cannot survive as a file name - a slash is a path
- * separator and a colon is not allowed - so naming the note after it and then
- * dropping it from the body loses the URL altogether (#591). It stays.
+ * A first line that is a URL cannot survive as a file name, so naming the note
+ * after it and dropping it from the body loses it altogether (#591).
  */
 import '../shims/runtime';
 
@@ -63,8 +59,6 @@ test('a first line that is a URL is kept in the note', async () => {
 
 		assert.ok(file, 'the note should be imported');
 
-		// The file name cannot hold it - that is the reason it has to stay in
-		// the body, where it is still a URL that works
 		const body = String(run.vault.contents.get(file.path));
 		assert.ok(body.contains(URL), `the URL was lost; the note holds ${JSON.stringify(body)}`);
 	}

--- a/tests/apple-notes/titles.test.ts
+++ b/tests/apple-notes/titles.test.ts
@@ -1,11 +1,3 @@
-/**
- * What an imported note is named. ZTITLE1 holds an abbreviation of the first
- * line, cut short with an ellipsis past about eighty characters (#541), so the
- * line itself is what to name the note after.
- *
- * A first line that is a URL cannot survive as a file name, so naming the note
- * after it and dropping it from the body loses it altogether (#591).
- */
 import '../shims/runtime';
 
 import { test } from 'node:test';
@@ -21,7 +13,6 @@ import { importing } from './importing';
 
 provideNodeModules({ fs: nodeFs as never, os: nodeOs, path: nodePath, zlib: nodeZlib });
 
-/** A first line long enough that Apple stores an abbreviation of it. */
 const LONG_LINE = 'The reason we moved buttons to the bottom is to improve accessibility for one-handed use';
 const ABBREVIATED = 'The reason we moved buttons to the bottom is to improve accessibility…';
 

--- a/tests/apple-notes/titles.test.ts
+++ b/tests/apple-notes/titles.test.ts
@@ -9,9 +9,40 @@ import * as nodeZlib from 'node:zlib';
 
 import { provideNodeModules } from '../../src/filesystem';
 import { DuplicateHandling } from '../../src/format-importer';
+import { noteTitle } from '../../src/formats/apple-notes/convert-note';
+import { sanitizeFileName } from '../../src/util';
 import { importing } from './importing';
 
 provideNodeModules({ fs: nodeFs as never, os: nodeOs, path: nodePath, zlib: nodeZlib });
+
+/** An attachment stands in the note text as one character. */
+const ATTACHMENT = '\uFFFC';
+const SOFT_RETURN = '\u2028';
+
+/**
+ * Apple looks past a line holding nothing but an attachment: a note opening
+ * with a photo is titled from the text under it. Naming it after that
+ * character instead put every such note at the same name.
+ */
+test('a note opening with an attachment is named after its text', () => {
+	assert.equal(noteTitle(`${ATTACHMENT}\nPhotos from Rome`, 'Photos from Rome'), 'Photos from Rome');
+	assert.equal(noteTitle(`${ATTACHMENT}${ATTACHMENT}\n\nRome`, 'Rome'), 'Rome');
+	assert.equal(noteTitle(`${ATTACHMENT}Photos from Rome\nMore`, 'x'), 'Photos from Rome');
+
+	// Nothing but attachments, so there is no text to name it after
+	assert.equal(noteTitle(`${ATTACHMENT}\n${ATTACHMENT}`, 'Photos from Rome'), 'Photos from Rome');
+});
+
+/**
+ * A soft return is part of the line Apple titles a note with - ZTITLE1 carries
+ * one - but a line separator in a file name is invisible.
+ */
+test('a soft return in the first line does not reach the file name', () => {
+	const title = noteTitle(`Sennheiser 416${SOFT_RETURN}Deity - S-Mic 2S\nBody`, 'x');
+
+	assert.equal(title, 'Sennheiser 416 Deity - S-Mic 2S');
+	assert.doesNotMatch(sanitizeFileName(title), /[\u2028\u2029]/);
+});
 
 const LONG_LINE = 'The reason we moved buttons to the bottom is to improve accessibility for one-handed use';
 const ABBREVIATED = 'The reason we moved buttons to the bottom is to improve accessibility…';

--- a/tests/shims/obsidian.ts
+++ b/tests/shims/obsidian.ts
@@ -202,6 +202,11 @@ export class TAbstractFile {
 	vault!: never;
 }
 
+export interface DataWriteOptions {
+	ctime?: number;
+	mtime?: number;
+}
+
 export class TFile extends TAbstractFile {
 	basename: string = '';
 	extension: string = '';

--- a/tests/shims/vault.ts
+++ b/tests/shims/vault.ts
@@ -12,7 +12,7 @@
  * taken, the app returns "Note 1", then "Note 2", and it compares without
  * regard to case, so "note" does not come back free while "Note" exists.
  */
-import { TAbstractFile, TFile, TFolder, normalizePath } from './obsidian';
+import { DataWriteOptions, TAbstractFile, TFile, TFolder, normalizePath } from './obsidian';
 
 export class MemoryVault {
 	/** Every file and folder, keyed by its lower-cased path. */
@@ -88,12 +88,12 @@ export class MemoryVault {
 		return folder;
 	}
 
-	async create(path: string, data: string): Promise<TFile> {
-		return this.write(path, data);
+	async create(path: string, data: string, options?: DataWriteOptions): Promise<TFile> {
+		return this.write(path, data, options);
 	}
 
-	async createBinary(path: string, data: ArrayBuffer): Promise<TFile> {
-		return this.write(path, data);
+	async createBinary(path: string, data: ArrayBuffer, options?: DataWriteOptions): Promise<TFile> {
+		return this.write(path, data, options);
 	}
 
 	// Taken by path rather than by TFile: what an importer hands back is
@@ -103,12 +103,15 @@ export class MemoryVault {
 		return String(this.contents.get(file.path) ?? '');
 	}
 
-	async modify(file: { path: string }, data: string): Promise<void> {
+	async modify(file: { path: string }, data: string, options?: DataWriteOptions): Promise<void> {
 		this.contents.set(file.path, data);
+
+		const entry = this.entries.get(normalizePath(file.path).toLowerCase());
+		if (entry instanceof TFile && options) Object.assign(entry.stat, options);
 	}
 
 	/** The vault refuses a name that is taken rather than picking another. */
-	private write(path: string, data: string | ArrayBuffer): TFile {
+	private write(path: string, data: string | ArrayBuffer, options?: DataWriteOptions): TFile {
 		const normalized = normalizePath(path);
 		if (this.entries.has(normalized.toLowerCase())) {
 			throw new Error('File already exists.');
@@ -121,6 +124,9 @@ export class MemoryVault {
 		file.basename = dot > 0 ? file.name.slice(0, dot) : file.name;
 		file.extension = dot > 0 ? file.name.slice(dot + 1) : '';
 		file.stat.size = typeof data === 'string' ? data.length : data.byteLength;
+
+		// The dates an importer asks for, which duplicate handling compares
+		if (options) Object.assign(file.stat, options);
 
 		this.entries.set(normalized.toLowerCase(), file);
 		this.contents.set(normalized, data);

--- a/tests/shims/vault.ts
+++ b/tests/shims/vault.ts
@@ -19,6 +19,8 @@ export class MemoryVault {
 	private entries = new Map<string, TAbstractFile>();
 	/** What each file holds, so a test can read back what an import wrote. */
 	readonly contents = new Map<string, string | ArrayBuffer>();
+	/** The vault settings an importer reads, which a test can set. */
+	readonly config = new Map<string, unknown>();
 
 	constructor() {
 		const root = new TFolder();
@@ -29,6 +31,11 @@ export class MemoryVault {
 
 	get root(): TFolder {
 		return this.entries.get('/') as TFolder;
+	}
+
+	/** A vault setting, as Obsidian hands it out: undefined when never set. */
+	getConfig(key: string): unknown {
+		return this.config.get(key);
 	}
 
 	/** Every file path written, in the order the paths were taken. */

--- a/tests/shims/vault.ts
+++ b/tests/shims/vault.ts
@@ -19,7 +19,6 @@ export class MemoryVault {
 	private entries = new Map<string, TAbstractFile>();
 	/** What each file holds, so a test can read back what an import wrote. */
 	readonly contents = new Map<string, string | ArrayBuffer>();
-	/** The vault settings an importer reads, which a test can set. */
 	readonly config = new Map<string, unknown>();
 
 	constructor() {
@@ -33,7 +32,6 @@ export class MemoryVault {
 		return this.entries.get('/') as TFolder;
 	}
 
-	/** Undefined when never set, as Obsidian hands one out. */
 	getConfig(key: string): unknown {
 		return this.config.get(key);
 	}

--- a/tests/shims/vault.ts
+++ b/tests/shims/vault.ts
@@ -33,7 +33,7 @@ export class MemoryVault {
 		return this.entries.get('/') as TFolder;
 	}
 
-	/** A vault setting, as Obsidian hands it out: undefined when never set. */
+	/** Undefined when never set, as Obsidian hands one out. */
 	getConfig(key: string): unknown {
 		return this.config.get(key);
 	}

--- a/tests/util/signature.test.ts
+++ b/tests/util/signature.test.ts
@@ -1,0 +1,44 @@
+/**
+ * The extension a file's own first bytes call for, which is what names an
+ * attachment whose source carries no extension of its own.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { extensionFromBytes } from '../../src/util';
+
+const bytes = (...values: number[]) => new Uint8Array(values);
+
+/** An ISO base media header, which is a length, "ftyp", and a brand. */
+function isoBrand(brand: string): Uint8Array {
+	const out = new Uint8Array(16);
+	for (let i = 0; i < 4; i++) out[4 + i] = 'ftyp'.charCodeAt(i);
+	for (let i = 0; i < 4; i++) out[8 + i] = brand.charCodeAt(i);
+
+	return out;
+}
+
+test('the formats an import is likely to meet', () => {
+	assert.equal(extensionFromBytes(bytes(0x89, 0x50, 0x4e, 0x47)), 'png');
+	assert.equal(extensionFromBytes(bytes(0xff, 0xd8, 0xff)), 'jpg');
+	assert.equal(extensionFromBytes(bytes(0x25, 0x50, 0x44, 0x46)), 'pdf');
+	assert.equal(extensionFromBytes(bytes(0x47, 0x49, 0x46, 0x38)), 'gif');
+	assert.equal(extensionFromBytes(bytes(0x00, 0x01, 0x02)), null);
+});
+
+/**
+ * An ISO base media file names its flavour in the brand after "ftyp", and most
+ * of them are not video. Calling an image mp4 leaves Obsidian treating it as
+ * one, which does not embed.
+ */
+test('an ISO base media file is named after its brand', () => {
+	assert.equal(extensionFromBytes(isoBrand('avif')), 'avif');
+	assert.equal(extensionFromBytes(isoBrand('avis')), 'avif');
+	assert.equal(extensionFromBytes(isoBrand('heic')), 'heic');
+	assert.equal(extensionFromBytes(isoBrand('heix')), 'heic');
+	assert.equal(extensionFromBytes(isoBrand('mif1')), 'heic');
+	assert.equal(extensionFromBytes(isoBrand('msf1')), 'heic');
+	assert.equal(extensionFromBytes(isoBrand('qt  ')), 'mov');
+	assert.equal(extensionFromBytes(isoBrand('mp42')), 'mp4');
+	assert.equal(extensionFromBytes(isoBrand('isom')), 'mp4');
+});


### PR DESCRIPTION
Fixes several Apple Notes import issues.

Formatting
- Keeps line breaks and pipes inside table cells (#243).
- Converts soft returns based on list context and the vault’s strict line-break setting (#328, superseding #573).
- Preserves list and checkbox prefixes when a line starts with an inline attachment (#471).

Titles

- Names notes from their first non-blank line, capped at 200 characters (#541).
- Keeps URL-only first lines in the note body (#591).
- Preserves titles that parent nested list items.
- Uses the derived title in duplicate and unchanged-note messages, including the relevant part of #564.

Tags

- Escapes plain-text hashes that Obsidian would otherwise interpret as tags (#471).
- Documents the current handling of Apple tags containing spaces or only digits (#471).

Attachments

- Missing rows no longer abort the note import (#218, #391).
- Scan fallbacks report a failure only when both sources fail (#393).
- Non-downloaded iCloud drawings are skipped.
- Errors identify the containing note and every searched path.
- Media files without extensions are identified from their contents (#471).