### PR TITLE
Centralize Markdown formatting

### DIFF
--- a/src/format-importer.ts
+++ b/src/format-importer.ts
@@ -4,6 +4,7 @@ import { HostPlugin } from './plugin-data';
 import { AuthCallback } from './constants';
 import { FolderSuggest } from './folder-suggest';
 import { ImportContext } from './import-context';
+import { formatMarkdown, markdownOutputFor } from './markdown-output';
 import { getUniqueFilePath, parseFrontMatterBlock, plural, sanitizeFileName, sanitizeFilePath } from './util';
 
 const MAX_PATH_DESCRIPTION_LENGTH = 300;
@@ -494,6 +495,10 @@ export abstract class FormatImporter {
 
 	async createFile(folder: TFolder, fileName: string, content: string, options?: DataWriteOptions): Promise<TFile> {
 		const path = getUniqueFilePath(this.vault, folder.path, fileName);
+
+		if (path.toLowerCase().endsWith('.md')) {
+			content = formatMarkdown(content, markdownOutputFor(this.vault));
+		}
 
 		return await this.vault.create(path, content, options);
 	}

--- a/src/formats/airtable-api.ts
+++ b/src/formats/airtable-api.ts
@@ -8,6 +8,7 @@ import { DuplicateHandling, FormatImporter } from '../format-importer';
 import { ImportContext } from '../import-context';
 import { parseFilePath } from '../filesystem';
 import { extractErrorMessage, sanitizeFileName, getUniqueFilePath, updatePropertyTypes, plural } from '../util';
+import { createMarkdown } from '../markdown-output';
 import { areAnySelected, selectedNodes } from '../tree';
 import { TreePicker } from '../tree-view';
 import type { FormulaImportStrategy } from '../base';
@@ -1186,7 +1187,7 @@ export class AirtableAPIImporter extends FormatImporter {
 			formatAttachmentsForYAML,
 		});
 
-		await this.vault.create(filePath, content);
+		await createMarkdown(this.vault, filePath, content);
 
 		ctx.reportNoteSuccess(title);
 

--- a/src/formats/apple-journal.ts
+++ b/src/formats/apple-journal.ts
@@ -4,6 +4,7 @@ import type { PickedFile } from '../filesystem';
 import { fs, os, path } from '../filesystem';
 import { DuplicateHandling, FormatImporter } from '../format-importer';
 import type { ImportContext } from '../import-context';
+import { createMarkdown, formattedMarkdown, modifyMarkdown } from '../markdown-output';
 import { sanitizeFileName } from '../util';
 import { convertJournalEntry } from './apple-journal/convert';
 
@@ -104,17 +105,17 @@ export class AppleJournalImporter extends FormatImporter {
 
 			if (this.duplicateHandling === DuplicateHandling.ImportUpdated) {
 				const existingContent = await this.vault.read(existingFile);
-				if (existingContent === mdContent) {
+				if (existingContent === formattedMarkdown(this.vault, mdContent)) {
 					ctx.reportSkipped(file.fullpath, 'journal entry unchanged since last import');
 					return false;
 				}
 			}
 
-			await this.vault.modify(existingFile, mdContent);
+			await modifyMarkdown(this.vault, existingFile, mdContent);
 			return true;
 		}
 
-		await this.vault.create(fullPath, mdContent);
+		await createMarkdown(this.vault, fullPath, mdContent);
 		return true;
 	}
 }

--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -6,6 +6,7 @@ import { ImportContext } from '../import-context';
 import { fs, fsPromises, nodeBufferToArrayBuffer, os, parseFilePath, path, splitext, zlib } from '../filesystem';
 import { extensionFromBytes, extractErrorMessage, sanitizeFileName, serializeFrontMatter } from '../util';
 import { DuplicateHandling, FormatImporter } from '../format-importer';
+import { modifyMarkdown } from '../markdown-output';
 import { selectedNodes } from '../tree';
 import { TreePicker, ViewableNode } from '../tree-view';
 import { Root } from 'protobufjs';
@@ -549,7 +550,7 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 		// Notes may reference other notes, so we want them in resolvedFiles before we parse to avoid cycles
 		const body = await converter.format(false, file.path);
 
-		await this.vault.modify(file, this.noteIdFrontMatter(row.ZIDENTIFIER) + body, {
+		await modifyMarkdown(this.vault, file, this.noteIdFrontMatter(row.ZIDENTIFIER) + body, {
 			ctime: this.decodeTime(row.ZCREATIONDATE3 || row.ZCREATIONDATE2 || row.ZCREATIONDATE1),
 			mtime: this.decodeTime(row.ZMODIFICATIONDATE1)
 		});

--- a/src/formats/evernote-enex.ts
+++ b/src/formats/evernote-enex.ts
@@ -1,8 +1,10 @@
 import { FileSystemAdapter, Notice } from 'obsidian';
 import { helpUrl } from '../constants';
 import { path } from '../filesystem';
+import { markdownOutputFor } from '../markdown-output';
 import { FormatImporter } from '../format-importer';
 import { ImportContext } from '../import-context';
+import { setMarkdownOutput } from './yarle/options';
 import { defaultYarleOptions, dropTheRope } from './yarle/yarle';
 
 const HELP_PERMALINK = 'import/evernote';
@@ -38,6 +40,9 @@ export class EvernoteEnexImporter extends FormatImporter {
 		let { app } = this;
 		let adapter = app.vault.adapter;
 		if (!(adapter instanceof FileSystemAdapter)) return;
+
+		// yarle writes its own files rather than through the vault
+		setMarkdownOutput(markdownOutputFor(app.vault));
 
 		let yarleOptions = {
 			...defaultYarleOptions,

--- a/src/formats/html.ts
+++ b/src/formats/html.ts
@@ -11,6 +11,7 @@ import { FormatImporter } from '../format-importer';
 import { convertHtmlDocument } from './html/convert';
 import { ImportContext } from '../import-context';
 import { extensionForMime } from '../mime';
+import { modifyMarkdown } from '../markdown-output';
 import { stringToUtf8 } from '../util';
 
 export class HtmlImporter extends FormatImporter {
@@ -150,7 +151,7 @@ export class HtmlImporter extends FormatImporter {
 						mdContent = mdContent.substring(0, change.from) + change.text + mdContent.substring(change.to);
 					}
 
-					await this.vault.modify(tFile, mdContent);
+					await modifyMarkdown(this.vault, tFile, mdContent);
 				}
 				catch (e) {
 					ctx.reportFailed(file.fullpath, e);
@@ -232,7 +233,7 @@ export class HtmlImporter extends FormatImporter {
 					mdContent = mdContent.substring(0, change.from) + change.text + mdContent.substring(change.to);
 				}
 
-				await this.vault.modify(mdFile, mdContent);
+				await modifyMarkdown(this.vault, mdFile, mdContent);
 			}
 
 			ctx.reportNoteSuccess(file.fullpath);

--- a/src/formats/notion-api.ts
+++ b/src/formats/notion-api.ts
@@ -3,6 +3,7 @@ import { DuplicateHandling, FormatImporter } from '../format-importer';
 import { ImportContext } from '../import-context';
 import { Client, PageObjectResponse } from '@notionhq/client';
 import { extractErrorMessage, sanitizeFileName, serializeFrontMatter, getUniqueFilePath, plural } from '../util';
+import { createMarkdown, modifyMarkdown } from '../markdown-output';
 import { areAnySelected } from '../tree';
 import { TreePicker } from '../tree-view';
 import type { FormulaImportStrategy } from '../base';
@@ -821,7 +822,7 @@ export class NotionAPIImporter extends FormatImporter {
 					const options: DataWriteOptions = {};
 					if (page.created_time) options.ctime = new Date(page.created_time).getTime();
 					if (page.last_edited_time) options.mtime = new Date(page.last_edited_time).getTime();
-					await this.vault.create(normalizePath(finalPath), fullContent, options);
+					await createMarkdown(this.vault, normalizePath(finalPath), fullContent, options);
 				}
 				catch (error) {
 					console.error(`[CREATE FILE] Failed to create file: ${finalPath}`);
@@ -1552,5 +1553,5 @@ export class NotionAPIImporter extends FormatImporter {
 }
 
 function modifyFilePreservingTimestamps(vault: Vault, file: TFile, newContent: string): Promise<void> {
-	return vault.modify(file, newContent, { mtime: file.stat.mtime, ctime: file.stat.ctime });
+	return modifyMarkdown(vault, file, newContent, { mtime: file.stat.mtime, ctime: file.stat.ctime });
 }

--- a/src/formats/notion-api/block-converter.ts
+++ b/src/formats/notion-api/block-converter.ts
@@ -9,6 +9,7 @@ import {
 } from '@notionhq/client';
 import { normalizePath, TFile } from 'obsidian';
 import { parseFilePath } from '../../filesystem';
+import { createMarkdown } from '../../markdown-output';
 import { sanitizeFileName } from '../../util';
 import { getBlockChildren, processBlockChildren } from './api-helpers';
 import { downloadAndFormatAttachment, extractAttachmentFromBlock, getCaptionFromBlock } from './attachment-helpers';
@@ -765,7 +766,7 @@ async function createSyncedBlockFile(
 		}
 	
 		// Create the file
-		await vault.create(filePath, markdown);
+		await createMarkdown(vault, filePath, markdown);
 		
 		
 		return filePath;

--- a/src/formats/roam-json.ts
+++ b/src/formats/roam-json.ts
@@ -3,6 +3,7 @@ import { Notice, TFile, requestUrl } from 'obsidian';
 import { parseFilePath } from '../filesystem';
 import { DuplicateHandling, FormatImporter } from '../format-importer';
 import { helpUrl } from '../constants';
+import { formattedMarkdown, modifyMarkdown } from '../markdown-output';
 import { sanitizeFileName } from '../util';
 import { BlockInfo, RoamBlock, RoamPage } from './roam/models/roam-json';
 import { convertDateString, sanitizeFileNameKeepPath } from './roam/utils';
@@ -38,10 +39,6 @@ export class RoamJSONImporter extends FormatImporter {
 			'Pick the JSON file from your Roam export.');
 		this.addOutputLocationSetting('Roam');
 		this.userDNPFormat = this.getUserDNPFormat();
-
-		this.addSetting()
-			?.setName('Import settings')
-			.setHeading();
 
 		this.addSetting()
 			?.setName('Download all attachments')
@@ -158,7 +155,7 @@ export class RoamJSONImporter extends FormatImporter {
 				if (callingBlockMarkdown) {
 					let lines = callingBlockMarkdown.split('\n');
 
-					let index = lines.findIndex((item: string) => item.contains('* ' + callingBlockStringScrubbed));
+					let index = lines.findIndex((item: string) => item.contains('- ' + callingBlockStringScrubbed));
 					if (index !== -1) {
 						lines[index] = lines[index].replace(callingBlockStringScrubbed, newCallingBlockReferences);
 					}
@@ -192,13 +189,13 @@ export class RoamJSONImporter extends FormatImporter {
 							continue;
 						}
 
-						if (await vault.read(existingFile) === markdownOutput) {
+						if (await vault.read(existingFile) === formattedMarkdown(vault, markdownOutput)) {
 							progress.reportSkipped(filename, 'page unchanged since last import');
 							index++;
 							continue;
 						}
 
-						await vault.modify(existingFile, markdownOutput);
+						await modifyMarkdown(vault, existingFile, markdownOutput);
 					}
 					else {
 						await this.createFile(folder, name, markdownOutput);
@@ -299,7 +296,7 @@ export class RoamJSONImporter extends FormatImporter {
 				let lines = markdown.split('\n');
 
 				// Edit the specific line, for example, the 5th line.
-				let index = lines.findIndex((item: string) => item.contains('* ' + sourceBlock.blockString));
+				let index = lines.findIndex((item: string) => item.contains('- ' + sourceBlock.blockString));
 				if (index !== -1) {
 					let newSourceBlockString = sourceBlock.blockString + ' ^' + sourceBlockUID;
 

--- a/src/formats/roam/convert.ts
+++ b/src/formats/roam/convert.ts
@@ -2,6 +2,8 @@ import { moment } from 'obsidian';
 import { RoamBlock, RoamPage } from './models/roam-json';
 import { convertDateString, sanitizeFileNameKeepPath } from './utils';
 
+const INDENT = '    ';
+
 const roamSpecificMarkup = ['POMO', 'word-count', 'date', 'slider', 'encrypt', 'TaoOfRoam', 'orphans', 'count', 'character-count', 'comment-button', 'query', 'streak', 'attr-table', 'mentions', 'search', 'roam/render', 'calc'];
 const roamSpecificMarkupRe = new RegExp(`\\{\\{(\\[\\[)?(${roamSpecificMarkup.join('|')})(\\]\\])?.*?\\}\\}(\\})?`, 'g');
 
@@ -103,12 +105,20 @@ export class RoamPageConverter {
 		if ('string' in json && json.string) {
 			const prefix = json.heading ? '#'.repeat(json.heading) + ' ' : '';
 			const scrubbed = await this.roamMarkupScrubber(graphFolder, attachmentsFolder, json.string);
-			markdown.push(`${isChild ? indent + '* ' : indent}${prefix}${scrubbed}`);
+			// A block can hold several lines - a fence, say - and every one after the
+			// first has to be indented or it falls out of the item
+			const [first, ...rest] = `${prefix}${scrubbed}`.split('\n');
+			const continuation = isChild ? indent + '  ' : indent;
+			markdown.push([
+				`${isChild ? indent + '- ' : indent}${first}`,
+				...rest.map(line => line ? continuation + line : line),
+			].join('\n'));
 		}
 
 		if (json.children) {
 			for (const child of json.children) {
-				markdown.push(await this.jsonToMarkdown(graphFolder, attachmentsFolder, child, indent + '  ', true, '', this.oldestTimestamp, this.newestTimestamp));
+				// The page is not a bullet, so its own blocks start at the margin
+				markdown.push(await this.jsonToMarkdown(graphFolder, attachmentsFolder, child, isChild ? indent + INDENT : indent, true, '', this.oldestTimestamp, this.newestTimestamp));
 			}
 		}
 

--- a/src/formats/yarle/options.ts
+++ b/src/formats/yarle/options.ts
@@ -1,5 +1,17 @@
 import { PickedFile } from '../../filesystem';
 import { TagSeparatorReplaceOptions } from './models';
+import type { MarkdownOutput } from '../../markdown-output';
+
+/** Set by the importer, because yarle's writes never reach createMarkdown. */
+let markdownOutput: MarkdownOutput = { indentUnit: '    ' };
+
+export function setMarkdownOutput(output: MarkdownOutput): void {
+	markdownOutput = output;
+}
+
+export function getMarkdownOutput(): MarkdownOutput {
+	return markdownOutput;
+}
 
 export interface YarleOptions {
 	enexSources: PickedFile[];

--- a/src/formats/yarle/utils/file-utils.ts
+++ b/src/formats/yarle/utils/file-utils.ts
@@ -1,11 +1,13 @@
 import { EvernoteNote } from '../models/EvernoteNote';
 import { fs } from '../../../filesystem';
+import { formatMarkdown } from '../../../markdown-output';
+import { getMarkdownOutput } from '../options';
 
 import { setFileDates } from './content-utils';
 
 export const writeFile = (absFilePath: string, data: string, note: EvernoteNote): void => {
 	try {
-		fs.writeFileSync(absFilePath, data);
+		fs.writeFileSync(absFilePath, formatMarkdown(data, getMarkdownOutput()));
 		setFileDates(absFilePath, note);
 	}
 	catch (e) {

--- a/src/formats/yarle/yarle.ts
+++ b/src/formats/yarle/yarle.ts
@@ -2,7 +2,8 @@ import { EvernoteNote, EvernoteNoteAttributes, EvernoteResourceAttributes } from
 import { fs, NodePickedFile, PickedFile } from '../../filesystem';
 import { ImportContext } from '../../import-context';
 import { mapEvernoteTask } from './models/EvernoteTask';
-import { YarleOptions } from './options';
+import { formatMarkdown } from '../../markdown-output';
+import { getMarkdownOutput, YarleOptions } from './options';
 import { processNode } from './process-node';
 import { convertTasktoMd } from './process-tasks';
 import { RuntimePropertiesSingleton } from './runtime-properties';
@@ -186,7 +187,7 @@ export const parseStream = async (options: YarleOptions, enexSource: PickedFile,
 
 					let updatedContent = fileContent.replace(taskPlaceholder, [...sortedTasks.values()].join('\n'));
 
-					fs.writeFileSync(currentNotePath, updatedContent);
+					fs.writeFileSync(currentNotePath, formatMarkdown(updatedContent, getMarkdownOutput()));
 				}
 			}
 		});

--- a/src/markdown-output.ts
+++ b/src/markdown-output.ts
@@ -1,0 +1,143 @@
+/**
+ * The markdown every importer writes, in the form this vault writes it.
+ *
+ * Conversions produce what they find natural - four spaces a level, or tabs -
+ * and the vault's preferences are applied here instead, so the same note does
+ * not import differently depending on where it came from.
+ */
+import { DataWriteOptions, TFile, Vault } from 'obsidian';
+
+export interface MarkdownOutput {
+	indentUnit: string;
+}
+
+/** The step a conversion indents by before this runs. A tab counts as one too. */
+const CONVERSION_STEP = 4;
+
+const LIST_MARKER = /^(?:[-*+]|\d+[.)])(?:[ \t]+|$)/;
+const FENCE_OPEN = /^(`{3,}|~{3,})/;
+/** A fence closes on its own delimiter, at least as long, and nothing after it. */
+const FENCE_CLOSE = /^(`{3,}|~{3,})[ \t]*\r?$/;
+/** "***" and "* * *" open with what looks like a bullet, and are not one. */
+const THEMATIC_BREAK = /^([-*_])(?:[ \t]*\1){2,}[ \t]*$/;
+
+/** The bullet Obsidian itself writes, in turndown and in the editor. */
+const BULLET = '-';
+
+export function markdownOutputFor(vault: Vault): MarkdownOutput {
+	// Not tabSize: that is how wide a tab is drawn, and spaces are always four
+	return { indentUnit: vault.getConfig('useTab') ? '\t' : '    ' };
+}
+
+/**
+ * What writing this content would put in the file.
+ *
+ * Compare against this rather than the converter's own output, or a note that
+ * was formatted on the way in never matches and is rewritten every import.
+ */
+export function formattedMarkdown(vault: Vault, content: string): string {
+	return formatMarkdown(content, markdownOutputFor(vault));
+}
+
+export async function createMarkdown(vault: Vault, path: string, content: string, options?: DataWriteOptions): Promise<TFile> {
+	return await vault.create(path, formattedMarkdown(vault, content), options);
+}
+
+export async function modifyMarkdown(vault: Vault, file: TFile, content: string, options?: DataWriteOptions): Promise<void> {
+	return await vault.modify(file, formattedMarkdown(vault, content), options);
+}
+
+/**
+ * Write a list the way this vault writes one: its indent, and Obsidian's bullet.
+ *
+ * Only in front of a list item and the lines that belong to one, so a note
+ * indented for some other reason is left as it was.
+ */
+export function formatMarkdown(content: string, { indentUnit }: MarkdownOutput): string {
+	const lines = content.split('\n');
+
+	// Where a fence's contents sit and where they are going, so code indented
+	// four spaces moves with its fence rather than being read as a level
+	let fenceFrom: string | null = null;
+	let fenceTo: string | null = null;
+	// The delimiter that opened it. A ``` line inside a ```` fence is code
+	let fenceDelimiter = '';
+	let inList = false;
+
+	for (let i = frontMatterEnd(lines); i < lines.length; i++) {
+		const line = lines[i];
+		const indent = line.match(/^[\t ]*/)![0];
+		const rest = line.slice(indent.length);
+
+		if (fenceFrom !== null) {
+			if (line.startsWith(fenceFrom)) lines[i] = fenceTo + line.slice(fenceFrom.length);
+			if (closes(rest, fenceDelimiter)) fenceFrom = fenceTo = null;
+			continue;
+		}
+
+		if (rest.trim() === '') continue; // A blank line does not end the item
+
+		const marker = THEMATIC_BREAK.test(rest) ? '' : rest.match(LIST_MARKER)?.[0] ?? '';
+		const opened = rest.slice(marker.length).match(FENCE_OPEN)?.[1];
+
+		const reindented: string = marker || (inList && indent !== '')
+			? reindent(indent, indentUnit)
+			: indent;
+
+		lines[i] = reindented + (/^[*+]/.test(marker) ? BULLET + rest.slice(1) : rest);
+		inList = reindented !== indent || !!marker || (inList && indent !== '');
+
+		if (opened) {
+			// A fence can open on a list item's own line: "- ```js"
+			fenceFrom = indent + ' '.repeat(marker.length);
+			fenceTo = reindented + ' '.repeat(marker.length);
+			fenceDelimiter = opened;
+		}
+	}
+
+	return lines.join('\n');
+}
+
+function closes(rest: string, delimiter: string): boolean {
+	const fence = rest.match(FENCE_CLOSE)?.[1];
+
+	return !!fence && fence[0] === delimiter[0] && fence.length >= delimiter.length;
+}
+
+/**
+ * The line after the frontmatter, whose YAML cannot be indented with a tab.
+ *
+ * The carriage return of a CRLF file survives splitting on \n, and a delimiter
+ * that is not recognised leaves the frontmatter to be rewritten as a list.
+ */
+function frontMatterEnd(lines: string[]): number {
+	const isDelimiter = (line: string | undefined) => line?.replace(/\r$/, '') === '---';
+
+	if (!isDelimiter(lines[0])) return 0;
+
+	const close = lines.findIndex((line, i) => i > 0 && isDelimiter(line));
+	return close === -1 ? 0 : close + 1;
+}
+
+/**
+ * Whatever does not divide into steps is kept: it is the two spaces aligning a
+ * wrapped line under its item's text, and moving it takes the line out of the item.
+ */
+function reindent(indent: string, indentUnit: string): string {
+	let steps = 0;
+	let at = 0;
+
+	while (at < indent.length) {
+		if (indent[at] === '\t') {
+			steps++;
+			at++;
+		}
+		else if (indent.startsWith(' '.repeat(CONVERSION_STEP), at)) {
+			steps++;
+			at += CONVERSION_STEP;
+		}
+		else break;
+	}
+
+	return indentUnit.repeat(steps) + indent.slice(at);
+}

--- a/tests/markdown-output/markdown-output.test.ts
+++ b/tests/markdown-output/markdown-output.test.ts
@@ -1,0 +1,203 @@
+/**
+ * The pass that puts every importer's markdown in the vault's form.
+ *
+ * Checked here rather than in a recording, which would have to pick one vault
+ * to be recorded against.
+ */
+import '../shims/runtime';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { formatMarkdown } from '../../src/markdown-output';
+
+const TABS = { indentUnit: '\t' };
+const SPACES = { indentUnit: '    ' };
+
+test('rewrites four-space list indentation as tabs', () => {
+	const converted = [
+		'- Block level',
+		'    - testing',
+		'    - test',
+		'        - testing',
+	].join('\n');
+
+	assert.equal(formatMarkdown(converted, TABS), [
+		'- Block level',
+		'\t- testing',
+		'\t- test',
+		'\t\t- testing',
+	].join('\n'));
+});
+
+test('rewrites tab list indentation as spaces', () => {
+	const converted = [
+		'- Block level',
+		'\t- testing',
+		'\t\t- testing',
+	].join('\n');
+
+	assert.equal(formatMarkdown(converted, SPACES), [
+		'- Block level',
+		'    - testing',
+		'        - testing',
+	].join('\n'));
+});
+
+test('leaves indentation already in the vault\'s form alone', () => {
+	const markdown = ['- one', '    - two'].join('\n');
+
+	assert.equal(formatMarkdown(markdown, SPACES), markdown);
+});
+
+test('handles ordered and task lists', () => {
+	assert.equal(formatMarkdown(['1. one', '    2. two'].join('\n'), TABS), ['1. one', '\t2. two'].join('\n'));
+	assert.equal(formatMarkdown(['- [ ] one', '    - [x] two'].join('\n'), TABS), ['- [ ] one', '\t- [x] two'].join('\n'));
+});
+
+test('keeps the alignment that holds a wrapped line inside its item', () => {
+	assert.equal(
+		formatMarkdown(['- one', '    - two', '      wrapped'].join('\n'), TABS),
+		['- one', '\t- two', '\t  wrapped'].join('\n'));
+});
+
+test('moves a fenced block with its item without touching the code', () => {
+	const converted = [
+		'- Code',
+		'    - ```python',
+		'      def f():',
+		'          return 1',
+		'      ```',
+	].join('\n');
+
+	// The code keeps its four-space indent: it is Python, not a list
+	assert.equal(formatMarkdown(converted, TABS), [
+		'- Code',
+		'\t- ```python',
+		'\t  def f():',
+		'\t      return 1',
+		'\t  ```',
+	].join('\n'));
+});
+
+test('leaves a list inside a code fence as written', () => {
+	// A sample of markdown, not a list: reindenting it changes the code
+	const markdown = [
+		'```markdown',
+		'- one',
+		'    - two',
+		'```',
+	].join('\n');
+
+	assert.equal(formatMarkdown(markdown, TABS), markdown);
+});
+
+test('leaves indentation that is not a list alone', () => {
+	const markdown = [
+		'A paragraph.',
+		'',
+		'    an indented code block',
+		'',
+		'```',
+		'    indented inside a fence',
+		'```',
+	].join('\n');
+
+	assert.equal(formatMarkdown(markdown, TABS), markdown);
+});
+
+test('does not carry a list across the paragraph that ends it', () => {
+	const markdown = [
+		'- one',
+		'',
+		'A paragraph.',
+		'',
+		'    an indented code block',
+	].join('\n');
+
+	assert.equal(formatMarkdown(markdown, TABS), markdown);
+});
+
+test('leaves frontmatter alone', () => {
+	const markdown = [
+		'---',
+		'aliases:',
+		'  - one',
+		'---',
+		'',
+		'- one',
+	].join('\n');
+
+	assert.equal(formatMarkdown(markdown, TABS), markdown);
+});
+
+test('writes every bullet as a dash', () => {
+	assert.equal(
+		formatMarkdown(['* one', '    + two', '        - three'].join('\n'), SPACES),
+		['- one', '    - two', '        - three'].join('\n'));
+});
+
+test('leaves ordered lists numbered as they were', () => {
+	const markdown = ['1. one', '2) two'].join('\n');
+
+	assert.equal(formatMarkdown(markdown, SPACES), markdown);
+});
+
+test('does not mistake a thematic break for a bullet', () => {
+	const markdown = ['* * *', '***', '- - -', '___'].join('\n');
+
+	assert.equal(formatMarkdown(markdown, SPACES), markdown);
+});
+
+test('leaves emphasis at the start of a line alone', () => {
+	const markdown = ['*italic* text', '**bold** text'].join('\n');
+
+	assert.equal(formatMarkdown(markdown, SPACES), markdown);
+});
+
+test('leaves CRLF frontmatter alone', () => {
+	// The \r survives splitting on \n, and an unrecognised delimiter would leave
+	// the YAML below to be rewritten as a list
+	const markdown = ['---', 'aliases:', '    - one', '---', '', '- one', '    - two'].join('\r\n');
+
+	assert.equal(formatMarkdown(markdown, TABS),
+		['---', 'aliases:', '    - one', '---', '', '- one', '\t- two'].join('\r\n'));
+});
+
+test('closes a fence only on its own delimiter', () => {
+	const markdown = [
+		'- Code',
+		'    - ````markdown',
+		'      ```',
+		'      * not a bullet',
+		'      ```',
+		'      ````',
+		'    - after',
+	].join('\n');
+
+	assert.equal(formatMarkdown(markdown, TABS), [
+		'- Code',
+		'\t- ````markdown',
+		'\t  ```',
+		'\t  * not a bullet',
+		'\t  ```',
+		'\t  ````',
+		'\t- after',
+	].join('\n'));
+});
+
+test('a tilde line does not close a backtick fence', () => {
+	const markdown = ['```', '~~~', '* not a bullet', '```'].join('\n');
+
+	assert.equal(formatMarkdown(markdown, TABS), markdown);
+});
+
+test('formatting what was already formatted changes nothing', () => {
+	// What lets an importer compare a converted note against the file on disk
+	const converted = ['---', 'a: 1', '---', '', '* one', '    + two', '        - three'].join('\n');
+
+	for (const output of [TABS, SPACES]) {
+		const once = formatMarkdown(converted, output);
+		assert.equal(formatMarkdown(once, output), once);
+	}
+});

--- a/tests/roam/convert.test.ts
+++ b/tests/roam/convert.test.ts
@@ -125,3 +125,56 @@ test('turns a Roam quote into a blockquote', async () => {
 test('turns a page alias into an Obsidian alias', async () => {
 	assert.equal(await scrubber().roamMarkupScrubber('', '', '[shown]([[Real Page]])'), '[[Real Page|shown]]');
 });
+
+/** The conversion writes four spaces a level; markdown-output.ts applies what the vault uses. */
+function outline() {
+	const converter = new RoamPageConverter({
+		userDNPFormat: DAILY_NOTE_FORMAT,
+		fileDateYAML: false,
+		titleYAML: false,
+		downloadAttachments: false,
+	});
+
+	const page = {
+		title: 'Outline',
+		children: [{
+			string: 'Block level',
+			children: [
+				{ string: 'testing' },
+				{ string: 'test', children: [{ string: 'testing' }] },
+			],
+		}],
+	} as unknown as RoamPage;
+
+	return converter.jsonToMarkdown('graph', 'graph/Attachments', page, '', false, '', 0, 0);
+}
+
+test('starts the outline at the margin and indents each level by four spaces', async () => {
+	assert.equal(await outline(), [
+		'- Block level',
+		'    - testing',
+		'    - test',
+		'        - testing',
+	].join('\n'));
+});
+
+test('indents the lines after the first to the item text, so a fence stays in the item', async () => {
+	const converter = new RoamPageConverter({
+		userDNPFormat: DAILY_NOTE_FORMAT,
+		fileDateYAML: false,
+		titleYAML: false,
+		downloadAttachments: false,
+	});
+
+	const page = {
+		title: 'Code',
+		children: [{ string: 'Code', children: [{ string: '```js\none();\ntwo();```' }] }],
+	} as unknown as RoamPage;
+
+	assert.equal(await converter.jsonToMarkdown('graph', 'graph/Attachments', page, '', false, '', 0, 0), [
+		'- Code',
+		'    - ```js',
+		'      one();',
+		'      two();```',
+	].join('\n'));
+});

--- a/tests/roam/expected/help-graph-excerpt/2021-02-01.md
+++ b/tests/roam/expected/help-graph-excerpt/2021-02-01.md
@@ -1,1 +1,1 @@
-  * [ ] Have a [[meeting]] with [[John Smith]] about [[Roam Research]] on [[2021-02-08]]. #marketing
+- [ ] Have a [[meeting]] with [[John Smith]] about [[Roam Research]] on [[2021-02-08]]. #marketing

--- a/tests/roam/expected/help-graph-excerpt/2021-10-07.md
+++ b/tests/roam/expected/help-graph-excerpt/2021-10-07.md
@@ -1,1 +1,1 @@
-  * ((0yr0CgkfA))
+- ((0yr0CgkfA))

--- a/tests/roam/expected/help-graph-excerpt/2023-02-10.md
+++ b/tests/roam/expected/help-graph-excerpt/2023-02-10.md
@@ -1,71 +1,71 @@
-  * [[Project 30 Demos in 6 Weeks]]
-    * {{[[help-graph-excerpt/DONE]]}} [[Experiment]] - Demo how it was possible to use the combination of [[roam/render]] and [[roam/templates|DONE]]}} [[Experiment]] - Demo how it was possible to use the combination of [[roam/render]] and [[roam/templates]] to create a **factory template** the creates customizable dropdowns which add block-refs to a selected item from a particular list.
-      * Video
-        * {{[[video]]: https://www.loom.com/share/1adf78d01db9435fb69bf4249a296a66}}
-      * To use 
-        * [ ] copy this block into your graph #.bp3-card
-          * ## Conor's [[help-graph-excerpt/Factory Template]] for creating Option Dropdowns based on block refences  #[[roam/templates|Factory Template]] for creating Option Dropdowns based on block refences  #[[roam/templates]]
-            * Congratulations! You have just created a new **Dropdown Template** 
-              * #.rm-g  #.rm-h 
-                * [ ] Edit the block below to change the template
-                  * [[help-graph-excerpt/RM/Component/Select]] an item from ((iYpGdGk0B)) [[roam/templates|RM/Component/Select]] an item from ((iYpGdGk0B)) [[roam/templates]]
-                    * 
-                * [ ] Edit these blocks to change the items visible in the dropdown
-                  * Dropdown List
-                    * A
-                    * B
-                    * C
-            * [ ]  Apply the template #.rm-E 
-              * [ ] type `;;`   
-              * {{((ovqdW0R_j)) 
-              *  This will produce a custom Select Component like this one 
-                *  
-                * built off this  ((iYpGdGk0B))
-            * This component is an experiment, and was built paritally as a demo of what you can do with  [[help-graph-excerpt/roam/render|roam/render]] - a feature of roam that allows you to build interactive components out of code blocks written *inside* your roam graph and referenced by the component in this format `` 
-              * If you'd like to edit the code for the template - you can edit it ((pBiRi-Hba))
-                * ```clojure
-(ns niki.dropdown
-  (:require
-    [clojure.string :as str]
-    [roam.block :as block]
-    [roam.datascript.reactive :as dr]))
+- [[Project 30 Demos in 6 Weeks]]
+    - {{[[help-graph-excerpt/DONE]]}} [[Experiment]] - Demo how it was possible to use the combination of [[roam/render]] and [[roam/templates|DONE]]}} [[Experiment]] - Demo how it was possible to use the combination of [[roam/render]] and [[roam/templates]] to create a **factory template** the creates customizable dropdowns which add block-refs to a selected item from a particular list.
+        - Video
+            - {{[[video]]: https://www.loom.com/share/1adf78d01db9435fb69bf4249a296a66}}
+        - To use 
+            - [ ] copy this block into your graph #.bp3-card
+                - ## Conor's [[help-graph-excerpt/Factory Template]] for creating Option Dropdowns based on block refences  #[[roam/templates|Factory Template]] for creating Option Dropdowns based on block refences  #[[roam/templates]]
+                    - Congratulations! You have just created a new **Dropdown Template** 
+                        - #.rm-g  #.rm-h 
+                            - [ ] Edit the block below to change the template
+                                - [[help-graph-excerpt/RM/Component/Select]] an item from ((iYpGdGk0B)) [[roam/templates|RM/Component/Select]] an item from ((iYpGdGk0B)) [[roam/templates]]
+                                    - 
+                            - [ ] Edit these blocks to change the items visible in the dropdown
+                                - Dropdown List
+                                    - A
+                                    - B
+                                    - C
+                    - [ ]  Apply the template #.rm-E 
+                        - [ ] type `;;`   
+                        - {{((ovqdW0R_j)) 
+                        -  This will produce a custom Select Component like this one 
+                            -  
+                            - built off this  ((iYpGdGk0B))
+                    - This component is an experiment, and was built paritally as a demo of what you can do with  [[help-graph-excerpt/roam/render|roam/render]] - a feature of roam that allows you to build interactive components out of code blocks written *inside* your roam graph and referenced by the component in this format `` 
+                        - If you'd like to edit the code for the template - you can edit it ((pBiRi-Hba))
+                            - ```clojure
+                              (ns niki.dropdown
+                                (:require
+                                  [clojure.string :as str]
+                                  [roam.block :as block]
+                                  [roam.datascript.reactive :as dr]))
 
-(defn replace-with-block-ref [block-uid opts-uid ref-uid]
-  (let [before (->> [:block/uid block-uid]
-                 (dr/pull [:block/string])
-                 (deref)
-                 :block/string)
-        pattern (re-pattern
-                  (str
-                    "\\{\\{"
-                    "(?:\\[\\[)?roam/render(?:\\]\\])?:" ;; [[help-graph-excerpt/roam/render|roam/render]]
-                    "\\s*"
-                    "\\(\\(([a-zA-Z0-9-]+)\\)\\)"        ;; render code block
-                    "\\s*"
-                    "\\(\\((" opts-uid ")\\)\\)"         ;; options block
-                    "\\s*"
-                    "(\\(\\(([a-zA-Z0-9-]+)\\)\\))?"     ;; selected block
-                    "\\}\\}"))
-        after   (str/replace before pattern
-                  (str ""))]
-    (block/update
-      {:block
-       {:uid block-uid 
-        :string after}})))
+                              (defn replace-with-block-ref [block-uid opts-uid ref-uid]
+                                (let [before (->> [:block/uid block-uid]
+                                               (dr/pull [:block/string])
+                                               (deref)
+                                               :block/string)
+                                      pattern (re-pattern
+                                                (str
+                                                  "\\{\\{"
+                                                  "(?:\\[\\[)?roam/render(?:\\]\\])?:" ;; [[help-graph-excerpt/roam/render|roam/render]]
+                                                  "\\s*"
+                                                  "\\(\\(([a-zA-Z0-9-]+)\\)\\)"        ;; render code block
+                                                  "\\s*"
+                                                  "\\(\\((" opts-uid ")\\)\\)"         ;; options block
+                                                  "\\s*"
+                                                  "(\\(\\(([a-zA-Z0-9-]+)\\)\\))?"     ;; selected block
+                                                  "\\}\\}"))
+                                      after   (str/replace before pattern
+                                                (str ""))]
+                                  (block/update
+                                    {:block
+                                     {:uid block-uid 
+                                      :string after}})))
 
-(defn view-children-clickable [block-uid opts-uid selected-uid]
-  (let [children (->> [:block/uid opts-uid]
-                   (dr/pull [{:block/children [:block/uid :block/string]}])
-                   deref
-                   :block/children)]
-    [:select {:id opts-uid
-              :on-change #(replace-with-block-ref block-uid opts-uid (-> % .-target .-value))}
-     (for [c children]
-       [:option
-        {:value    (:block/uid c)
-         :selected (= (:block/uid c) selected-uid)
-         :on-change #(replace-with-block-ref (:block/string c))}
-        (:block/string c)])]))
+                              (defn view-children-clickable [block-uid opts-uid selected-uid]
+                                (let [children (->> [:block/uid opts-uid]
+                                                 (dr/pull [{:block/children [:block/uid :block/string]}])
+                                                 deref
+                                                 :block/children)]
+                                  [:select {:id opts-uid
+                                            :on-change #(replace-with-block-ref block-uid opts-uid (-> % .-target .-value))}
+                                   (for [c children]
+                                     [:option
+                                      {:value    (:block/uid c)
+                                       :selected (= (:block/uid c) selected-uid)
+                                       :on-change #(replace-with-block-ref (:block/string c))}
+                                      (:block/string c)])]))
 
-(defn main [{:keys [block-uid]} [_ opts-uid] & [[_ selected-uid]]]
-  [view-children-clickable block-uid opts-uid selected-uid])```
+                              (defn main [{:keys [block-uid]} [_ opts-uid] & [[_ selected-uid]]]
+                                [view-children-clickable block-uid opts-uid selected-uid])```

--- a/tests/roam/expected/help-graph-excerpt/Code Block.md
+++ b/tests/roam/expected/help-graph-excerpt/Code Block.md
@@ -1,35 +1,35 @@
-  * You can include code in different programming languages in Roam, for example
-    * JS block
-      * ```javascript
-<!DOCTYPE HTML>
-<html>
+- You can include code in different programming languages in Roam, for example
+    - JS block
+        - ```javascript
+          <!DOCTYPE HTML>
+          <html>
 
-<body>
+          <body>
 
-  <p>Before the script...</p>
+            <p>Before the script...</p>
 
-  <script>
-    alert( 'Hello, Roamans!' );
-  </script>
+            <script>
+              alert( 'Hello, Roamans!' );
+            </script>
 
-  <p>...After the script.</p>
+            <p>...After the script.</p>
 
-</body>
+          </body>
 
-</html>```
-    * CSS block
-      * ```css
-<style type="text/css">
-h1 {
-	color: DeepSkyBlue;
-}
-</style>
+          </html>```
+    - CSS block
+        - ```css
+          <style type="text/css">
+          h1 {
+          	color: DeepSkyBlue;
+          }
+          </style>
 
-<h1>Hello, Roamans!</h1>```
-    * Clojure block
-      * ```clojure
-(ns hello-world.core)
+          <h1>Hello, Roamans!</h1>```
+    - Clojure block
+        - ```clojure
+          (ns hello-world.core)
 
-(println "Hello Roamans!")```
-  * Key Commands:
-    * `/code block`
+          (println "Hello Roamans!")```
+- Key Commands:
+    - `/code block`

--- a/tests/roam/expected/help-graph-excerpt/Community Videos.md
+++ b/tests/roam/expected/help-graph-excerpt/Community Videos.md
@@ -1,3 +1,3 @@
-  * ### [Request to be featured](https://roamresearch.typeform.com/to/g5W8uCqz)
+- ### [Request to be featured](https://roamresearch.typeform.com/to/g5W8uCqz)
 
-  * ## Check out the [[Linked References|backlinks]] below to see all the videos our community has made!
+- ## Check out the [[Linked References|backlinks]] below to see all the videos our community has made!

--- a/tests/roam/expected/help-graph-excerpt/Customizable Hotkeys.md
+++ b/tests/roam/expected/help-graph-excerpt/Customizable Hotkeys.md
@@ -1,1 +1,1 @@
-  * ![](https://firebasestorage.googleapis.com/v0/b/example-graph/o/imgs%2Fapp%2Fhelp%2FOJFPJqjqmA.gif?alt=media&token=00000000-0000-0000-0000-000000000000)
+- ![](https://firebasestorage.googleapis.com/v0/b/example-graph/o/imgs%2Fapp%2Fhelp%2FOJFPJqjqmA.gif?alt=media&token=00000000-0000-0000-0000-000000000000)

--- a/tests/roam/expected/help-graph-excerpt/How to write a 21st Century Proof.md
+++ b/tests/roam/expected/help-graph-excerpt/How to write a 21st Century Proof.md
@@ -1,1 +1,1 @@
-  * source: https://lamport.azurewebsites.net/pubs/proof.pdf
+- source: https://lamport.azurewebsites.net/pubs/proof.pdf

--- a/tests/roam/expected/help-graph-excerpt/Latex.md
+++ b/tests/roam/expected/help-graph-excerpt/Latex.md
@@ -1,4 +1,4 @@
-  * Description:
-    * Any text entered with `$$double dollar signs$$` will be evaluated as latex, using [[Khan Academy]]'s katex typesetting library -- see docs for that here https://katex.org/ - particularly here https://katex.org/docs/supported.html
-  * [[Change Log]]
-    * ((UvCvJ2V3T))
+- Description:
+    - Any text entered with `$$double dollar signs$$` will be evaluated as latex, using [[Khan Academy]]'s katex typesetting library -- see docs for that here https://katex.org/ - particularly here https://katex.org/docs/supported.html
+- [[Change Log]]
+    - ((UvCvJ2V3T))

--- a/tests/roam/expected/help-graph-excerpt/Plugins.md
+++ b/tests/roam/expected/help-graph-excerpt/Plugins.md
@@ -1,4 +1,4 @@
-  * [[--]]
-    * # ((dmQooXFj9))((dmQooXFj9))((dmQooXFj9))
-    * # [Request to be featured](https://roamresearch.typeform.com/to/g5W8uCqz)
-    * # ((dmQooXFj9))((dmQooXFj9))((dmQooXFj9))
+- [[--]]
+    - # ((dmQooXFj9))((dmQooXFj9))((dmQooXFj9))
+    - # [Request to be featured](https://roamresearch.typeform.com/to/g5W8uCqz)
+    - # ((dmQooXFj9))((dmQooXFj9))((dmQooXFj9))

--- a/tests/roam/expected/help-graph-excerpt/Query.md
+++ b/tests/roam/expected/help-graph-excerpt/Query.md
@@ -1,41 +1,41 @@
-  * [[--]]
-    * # **Types of queries**
-      * ### **and**
-        * Find all blocks matching multiple conditions – i.e. blocks or their parents containing multiple page or block references.
-        * `
+- [[--]]
+    - # **Types of queries**
+        - ### **and**
+            - Find all blocks matching multiple conditions – i.e. blocks or their parents containing multiple page or block references.
+            - `
 
 
-`
-      * ### **or**
-        * Find all blocks matching any of a number of conditions – i.e. blocks or their parents containing any of the selected page or block references.
+              `
+        - ### **or**
+            - Find all blocks matching any of a number of conditions – i.e. blocks or their parents containing any of the selected page or block references.
 
-        * `
+            - `
 
 
-`
-      * ### **not**
-        * Exclude blocks matching any of the page or block references selected.
-        * `}
-}`
-      * ### **between**
-        * Finds all blocks on daily pages and blocks mentioning a date between two days. ==**This only works on Daily Notes page**==.
-        * You can use the following as a shorthand: [[today]], [[tomorrow]], [[yesterday]], [[last week]], [[next week]], [[last month]], and [[next month]]. 
-        * `
-}
-}`
-    * ## Community Videos:
-      * ### Query syntax and logic: how to ask Roam questions with queries by [[Sam Patel]]
-        * ![](https://www.youtube.com/watch?v=EXAMPLE0001&t=20s&ab_channel=RobertHaisfield)
-      * ### How Queries Work in Roam Research by [[R.J. Nestor]]
-        * ![](https://www.youtube.com/watch?v=EXAMPLE0001)
-      * ### Roam Research Search Queries by [[Alex Rivera]]
-        * ![](https://www.youtube.com/watch?v=EXAMPLE0001)
-      * ### Insight Hunting with Queries in Roam by [[Example Studio]]
-        * ![](https://www.youtube.com/watch?v=EXAMPLE0001)
-      * ### Roam Research Query Tutorial: Pending Tasks for Task Management and Task Dashboard Using Queries by [[The Upgraded Brain]]
-        * ![](https://www.youtube.com/watch?v=EXAMPLE0001)
-    * ## Articles:
-      * ### [How to query in Roam](https://roamhacks.com/how-to-query-roam/) by [[Roamhacks]]
-      * ### [Searching Roam With Queries: A Primer](https://www.roamstack.com/roam-queries-primer/) by [[RoamStack]]
-    * ## Key Commands:
-      * `/query`
+              `
+        - ### **not**
+            - Exclude blocks matching any of the page or block references selected.
+            - `}
+              }`
+        - ### **between**
+            - Finds all blocks on daily pages and blocks mentioning a date between two days. ==**This only works on Daily Notes page**==.
+            - You can use the following as a shorthand: [[today]], [[tomorrow]], [[yesterday]], [[last week]], [[next week]], [[last month]], and [[next month]]. 
+            - `
+              }
+              }`
+    - ## Community Videos:
+        - ### Query syntax and logic: how to ask Roam questions with queries by [[Sam Patel]]
+            - ![](https://www.youtube.com/watch?v=EXAMPLE0001&t=20s&ab_channel=RobertHaisfield)
+        - ### How Queries Work in Roam Research by [[R.J. Nestor]]
+            - ![](https://www.youtube.com/watch?v=EXAMPLE0001)
+        - ### Roam Research Search Queries by [[Alex Rivera]]
+            - ![](https://www.youtube.com/watch?v=EXAMPLE0001)
+        - ### Insight Hunting with Queries in Roam by [[Example Studio]]
+            - ![](https://www.youtube.com/watch?v=EXAMPLE0001)
+        - ### Roam Research Query Tutorial: Pending Tasks for Task Management and Task Dashboard Using Queries by [[The Upgraded Brain]]
+            - ![](https://www.youtube.com/watch?v=EXAMPLE0001)
+    - ## Articles:
+        - ### [How to query in Roam](https://roamhacks.com/how-to-query-roam/) by [[Roamhacks]]
+        - ### [Searching Roam With Queries: A Primer](https://www.roamstack.com/roam-queries-primer/) by [[RoamStack]]
+    - ## Key Commands:
+        - `/query`

--- a/tests/roam/expected/help-graph-excerpt/Secret Feature.md
+++ b/tests/roam/expected/help-graph-excerpt/Secret Feature.md
@@ -1,2 +1,2 @@
-  * ((V1RLPs0ai))
-    * ![](https://twitter.com/example/status/1234567890?s=20)
+- ((V1RLPs0ai))
+    - ![](https://twitter.com/example/status/1234567890?s=20)

--- a/tests/roam/expected/help-graph-excerpt/TODO.md
+++ b/tests/roam/expected/help-graph-excerpt/TODO.md
@@ -1,2 +1,2 @@
-  * [[help-graph-excerpt/TODO/DONE|TODO/DONE]] for feature explanation
-  * [[Task Management]] for use cases and workflows
+- [[help-graph-excerpt/TODO/DONE|TODO/DONE]] for feature explanation
+- [[Task Management]] for use cases and workflows

--- a/tests/roam/expected/help-graph-excerpt/Table.md
+++ b/tests/roam/expected/help-graph-excerpt/Table.md
@@ -1,14 +1,14 @@
-  * [[--]]
-  * {{[[table]]}}
-  * ## Articles:
-    * [How to build a table in Roam Research](https://web.archive.org/web/20201109133038/https://www.roamtips.com/home/create-tables-roam-research) - [[Roam Tips and Hacks]] 
-  * ## Community Videos:
-    * ### How to Set Goals Using Tables in Roam Research by [[Jo Kim]]
-      * ![](https://www.youtube.com/watch?v=EXAMPLE0001)
-    * ### Roam Research: Tables by [[Pat Morgan]]
-      * ![](https://www.youtube.com/watch?v=EXAMPLE0001)
-  * ## Roam Team Videos:
-    * ### Tables with Complex Cells (no audio) by [[Robin Alvarez]]
-      * ![](https://www.youtube.com/watch?v=EXAMPLE0001)
-#[[Table]]
-  * [[--]]
+- [[--]]
+- {{[[table]]}}
+- ## Articles:
+    - [How to build a table in Roam Research](https://web.archive.org/web/20201109133038/https://www.roamtips.com/home/create-tables-roam-research) - [[Roam Tips and Hacks]] 
+- ## Community Videos:
+    - ### How to Set Goals Using Tables in Roam Research by [[Jo Kim]]
+        - ![](https://www.youtube.com/watch?v=EXAMPLE0001)
+    - ### Roam Research: Tables by [[Pat Morgan]]
+        - ![](https://www.youtube.com/watch?v=EXAMPLE0001)
+- ## Roam Team Videos:
+    - ### Tables with Complex Cells (no audio) by [[Robin Alvarez]]
+        - ![](https://www.youtube.com/watch?v=EXAMPLE0001)
+          #[[Table]]
+- [[--]]

--- a/tests/roam/expected/help-graph-excerpt/Unlinked References.md
+++ b/tests/roam/expected/help-graph-excerpt/Unlinked References.md
@@ -1,2 +1,2 @@
-  * Roam Team Videos:
-    * ![](https://www.youtube.com/watch?v=EXAMPLE0001)`
+- Roam Team Videos:
+    - ![](https://www.youtube.com/watch?v=EXAMPLE0001)`

--- a/tests/roam/expected/help-graph-excerpt/Welcome to Roam v2.md
+++ b/tests/roam/expected/help-graph-excerpt/Welcome to Roam v2.md
@@ -1,21 +1,21 @@
-  * ## **Quick Start**
-    * There's very little to know to start using Roam.
-      * ### Everything is a block
-        * **Each bullet you see is a *block*, and we write them inside pages like this one.**
-          * We create new blocks by pressing `Enter`; and nest them using `Tab` (press`Shift+Tab` to unindent)-
-            * This creates *children blocks*, which we can expand, collapse, and focus. 
-            * Indenting provides structure. We can scan pages with ease and find related blocks. Try clicking the **ᐅ** icon on the next block!
-      * ### Everything is where you need it to be
-        * **Organizing information is effortless with** [[help-graph-excerpt/Page References|page]]/[[Block References|Page References|block references]]/[[Block References|block references]].
-          * Let's say we have a meeting. In our Daily Notes, we might write
-            * ((QhoXgk8VU))
-          * Those square brackets turn text into ***backlinks***.
-            * This automatically creates a page for each keyword--click the backlink to go the keyword's page. 
-            * At the bottom, you'll find instances where the page was mentioned--its *page references*.
-            * So the meeting reminder block appears on [[meeting]], [[John Smith]], [[marketing]], and [[Roam Research]]!
-            * This way, we never have to worry about which folder to file things in- just [[backlink]] as you go.
-      * ### Everything is a `/` away
-        * Roam is packed with powerful features. Anytime you want to do more than type text,
-          * just type `/` to bring up the inline command palette.
-            * If you don't find what you're looking for, click on the Help
-            *  icon in the top right of the page! If you can think it, you can do it in Roam.
+- ## **Quick Start**
+    - There's very little to know to start using Roam.
+        - ### Everything is a block
+            - **Each bullet you see is a *block*, and we write them inside pages like this one.**
+                - We create new blocks by pressing `Enter`; and nest them using `Tab` (press`Shift+Tab` to unindent)-
+                    - This creates *children blocks*, which we can expand, collapse, and focus. 
+                    - Indenting provides structure. We can scan pages with ease and find related blocks. Try clicking the **ᐅ** icon on the next block!
+        - ### Everything is where you need it to be
+            - **Organizing information is effortless with** [[help-graph-excerpt/Page References|page]]/[[Block References|Page References|block references]]/[[Block References|block references]].
+                - Let's say we have a meeting. In our Daily Notes, we might write
+                    - ((QhoXgk8VU))
+                - Those square brackets turn text into ***backlinks***.
+                    - This automatically creates a page for each keyword--click the backlink to go the keyword's page. 
+                    - At the bottom, you'll find instances where the page was mentioned--its *page references*.
+                    - So the meeting reminder block appears on [[meeting]], [[John Smith]], [[marketing]], and [[Roam Research]]!
+                    - This way, we never have to worry about which folder to file things in- just [[backlink]] as you go.
+        - ### Everything is a `/` away
+            - Roam is packed with powerful features. Anytime you want to do more than type text,
+                - just type `/` to bring up the inline command palette.
+                    - If you don't find what you're looking for, click on the Help
+                    -  icon in the top right of the page! If you can think it, you can do it in Roam.

--- a/tests/roam/expected/small-test-graph/Theme Tester.md
+++ b/tests/roam/expected/small-test-graph/Theme Tester.md
@@ -1,129 +1,129 @@
-  * Todo
-    * [ ]  unchecked
-    * [x]  checked
-  * Text Styling
-    * **Bold**
-    * *Italics*
-    * Highlights ==of some== words
-    * this one, ~~not this one~~
-    * # H1
-      * sub text
-    * ## H2
-      * sub text
-    * ### H3
-      * sub text
-    * ---
-  * Block refs
-    * ((P68pRja7i))
-    * the [[Theme Tester]] link
-    * ((ME2M37gZr))
-  * Images 
-    * typical remote image
-      * ![](https://i.imgur.com/SEr4dkd.jpg)
-    * remote image with description
-      * ![swedish vallhund](https://i.imgur.com/SEr4dkd.jpg)
-  * Uploaded Files
-    * image
-      * some text before ![](https://firebasestorage.googleapis.com/v0/b/example-graph/o/imgs%2Fapp%2Fhelp%2FywRWXjCVNW.png?alt=media&token=00000000-0000-0000-0000-000000000000)
-    * video
-      * some text before {{[[video]]: https://firebasestorage.googleapis.com/v0/b/example-graph/o/imgs%2Fapp%2Fhelp%2F5_JZnrFS-l.mp4?alt=media&token=00000000-0000-0000-0000-000000000000}}
-    * gif
-      * some text before ![](https://firebasestorage.googleapis.com/v0/b/example-graph/o/imgs%2Fapp%2Fhelp%2FCGJbyfjuGM.gif?alt=media&token=00000000-0000-0000-0000-000000000000)
-    * pdf
-      * some text before {{[[pdf]]: https://firebasestorage.googleapis.com/v0/b/example-graph/o/imgs%2Fapp%2Fhelp%2FAo1ZWqQOkv.pdf?alt=media&token=00000000-0000-0000-0000-000000000000}}
-    * audio
-      * some text before {{[[audio]]: https://firebasestorage.googleapis.com/v0/b/example-graph/o/imgs%2Fapp%2Fhelp-documentation%2Fhz3WHZhdUg.mp3?alt=media&token=00000000-0000-0000-0000-000000000000}}
-  * Links
-    * The [[Theme Tester]] Page Link
-      * [[bad improv]]
-      * [[small-test-graph/roam/css|roam/css]]
-    * [[small-test-graph/roam/css|roam/css]]
-    * #[[mental health]]
-    * [[Theme Tester|Basic Alias]]
-    * ((JF3iFJPKu))
-    * [External Alias](https://www.usgbc.org/education/sessions/day-1-study-plan-10411494)
-    * This is a paragraph with several types of tags and aliases ((JF3iFJPKu)) [[small-test-graph/Theme Tester|Basic Alias]] #test [External Alias](https://www.usgbc.org/education/sessions/day-1-study-plan-10411494) [[Theme Tester]] #[[mental health|Theme Tester]]) #test [External Alias](https://www.usgbc.org/education/sessions/day-1-study-plan-10411494) [[Theme Tester]] #[[mental health]]
-    * metadata: www.google.com
-    * Tags
-      * #[[exercise]]
-      * #awe
-      * #[[video]]
-        * video:
-      * #seedlings
-      * #budding
-      * #evergreen
-      * #tweet
-      * #religion
-      * #[[campaign 1]]
-      * #newsletter
-      * #[[recipes]] 
-      * #Projects
-      * #[[Quick Capture]]
-      * #[[note taking]]
-      * [[2023-08-05]]
-      * [[small-test-graph/Video/Movie/Shrek|Video/Movie/Shrek]]
-  * Code
-    * `import code`
-    * ```javascript
-super well written code here
-and a second line of amazing code here```
-  * Embeds
-    * Embedded blocks
-      * ((sHQRa0Wan))
-    * Embedded Pages
-      * [[testing]]
-  * Misc Roam Components
-    * pomodoro
-      * 
-    * in-line  {{or:options | versioning}}
-    * Calc
-      *  = 
-    * 
-    * 
-    * Diagrams
-      * Regular
-        * {{[[diagram]]}}
-          * one
-          * two 
-          * three
-        * {{diagram}}
-      * Mermaid
-        * {{mermaid}}
-          * pie title Pets adopted by volunteers
-            * "Dogs" : 386
-            * "Cats" : 85
-            * "Rats" : 15					
-      * Table
-        * {{[[table]]}}
-          * another table
-            * another column
-          * more subtext
-            * even more subtext
-          * more subtext
-            * even more subtext
-      * Kanban
-        * {{[[kanban]]}}
-          * one
-          * two
-            * sub one
-            * sub two
+- Todo
+    - [ ]  unchecked
+    - [x]  checked
+- Text Styling
+    - **Bold**
+    - *Italics*
+    - Highlights ==of some== words
+    - this one, ~~not this one~~
+    - # H1
+        - sub text
+    - ## H2
+        - sub text
+    - ### H3
+        - sub text
+    - ---
+- Block refs
+    - ((P68pRja7i))
+    - the [[Theme Tester]] link
+    - ((ME2M37gZr))
+- Images 
+    - typical remote image
+        - ![](https://i.imgur.com/SEr4dkd.jpg)
+    - remote image with description
+        - ![swedish vallhund](https://i.imgur.com/SEr4dkd.jpg)
+- Uploaded Files
+    - image
+        - some text before ![](https://firebasestorage.googleapis.com/v0/b/example-graph/o/imgs%2Fapp%2Fhelp%2FywRWXjCVNW.png?alt=media&token=00000000-0000-0000-0000-000000000000)
+    - video
+        - some text before {{[[video]]: https://firebasestorage.googleapis.com/v0/b/example-graph/o/imgs%2Fapp%2Fhelp%2F5_JZnrFS-l.mp4?alt=media&token=00000000-0000-0000-0000-000000000000}}
+    - gif
+        - some text before ![](https://firebasestorage.googleapis.com/v0/b/example-graph/o/imgs%2Fapp%2Fhelp%2FCGJbyfjuGM.gif?alt=media&token=00000000-0000-0000-0000-000000000000)
+    - pdf
+        - some text before {{[[pdf]]: https://firebasestorage.googleapis.com/v0/b/example-graph/o/imgs%2Fapp%2Fhelp%2FAo1ZWqQOkv.pdf?alt=media&token=00000000-0000-0000-0000-000000000000}}
+    - audio
+        - some text before {{[[audio]]: https://firebasestorage.googleapis.com/v0/b/example-graph/o/imgs%2Fapp%2Fhelp-documentation%2Fhz3WHZhdUg.mp3?alt=media&token=00000000-0000-0000-0000-000000000000}}
+- Links
+    - The [[Theme Tester]] Page Link
+        - [[bad improv]]
+        - [[small-test-graph/roam/css|roam/css]]
+    - [[small-test-graph/roam/css|roam/css]]
+    - #[[mental health]]
+    - [[Theme Tester|Basic Alias]]
+    - ((JF3iFJPKu))
+    - [External Alias](https://www.usgbc.org/education/sessions/day-1-study-plan-10411494)
+    - This is a paragraph with several types of tags and aliases ((JF3iFJPKu)) [[small-test-graph/Theme Tester|Basic Alias]] #test [External Alias](https://www.usgbc.org/education/sessions/day-1-study-plan-10411494) [[Theme Tester]] #[[mental health|Theme Tester]]) #test [External Alias](https://www.usgbc.org/education/sessions/day-1-study-plan-10411494) [[Theme Tester]] #[[mental health]]
+    - metadata: www.google.com
+    - Tags
+        - #[[exercise]]
+        - #awe
+        - #[[video]]
+            - video:
+        - #seedlings
+        - #budding
+        - #evergreen
+        - #tweet
+        - #religion
+        - #[[campaign 1]]
+        - #newsletter
+        - #[[recipes]] 
+        - #Projects
+        - #[[Quick Capture]]
+        - #[[note taking]]
+        - [[2023-08-05]]
+        - [[small-test-graph/Video/Movie/Shrek|Video/Movie/Shrek]]
+- Code
+    - `import code`
+    - ```javascript
+      super well written code here
+      and a second line of amazing code here```
+- Embeds
+    - Embedded blocks
+        - ((sHQRa0Wan))
+    - Embedded Pages
+        - [[testing]]
+- Misc Roam Components
+    - pomodoro
+        - 
+    - in-line  {{or:options | versioning}}
+    - Calc
+        -  = 
+    - 
+    - 
+    - Diagrams
+        - Regular
+            - {{[[diagram]]}}
+                - one
+                - two 
+                - three
+            - {{diagram}}
+        - Mermaid
+            - {{mermaid}}
+                - pie title Pets adopted by volunteers
+                    - "Dogs" : 386
+                    - "Cats" : 85
+                    - "Rats" : 15					
+        - Table
+            - {{[[table]]}}
+                - another table
+                    - another column
+                - more subtext
+                    - even more subtext
+                - more subtext
+                    - even more subtext
+        - Kanban
+            - {{[[kanban]]}}
+                - one
+                - two
+                    - sub one
+                    - sub two
 
-    * query
-      * 
-    * comments
-      * There is lots of controversial ideas in this block 
-    * Blockquotes
-      * > Regulare quote using page brackets
-      * > bare quote without brackets
-    * Collapsable Parenthesis 
-      * A very long ((and interesting)) quote collapsed and one ((open)) also one with regular ((xNaGTlLLA)).
-    * LayTEX
-      * $$O(n^2)$$
-    * word and character counts
-      *   very cool  
-    * progress bar
-      * 
-        * [ ] 
-        * [x] 
-    * Streaks
-      * 
+    - query
+        - 
+    - comments
+        - There is lots of controversial ideas in this block 
+    - Blockquotes
+        - > Regulare quote using page brackets
+        - > bare quote without brackets
+    - Collapsable Parenthesis 
+        - A very long ((and interesting)) quote collapsed and one ((open)) also one with regular ((xNaGTlLLA)).
+    - LayTEX
+        - $$O(n^2)$$
+    - word and character counts
+        -   very cool  
+    - progress bar
+        - 
+            - [ ] 
+            - [x] 
+    - Streaks
+        - 

--- a/tests/write/create-file.test.ts
+++ b/tests/write/create-file.test.ts
@@ -95,3 +95,22 @@ test('a title a file name cannot hold is sanitized before the name is picked', a
 
 	assert.equal(file.path, 'Q1-Q2 plan.md');
 });
+
+/** The pass is checked in tests/markdown-output; this is that the write reaches it. */
+test('markdown is written with the indent the vault uses', async () => {
+	const { vault, subject } = importer();
+	vault.config.set('useTab', true);
+
+	const file = await subject.saveAsMarkdownFile(vault.root, 'Outline', '- one\n    - two');
+
+	assert.equal(await vault.read(file), '- one\n\t- two');
+});
+
+test('a file that is not markdown is written as it was given', async () => {
+	const { vault, subject } = importer();
+	vault.config.set('useTab', true);
+
+	const file = await subject.createFile(vault.root, 'View.base', 'views:\n    - type: table');
+
+	assert.equal(await vault.read(file), 'views:\n    - type: table');
+});


### PR DESCRIPTION
Make imported Markdown consistently follow the destination vault’s Obsidian settings:

- Standardize list indentation and bullet markers across importers.
- Preserve YAML frontmatter, fenced code blocks, indented code, and CRLF input.
- Normalize resolvable internal links and embeds using Obsidian’s link-generation APIs.
- Honor wikilink/Markdown-link and shortest/relative/absolute path settings.
- Route imported attachments through Obsidian’s configured attachment location.
- Respect `strictLineBreaks` for Google Keep text.
- Track Markdown written through alternate paths, including Evernote/Yarle and Notion synced blocks.
- Normalize duplicate comparisons so unchanged formatted notes are not repeatedly imported.
- Show progress while standardizing Markdown and report per-file failures.
- Finalize partial imports even when the main import throws.

YAML property links remain wikilinks because that is the format Obsidian properties support. Evernote retains Yarle’s per-note resource-directory layout, while its Markdown links are normalized.

Additional fixes

- Preserve HTML attachment embeds when regenerating their links.
- Avoid overwriting existing Textbundle attachments after reporting them as skipped.
- Preserve imported file timestamps during post-import normalization.

Closes #250, supersedes #569