### PR TITLE
Onenote fixes

### DIFF
--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -70,12 +70,8 @@ function evalInObsidian(code) {
 	return out.slice(2).trim();
 }
 
-// Note: no // comments inside this script. It reaches Obsidian as one argument
-// and a line comment there swallows everything after it.
-//
-// saveSourceId is turned off per import because the recordings come from the
-// conversion seam, which writes no source id; whether the id is written at all
-// is checked in tests/write.
+// Obsidian receives this as one argument, so a line comment would hide the rest.
+// Recorded converter output excludes importer metadata such as source IDs.
 const script = `
 (async () => {
 	const fs = require('fs');

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -70,6 +70,12 @@ function evalInObsidian(code) {
 	return out.slice(2).trim();
 }
 
+// Note: no // comments inside this script. It reaches Obsidian as one argument
+// and a line comment there swallows everything after it.
+//
+// saveSourceId is turned off per import because the recordings come from the
+// conversion seam, which writes no source id; whether the id is written at all
+// is checked in tests/write.
 const script = `
 (async () => {
 	const fs = require('fs');
@@ -85,7 +91,8 @@ const script = `
 		const ctx = await plugin.runImport(
 			testCase.importer,
 			[repo + '/' + testCase.fixture],
-			folder);
+			folder,
+			importer => { importer.saveSourceId = false; });
 
 		const file = app.vault.getAbstractFileByPath(folder + '/' + testCase.note);
 		const produced = file ? await app.vault.read(file) : null;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,12 +8,8 @@ export const NOTION_ID_PROPERTY = 'notion-id';
 /**
  * What an import can embed rather than skip.
  *
- * This is what Obsidian itself renders, read from `app.viewRegistry` — audio
- * and video, images, and PDF. It had been missing most of the audio formats,
- * so a OneNote page's recordings were skipped as incompatible even with the
- * incompatible-attachment setting turned on, which is issue #226. `mpg` is
- * kept though Obsidian does not render it, because imports have relied on it
- * being downloaded.
+ * What Obsidian itself renders, read from `app.viewRegistry`. `mpg` is kept
+ * though Obsidian does not render it, because imports rely on it downloading.
  */
 export const ATTACHMENT_EXTS = [
 	'png', 'webp', 'jpg', 'jpeg', 'gif', 'bmp', 'svg', 'avif',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,12 +5,6 @@ export const AUTH_REDIRECT_URI: string = 'obsidian://importer-auth/';
 
 export const NOTION_ID_PROPERTY = 'notion-id';
 
-/**
- * What an import can embed rather than skip.
- *
- * What Obsidian itself renders, read from `app.viewRegistry`. `mpg` is kept
- * though Obsidian does not render it, because imports rely on it downloading.
- */
 export const ATTACHMENT_EXTS = [
 	'png', 'webp', 'jpg', 'jpeg', 'gif', 'bmp', 'svg', 'avif',
 	'mp3', 'wav', 'm4a', '3gp', 'flac', 'ogg', 'oga', 'opus',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,7 +5,22 @@ export const AUTH_REDIRECT_URI: string = 'obsidian://importer-auth/';
 
 export const NOTION_ID_PROPERTY = 'notion-id';
 
-export const ATTACHMENT_EXTS = ['png', 'webp', 'jpg', 'jpeg', 'gif', 'bmp', 'svg', 'mpg', 'm4a', 'webm', 'wav', 'ogv', '3gp', 'mov', 'mp4', 'mkv', 'pdf'];
+/**
+ * What an import can embed rather than skip.
+ *
+ * This is what Obsidian itself renders, read from `app.viewRegistry` — audio
+ * and video, images, and PDF. It had been missing most of the audio formats,
+ * so a OneNote page's recordings were skipped as incompatible even with the
+ * incompatible-attachment setting turned on, which is issue #226. `mpg` is
+ * kept though Obsidian does not render it, because imports have relied on it
+ * being downloaded.
+ */
+export const ATTACHMENT_EXTS = [
+	'png', 'webp', 'jpg', 'jpeg', 'gif', 'bmp', 'svg', 'avif',
+	'mp3', 'wav', 'm4a', '3gp', 'flac', 'ogg', 'oga', 'opus',
+	'mp4', 'webm', 'ogv', 'mov', 'mkv', 'mpg',
+	'pdf',
+];
 
 export type AuthCallback = (data: ObsidianProtocolData) => void;
 

--- a/src/format-importer.ts
+++ b/src/format-importer.ts
@@ -694,8 +694,11 @@ export abstract class FormatImporter {
 
 		if (this.duplicateHandling === DuplicateHandling.Skip) return { path: candidate, reuse: existing };
 
-		// Update leaves alone what the source has not touched since.
-		if (sourceMtime !== undefined && sourceMtime <= existing.stat.mtime) {
+		// Update leaves alone what the source has not touched since. Where the
+		// source offers no time to compare, an attachment of that name is taken
+		// to be the same one: fetching a binary again to overwrite it with
+		// itself is all cost and no change.
+		if (sourceMtime === undefined || sourceMtime <= existing.stat.mtime) {
 			return { path: candidate, reuse: existing };
 		}
 
@@ -703,14 +706,18 @@ export abstract class FormatImporter {
 	}
 
 	/** Write an attachment, replacing whatever placeAttachment pointed at. */
-	protected async writeAttachment(path: string, data: ArrayBuffer, options?: DataWriteOptions): Promise<TFile> {
+	protected async writeAttachment(path: string, data: ArrayBuffer | string, options?: DataWriteOptions): Promise<TFile> {
 		const existing = this.vault.getAbstractFileByPath(path);
+
 		if (existing instanceof TFile) {
-			await this.vault.modifyBinary(existing, data, options);
+			if (typeof data === 'string') await this.vault.modify(existing, data, options);
+			else await this.vault.modifyBinary(existing, data, options);
 			return existing;
 		}
 
-		return this.vault.createBinary(path, data, options);
+		return typeof data === 'string'
+			? this.vault.create(path, data, options)
+			: this.vault.createBinary(path, data, options);
 	}
 
 	async getAvailablePathForAttachment(filename: string, claimedPaths: string[], sourcePath?: string): Promise<string> {

--- a/src/format-importer.ts
+++ b/src/format-importer.ts
@@ -21,6 +21,13 @@ const DUPLICATE_HANDLING_LABELS: Record<DuplicateHandling, string> = {
 	[DuplicateHandling.Update]: 'Update',
 };
 
+/**
+ * What a file already occupying an attachment's name turned out to be:
+ * this attachment as the source still has it, this attachment as it used to
+ * be, or an attachment belonging to something else entirely.
+ */
+export type AttachmentVerdict = 'same' | 'stale' | 'another';
+
 export type AttachmentLocationMode = 'vault' | 'folder' | 'note' | 'subfolder';
 
 export interface AttachmentLocation {
@@ -642,10 +649,7 @@ export abstract class FormatImporter {
 	}
 
 	/** How an attachment is named in its folder, and how collisions are numbered. */
-	private async attachmentNaming(filename: string, sourcePath?: string): Promise<{
-		preferred: string;
-		free: (taken: (path: string) => boolean) => string;
-	}> {
+	private async attachmentNaming(filename: string, sourcePath?: string): Promise<(nth: number) => string> {
 		const folder = await this.createFolders(await this.attachmentFolderPath(sourcePath));
 		const parent = folder.path === '/' ? '' : folder.path;
 
@@ -653,51 +657,47 @@ export abstract class FormatImporter {
 		const name = sanitizeFileName(basename);
 		const fullExt = extension ? '.' + extension : '';
 
-		const at = (candidate: string) => normalizePath(parent ? `${parent}/${candidate}` : candidate);
-		const preferred = at(`${name}${fullExt}`);
-
-		const free = (taken: (path: string) => boolean) => {
-			let path = preferred;
-			for (let i = 1; taken(path); i++) {
-				path = at(`${name} ${i}${fullExt}`);
-			}
-			return path;
-		};
-
-		return { preferred, free };
+		return nth => normalizePath(
+			parent ? `${parent}/${name}${nth ? ` ${nth}` : ''}${fullExt}`
+				: `${name}${nth ? ` ${nth}` : ''}${fullExt}`);
 	}
 
-	/** Reuse prior imports, but give same-run name collisions a new path. */
+	/**
+	 * Where this attachment belongs, and the copy already there if it is this
+	 * one. A name is not an identity — two sources can offer the same one — so
+	 * the importer is asked what a file occupying the name actually is. A name
+	 * it does not recognise is passed over rather than taken, which is what
+	 * keeps one page's attachment out of another page's note.
+	 */
 	protected async placeAttachment(
 		filename: string,
-		sourcePath?: string,
-		sourceMtime?: number,
+		sourcePath: string | undefined,
+		recognise: (existing: TFile) => AttachmentVerdict | Promise<AttachmentVerdict>,
 	): Promise<{ path: string, reuse: TFile | null }> {
-		const { preferred: candidate, free } = await this.attachmentNaming(filename, sourcePath);
+		const at = await this.attachmentNaming(filename, sourcePath);
+		const reusing = this.duplicateHandling !== DuplicateHandling.CreateCopy;
 
-		const unclaimedPath = () => {
-			const path = free(taken => !!this.vault.getAbstractFileByPath(taken));
-			this.claimPath(path);
-			return { path, reuse: null };
-		};
+		for (let nth = 0; ; nth++) {
+			const candidate = at(nth);
+			if (this.hasClaimed(candidate)) continue;
 
-		if (this.duplicateHandling === DuplicateHandling.CreateCopy) return unclaimedPath();
+			const existing = this.vault.getAbstractFileByPath(candidate);
+			if (!(existing instanceof TFile)) {
+				this.claimPath(candidate);
+				return { path: candidate, reuse: null };
+			}
 
-		if (this.hasClaimed(candidate)) return unclaimedPath();
+			if (!reusing) continue;
 
-		const existing = this.vault.getAbstractFileByPath(candidate);
-		if (!(existing instanceof TFile)) return unclaimedPath();
+			const verdict = await recognise(existing);
+			if (verdict === 'another') continue;
 
-		this.claimPath(candidate);
+			this.claimPath(candidate);
 
-		if (this.duplicateHandling === DuplicateHandling.Skip) return { path: candidate, reuse: existing };
-
-		// Without a source time, reuse rather than overwrite indistinguishable data.
-		if (sourceMtime === undefined || sourceMtime <= existing.stat.mtime) {
-			return { path: candidate, reuse: existing };
+			// Skip leaves what is there even when the source has moved on.
+			const stale = verdict === 'stale' && this.duplicateHandling !== DuplicateHandling.Skip;
+			return { path: candidate, reuse: stale ? null : existing };
 		}
-
-		return { path: candidate, reuse: null };
 	}
 
 	protected async writeAttachment(path: string, data: ArrayBuffer | string, options?: DataWriteOptions): Promise<TFile> {
@@ -715,10 +715,14 @@ export abstract class FormatImporter {
 	}
 
 	async getAvailablePathForAttachment(filename: string, claimedPaths: string[], sourcePath?: string): Promise<string> {
-		const { free } = await this.attachmentNaming(filename, sourcePath);
+		const at = await this.attachmentNaming(filename, sourcePath);
 
-		return free(candidate =>
-			claimedPaths.includes(candidate) || !!this.vault.getAbstractFileByPath(candidate));
+		for (let nth = 0; ; nth++) {
+			const candidate = at(nth);
+			if (!claimedPaths.includes(candidate) && !this.vault.getAbstractFileByPath(candidate)) {
+				return candidate;
+			}
+		}
 	}
 
 	async backOff(durationSeconds: number, reason: string, ctx: ImportContext | undefined): Promise<void> {

--- a/src/format-importer.ts
+++ b/src/format-importer.ts
@@ -636,6 +636,63 @@ export abstract class FormatImporter {
 		return normalizePath(`${noteFolder}/${configured}`);
 	}
 
+	/**
+	 * Where an attachment belongs, and whether one already in the vault is that
+	 * same attachment rather than a different one that reached the name first.
+	 *
+	 * Attachments carry no id, so the only handle is the name in the folder
+	 * they belong to. That is enough to recognise one across imports and not
+	 * enough within a single run, where a second attachment of the same name is
+	 * a different file that needs its own path.
+	 */
+	protected async placeAttachment(
+		filename: string,
+		sourcePath?: string,
+		sourceMtime?: number,
+	): Promise<{ path: string, reuse: TFile | null }> {
+		const unclaimedPath = async () => {
+			const path = await this.getAvailablePathForAttachment(filename, [], sourcePath);
+			this.claimPath(path);
+			return { path, reuse: null };
+		};
+
+		if (this.duplicateHandling === DuplicateHandling.CreateCopy) return unclaimedPath();
+
+		const folderPath = await this.attachmentFolderPath(sourcePath);
+		const parent = folderPath === '/' ? '' : folderPath;
+		const { basename, extension } = parseFilePath(filename);
+		const name = `${sanitizeFileName(basename)}${extension ? `.${extension}` : ''}`;
+		const candidate = normalizePath(parent ? `${parent}/${name}` : name);
+
+		// Written by this run, so it is a different attachment of one name.
+		if (this.hasClaimed(candidate)) return unclaimedPath();
+
+		const existing = this.vault.getAbstractFileByPath(candidate);
+		if (!(existing instanceof TFile)) return unclaimedPath();
+
+		this.claimPath(candidate);
+
+		if (this.duplicateHandling === DuplicateHandling.Skip) return { path: candidate, reuse: existing };
+
+		// Update leaves alone what the source has not touched since.
+		if (sourceMtime !== undefined && sourceMtime <= existing.stat.mtime) {
+			return { path: candidate, reuse: existing };
+		}
+
+		return { path: candidate, reuse: null };
+	}
+
+	/** Write an attachment, replacing whatever placeAttachment pointed at. */
+	protected async writeAttachment(path: string, data: ArrayBuffer, options?: DataWriteOptions): Promise<TFile> {
+		const existing = this.vault.getAbstractFileByPath(path);
+		if (existing instanceof TFile) {
+			await this.vault.modifyBinary(existing, data, options);
+			return existing;
+		}
+
+		return this.vault.createBinary(path, data, options);
+	}
+
 	async getAvailablePathForAttachment(filename: string, claimedPaths: string[], sourcePath?: string): Promise<string> {
 		const folderPath = await this.attachmentFolderPath(sourcePath);
 		const folder = await this.createFolders(folderPath);

--- a/src/format-importer.ts
+++ b/src/format-importer.ts
@@ -94,7 +94,6 @@ export abstract class FormatImporter {
 	defaultOutputFolder: string = 'Import';
 
 	attachmentLocation: AttachmentLocation;
-	/** Resolved against duplicateModes once the importer has set them up. */
 	duplicateHandling: DuplicateHandling = DuplicateHandling.Update;
 
 	duplicateModes: DuplicateHandling[] = [
@@ -542,11 +541,6 @@ export abstract class FormatImporter {
 		});
 	}
 
-	/**
-	 * Not every importer offers Update, and a default it does not offer is not
-	 * one it can use. Skip is the nearest thing where it is missing: both leave
-	 * a note that is already there alone rather than writing a second copy.
-	 */
 	private defaultDuplicateHandling(): DuplicateHandling {
 		for (const preferred of [DuplicateHandling.Update, DuplicateHandling.Skip]) {
 			if (this.duplicateModes.includes(preferred)) return preferred;
@@ -557,9 +551,7 @@ export abstract class FormatImporter {
 
 	private async loadOutputSettings(): Promise<void> {
 		this.outputLocation = this.defaultOutputFolder;
-		// duplicateModes are set in init(), so the field default cannot know
-		// whether this importer offers it. Only correct it if it does not,
-		// leaving a mode the caller chose deliberately alone.
+		// init() may remove the field default from duplicateModes.
 		if (!this.duplicateModes.includes(this.duplicateHandling)) {
 			this.duplicateHandling = this.defaultDuplicateHandling();
 		}
@@ -656,15 +648,7 @@ export abstract class FormatImporter {
 		return normalizePath(`${noteFolder}/${configured}`);
 	}
 
-	/**
-	 * Where an attachment belongs, and whether one already in the vault is that
-	 * same attachment rather than a different one that reached the name first.
-	 *
-	 * Attachments carry no id, so the only handle is the name in the folder
-	 * they belong to. That is enough to recognise one across imports and not
-	 * enough within a single run, where a second attachment of the same name is
-	 * a different file that needs its own path.
-	 */
+	/** Reuse prior imports, but give same-run name collisions a new path. */
 	protected async placeAttachment(
 		filename: string,
 		sourcePath?: string,
@@ -684,7 +668,6 @@ export abstract class FormatImporter {
 		const name = `${sanitizeFileName(basename)}${extension ? `.${extension}` : ''}`;
 		const candidate = normalizePath(parent ? `${parent}/${name}` : name);
 
-		// Written by this run, so it is a different attachment of one name.
 		if (this.hasClaimed(candidate)) return unclaimedPath();
 
 		const existing = this.vault.getAbstractFileByPath(candidate);
@@ -694,10 +677,7 @@ export abstract class FormatImporter {
 
 		if (this.duplicateHandling === DuplicateHandling.Skip) return { path: candidate, reuse: existing };
 
-		// Update leaves alone what the source has not touched since. Where the
-		// source offers no time to compare, an attachment of that name is taken
-		// to be the same one: fetching a binary again to overwrite it with
-		// itself is all cost and no change.
+		// Without a source time, reuse rather than overwrite indistinguishable data.
 		if (sourceMtime === undefined || sourceMtime <= existing.stat.mtime) {
 			return { path: candidate, reuse: existing };
 		}
@@ -705,7 +685,6 @@ export abstract class FormatImporter {
 		return { path: candidate, reuse: null };
 	}
 
-	/** Write an attachment, replacing whatever placeAttachment pointed at. */
 	protected async writeAttachment(path: string, data: ArrayBuffer | string, options?: DataWriteOptions): Promise<TFile> {
 		const existing = this.vault.getAbstractFileByPath(path);
 

--- a/src/format-importer.ts
+++ b/src/format-importer.ts
@@ -541,19 +541,12 @@ export abstract class FormatImporter {
 		});
 	}
 
-	private defaultDuplicateHandling(): DuplicateHandling {
-		for (const preferred of [DuplicateHandling.Update, DuplicateHandling.Skip]) {
-			if (this.duplicateModes.includes(preferred)) return preferred;
-		}
-
-		return this.duplicateModes[0];
-	}
-
 	private async loadOutputSettings(): Promise<void> {
 		this.outputLocation = this.defaultOutputFolder;
 		// init() may remove the field default from duplicateModes.
 		if (!this.duplicateModes.includes(this.duplicateHandling)) {
-			this.duplicateHandling = this.defaultDuplicateHandling();
+			this.duplicateHandling = [DuplicateHandling.Update, DuplicateHandling.Skip]
+				.find(mode => this.duplicateModes.includes(mode)) ?? this.duplicateModes[0];
 		}
 
 		if (!this.host.plugin) return;
@@ -648,25 +641,47 @@ export abstract class FormatImporter {
 		return normalizePath(`${noteFolder}/${configured}`);
 	}
 
+	/** How an attachment is named in its folder, and how collisions are numbered. */
+	private async attachmentNaming(filename: string, sourcePath?: string): Promise<{
+		preferred: string;
+		free: (taken: (path: string) => boolean) => string;
+	}> {
+		const folder = await this.createFolders(await this.attachmentFolderPath(sourcePath));
+		const parent = folder.path === '/' ? '' : folder.path;
+
+		const { basename, extension } = parseFilePath(filename);
+		const name = sanitizeFileName(basename);
+		const fullExt = extension ? '.' + extension : '';
+
+		const at = (candidate: string) => normalizePath(parent ? `${parent}/${candidate}` : candidate);
+		const preferred = at(`${name}${fullExt}`);
+
+		const free = (taken: (path: string) => boolean) => {
+			let path = preferred;
+			for (let i = 1; taken(path); i++) {
+				path = at(`${name} ${i}${fullExt}`);
+			}
+			return path;
+		};
+
+		return { preferred, free };
+	}
+
 	/** Reuse prior imports, but give same-run name collisions a new path. */
 	protected async placeAttachment(
 		filename: string,
 		sourcePath?: string,
 		sourceMtime?: number,
 	): Promise<{ path: string, reuse: TFile | null }> {
-		const unclaimedPath = async () => {
-			const path = await this.getAvailablePathForAttachment(filename, [], sourcePath);
+		const { preferred: candidate, free } = await this.attachmentNaming(filename, sourcePath);
+
+		const unclaimedPath = () => {
+			const path = free(taken => !!this.vault.getAbstractFileByPath(taken));
 			this.claimPath(path);
 			return { path, reuse: null };
 		};
 
 		if (this.duplicateHandling === DuplicateHandling.CreateCopy) return unclaimedPath();
-
-		const folderPath = await this.attachmentFolderPath(sourcePath);
-		const parent = folderPath === '/' ? '' : folderPath;
-		const { basename, extension } = parseFilePath(filename);
-		const name = `${sanitizeFileName(basename)}${extension ? `.${extension}` : ''}`;
-		const candidate = normalizePath(parent ? `${parent}/${name}` : name);
 
 		if (this.hasClaimed(candidate)) return unclaimedPath();
 
@@ -700,24 +715,10 @@ export abstract class FormatImporter {
 	}
 
 	async getAvailablePathForAttachment(filename: string, claimedPaths: string[], sourcePath?: string): Promise<string> {
-		const folderPath = await this.attachmentFolderPath(sourcePath);
-		const folder = await this.createFolders(folderPath);
-		const parent = folder.path === '/' ? '' : folder.path;
+		const { free } = await this.attachmentNaming(filename, sourcePath);
 
-		const { basename, extension } = parseFilePath(filename);
-		const name = sanitizeFileName(basename);
-		const fullExt = extension ? '.' + extension : '';
-
-		const at = (candidate: string) => normalizePath(parent ? `${parent}/${candidate}` : candidate);
-		const taken = (candidate: string) =>
-			claimedPaths.includes(candidate) || !!this.vault.getAbstractFileByPath(candidate);
-
-		let outputPath = at(`${name}${fullExt}`);
-		for (let i = 1; taken(outputPath); i++) {
-			outputPath = at(`${name} ${i}${fullExt}`);
-		}
-
-		return outputPath;
+		return free(candidate =>
+			claimedPaths.includes(candidate) || !!this.vault.getAbstractFileByPath(candidate));
 	}
 
 	async backOff(durationSeconds: number, reason: string, ctx: ImportContext | undefined): Promise<void> {

--- a/src/format-importer.ts
+++ b/src/format-importer.ts
@@ -94,7 +94,8 @@ export abstract class FormatImporter {
 	defaultOutputFolder: string = 'Import';
 
 	attachmentLocation: AttachmentLocation;
-	duplicateHandling: DuplicateHandling = DuplicateHandling.CreateCopy;
+	/** Resolved against duplicateModes once the importer has set them up. */
+	duplicateHandling: DuplicateHandling = DuplicateHandling.Update;
 
 	duplicateModes: DuplicateHandling[] = [
 		DuplicateHandling.CreateCopy,
@@ -106,7 +107,7 @@ export abstract class FormatImporter {
 	idProperty: string | null = null;
 	idLabel: string = 'source ID';
 
-	saveSourceId: boolean = false;
+	saveSourceId: boolean = true;
 
 	// Controls which interruption buttons the importer supports.
 	interruption: 'none' | 'stop' | 'pause' = 'none';
@@ -541,8 +542,27 @@ export abstract class FormatImporter {
 		});
 	}
 
+	/**
+	 * Not every importer offers Update, and a default it does not offer is not
+	 * one it can use. Skip is the nearest thing where it is missing: both leave
+	 * a note that is already there alone rather than writing a second copy.
+	 */
+	private defaultDuplicateHandling(): DuplicateHandling {
+		for (const preferred of [DuplicateHandling.Update, DuplicateHandling.Skip]) {
+			if (this.duplicateModes.includes(preferred)) return preferred;
+		}
+
+		return this.duplicateModes[0];
+	}
+
 	private async loadOutputSettings(): Promise<void> {
 		this.outputLocation = this.defaultOutputFolder;
+		// duplicateModes are set in init(), so the field default cannot know
+		// whether this importer offers it. Only correct it if it does not,
+		// leaving a mode the caller chose deliberately alone.
+		if (!this.duplicateModes.includes(this.duplicateHandling)) {
+			this.duplicateHandling = this.defaultDuplicateHandling();
+		}
 
 		if (!this.host.plugin) return;
 

--- a/src/format-importer.ts
+++ b/src/format-importer.ts
@@ -682,10 +682,11 @@ export abstract class FormatImporter {
 			if (this.hasClaimed(candidate)) continue;
 
 			const existing = this.vault.getAbstractFileByPath(candidate);
-			if (!(existing instanceof TFile)) {
+			if (existing === null) {
 				this.claimPath(candidate);
 				return { path: candidate, reuse: null };
 			}
+			if (!(existing instanceof TFile)) continue;
 
 			if (!reusing) continue;
 

--- a/src/formats/airtable-api.ts
+++ b/src/formats/airtable-api.ts
@@ -9,6 +9,7 @@ import { ImportContext } from '../import-context';
 import { parseFilePath } from '../filesystem';
 import { extractErrorMessage, sanitizeFileName, getUniqueFilePath, updatePropertyTypes, plural } from '../util';
 import { areAnySelected, selectedNodes } from '../tree';
+import { describeRequestFailure } from '../request-failure';
 import { TreePicker } from '../tree-view';
 import type { FormulaImportStrategy } from '../base';
 import {
@@ -158,7 +159,11 @@ export class AirtableAPIImporter extends FormatImporter {
 			hint: 'Load your Airtable bases and tables to get started.',
 			loading: 'Fetching bases...',
 			empty: 'No bases found.',
-			failed: 'Could not load your bases. Check your token and try again.',
+			failed: error => describeRequestFailure(error, {
+				name: 'Airtable',
+				subject: 'your bases',
+				credential: 'Check that your personal access token is current and has access to them.',
+			}),
 			view: {
 				icon: node => node.type === 'base' ? 'database' : 'file',
 				isCollapsible: node => node.type === 'base' || !!node.children?.length,

--- a/src/formats/airtable-api/api-helpers.ts
+++ b/src/formats/airtable-api/api-helpers.ts
@@ -67,7 +67,10 @@ export async function makeAirtableRequest<T>(options: AirtableRequestOptions, at
 			// Rate limited - Airtable requires 30 second wait per official docs
 			// https://airtable.com/developers/web/api/rate-limits
 			if (attempt >= MAX_RATE_LIMIT_RETRIES) {
-				throw new Error(`Airtable API error: still rate limited after ${MAX_RATE_LIMIT_RETRIES} attempts`);
+				throw Object.assign(
+					new Error(`Airtable API error: still rate limited after ${MAX_RATE_LIMIT_RETRIES} attempts`),
+					{ status: 429 },
+				);
 			}
 
 			const retryAfter = response.headers?.['retry-after']
@@ -81,7 +84,7 @@ export async function makeAirtableRequest<T>(options: AirtableRequestOptions, at
 
 		if (response.status >= 400) {
 			const errorText = response.text || `HTTP ${response.status}`;
-			throw new Error(`Airtable API error: ${errorText}`);
+			throw Object.assign(new Error(`Airtable API error: ${errorText}`), { status: response.status });
 		}
 
 		return response.json as T;

--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -21,20 +21,23 @@ const NOTE_ID_PROPERTY = 'apple-notes-id';
 const LOCAL_STORAGE_KEY = 'apple-notes-importer-file-prefix';
 const NO_ACCESS_HINT = 'Allow access to your notes to see the folders in them.';
 
-function describeFolderFailure(error: unknown): string {
-	const { code, message } = requestFailure(error);
+export function describeFolderFailure(error: unknown): string {
+	// The vendored sqlite layer labels everything SQLITE_ERROR and puts what
+	// actually happened in the message — either its own 'busy DB or query too
+	// slow' or whatever the sqlite3 binary wrote to stderr. Matching on the
+	// filesystem codes instead reads well and never fires, and a missing or
+	// unreadable database never gets this far anyway: readableDataFolder
+	// checks for it first and the picker shows the access hint.
+	const detail = (requestFailure(error).message ?? '').replace(/^SQLITE_ERROR:\s*/, '').trim();
 
-	if (code === 'ENOENT') {
-		return 'Could not find your Apple Notes database. Check that Notes is still installed and has been opened at least once.';
-	}
-	if (code === 'EACCES' || code === 'EPERM') {
-		return `Obsidian was not allowed to read your Apple Notes database. ${NO_ACCESS_HINT}`;
-	}
-	if (code === 'EBUSY' || code === 'SQLITE_BUSY') {
+	if (/\block|locked|busy\b/i.test(detail)) {
 		return 'Your Apple Notes database is in use. Quit Notes and try again.';
 	}
+	if (/unable to open|no such file|not authorized/i.test(detail)) {
+		return `Could not open your Apple Notes database. ${NO_ACCESS_HINT}`;
+	}
 
-	return message ? `Could not read your notes: ${message}` : 'Could not read your notes.';
+	return detail ? `Could not read your notes: ${detail}` : 'Could not read your notes.';
 }
 
 interface AppleNotesTreeNode extends ViewableNode<AppleNotesTreeNode> {

--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -3,7 +3,7 @@ import { NoteConverter, noteTitle } from './apple-notes/convert-note';
 import { ANAccount, ANAttachment, ANContext, ANConverter, ANConverterType, ANFolderType } from './apple-notes/models';
 import { descriptor } from './apple-notes/descriptor';
 import { ImportContext } from '../import-context';
-import { fs, fsPromises, nodeBufferToArrayBuffer, os, parseFilePath, path, splitext, zlib } from '../filesystem';
+import { fs, fsPromises, nodeBufferToArrayBuffer, os, path, splitext, zlib } from '../filesystem';
 import { extensionFromBytes, extractErrorMessage, sanitizeFileName } from '../util';
 import { requestFailure } from '../request-failure';
 import { DuplicateHandling, FormatImporter } from '../format-importer';
@@ -695,35 +695,22 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 
 			const attachmentName = outExt ? `${finalAttachmentName}.${outExt}` : finalAttachmentName;
 
-			// First resolve the configured folder, then check the unsuffixed name there.
 			const notePath = this.resolvedFiles[row.ZNOTE]?.path;
-			const uniqueAttachmentPath = await this.getAvailablePathForAttachment(attachmentName, [], notePath);
-			const { parent } = parseFilePath(uniqueAttachmentPath);
-			const existingAttachment = this.vault.getAbstractFileByPath(path.join(parent, attachmentName));
+			const mtime = this.decodeTime(row.ZMODIFICATIONDATE);
+			const { path: attachmentPath, reuse } = await this.placeAttachment(attachmentName, notePath, mtime);
 
-			if (existingAttachment && existingAttachment instanceof TFile) {
-				if (this.duplicateHandling === DuplicateHandling.Skip) {
-					this.ctx.reportSkipped(finalAttachmentName, 'attachment already exists');
-					return existingAttachment;
-				}
-				else if (this.duplicateHandling === DuplicateHandling.Update) {
-					const appleAttachmentModTime = this.decodeTime(row.ZMODIFICATIONDATE);
-					const existingAttachmentModTime = existingAttachment.stat.mtime;
-
-					if (appleAttachmentModTime <= existingAttachmentModTime) {
-						this.ctx.reportSkipped(finalAttachmentName, 'attachment unchanged since last import');
-						return existingAttachment;
-					}
-				}
+			if (reuse) {
+				this.ctx.reportSkipped(finalAttachmentName, this.duplicateHandling === DuplicateHandling.Skip
+					? 'attachment already exists'
+					: 'attachment unchanged since last import');
+				return reuse;
 			}
 
 			binary ??= await this.getAttachmentSource(this.resolvedAccounts[this.owners[row.ZNOTE]], sourcePath);
 
-			const attachmentPath = await this.getAvailablePathForAttachment(attachmentName, [], notePath);
-
-			file = await this.vault.createBinary(
+			file = await this.writeAttachment(
 				attachmentPath, nodeBufferToArrayBuffer(binary),
-				{ ctime: this.decodeTime(row.ZCREATIONDATE), mtime: this.decodeTime(row.ZMODIFICATIONDATE) }
+				{ ctime: this.decodeTime(row.ZCREATIONDATE), mtime }
 			);
 		}
 		catch (e) {

--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -681,8 +681,21 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 			const attachmentName = outExt ? `${finalAttachmentName}.${outExt}` : finalAttachmentName;
 
 			const notePath = this.resolvedFiles[row.ZNOTE]?.path;
+			const ctime = this.decodeTime(row.ZCREATIONDATE);
 			const mtime = this.decodeTime(row.ZMODIFICATIONDATE);
-			const { path: attachmentPath, reuse } = await this.placeAttachment(attachmentName, notePath, mtime);
+
+			// An attachment is written with the times Apple Notes gave it, and
+			// editing one does not change when it was created. So a file created
+			// at another moment is another attachment that happens to share the
+			// name, not an earlier version of this one. Without a creation date
+			// there is nothing to tell them apart, and decodeTime says "now",
+			// which would match nothing and write another copy every import.
+			const created = Number(row.ZCREATIONDATE) > 0;
+
+			const { path: attachmentPath, reuse } = await this.placeAttachment(attachmentName, notePath,
+				existing => created && existing.stat.ctime !== ctime ? 'another'
+					: mtime > existing.stat.mtime ? 'stale'
+						: 'same');
 
 			if (reuse) {
 				this.ctx.reportSkipped(finalAttachmentName, this.duplicateHandling === DuplicateHandling.Skip
@@ -694,8 +707,7 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 			binary ??= await this.getAttachmentSource(this.resolvedAccounts[this.owners[row.ZNOTE]], sourcePath);
 
 			file = await this.writeAttachment(
-				attachmentPath, nodeBufferToArrayBuffer(binary),
-				{ ctime: this.decodeTime(row.ZCREATIONDATE), mtime }
+				attachmentPath, nodeBufferToArrayBuffer(binary), { ctime, mtime }
 			);
 		}
 		catch (e) {

--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -5,6 +5,7 @@ import { descriptor } from './apple-notes/descriptor';
 import { ImportContext } from '../import-context';
 import { fs, fsPromises, nodeBufferToArrayBuffer, os, parseFilePath, path, splitext, zlib } from '../filesystem';
 import { extensionFromBytes, extractErrorMessage, sanitizeFileName } from '../util';
+import { requestFailure } from '../request-failure';
 import { DuplicateHandling, FormatImporter } from '../format-importer';
 import { selectedNodes } from '../tree';
 import { TreePicker, ViewableNode } from '../tree-view';
@@ -19,6 +20,22 @@ const CORETIME_OFFSET = 978307200;
 const NOTE_ID_PROPERTY = 'apple-notes-id';
 const LOCAL_STORAGE_KEY = 'apple-notes-importer-file-prefix';
 const NO_ACCESS_HINT = 'Allow access to your notes to see the folders in them.';
+
+function describeFolderFailure(error: unknown): string {
+	const { code, message } = requestFailure(error);
+
+	if (code === 'ENOENT') {
+		return 'Could not find your Apple Notes database. Check that Notes is still installed and has been opened at least once.';
+	}
+	if (code === 'EACCES' || code === 'EPERM') {
+		return `Obsidian was not allowed to read your Apple Notes database. ${NO_ACCESS_HINT}`;
+	}
+	if (code === 'EBUSY' || code === 'SQLITE_BUSY') {
+		return 'Your Apple Notes database is in use. Quit Notes and try again.';
+	}
+
+	return message ? `Could not read your notes: ${message}` : 'Could not read your notes.';
+}
 
 interface AppleNotesTreeNode extends ViewableNode<AppleNotesTreeNode> {
 	id: number;
@@ -201,7 +218,7 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 				hint: NO_ACCESS_HINT,
 				loading: 'Reading folders...',
 				empty: 'No folders found.',
-				failed: 'Could not read your notes. Check that the folder is still where it was.',
+				failed: error => describeFolderFailure(error),
 				view: {
 					icon: node => node.type === 'account' ? 'user' : 'folder',
 					flair: node => node.type === 'account' ? '' : String(node.notes),

--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -5,7 +5,7 @@ import { descriptor } from './apple-notes/descriptor';
 import { ImportContext } from '../import-context';
 import { fs, fsPromises, nodeBufferToArrayBuffer, os, path, splitext, zlib } from '../filesystem';
 import { extensionFromBytes, extractErrorMessage, sanitizeFileName } from '../util';
-import { requestFailure } from '../request-failure';
+import { describeFolderFailure, NO_ACCESS_HINT } from './apple-notes/errors';
 import { DuplicateHandling, FormatImporter } from '../format-importer';
 import { selectedNodes } from '../tree';
 import { TreePicker, ViewableNode } from '../tree-view';
@@ -19,21 +19,6 @@ const NOTE_DB = 'NoteStore.sqlite';
 const CORETIME_OFFSET = 978307200;
 const NOTE_ID_PROPERTY = 'apple-notes-id';
 const LOCAL_STORAGE_KEY = 'apple-notes-importer-file-prefix';
-const NO_ACCESS_HINT = 'Allow access to your notes to see the folders in them.';
-
-export function describeFolderFailure(error: unknown): string {
-	// SQLite errors arrive either prefixed or as bare stderr.
-	const detail = (requestFailure(error).message ?? '').replace(/^SQLITE_ERROR:\s*/, '').trim();
-
-	if (/\block|locked|busy\b/i.test(detail)) {
-		return 'Your Apple Notes database is in use. Quit Notes and try again.';
-	}
-	if (/unable to open|no such file|not authorized/i.test(detail)) {
-		return `Could not open your Apple Notes database. ${NO_ACCESS_HINT}`;
-	}
-
-	return detail ? `Could not read your notes: ${detail}` : 'Could not read your notes.';
-}
 
 interface AppleNotesTreeNode extends ViewableNode<AppleNotesTreeNode> {
 	id: number;
@@ -216,7 +201,7 @@ export class AppleNotesImporter extends FormatImporter implements ANContext<TFil
 				hint: NO_ACCESS_HINT,
 				loading: 'Reading folders...',
 				empty: 'No folders found.',
-				failed: error => describeFolderFailure(error),
+				failed: describeFolderFailure,
 				view: {
 					icon: node => node.type === 'account' ? 'user' : 'folder',
 					flair: node => node.type === 'account' ? '' : String(node.notes),

--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -22,10 +22,7 @@ const LOCAL_STORAGE_KEY = 'apple-notes-importer-file-prefix';
 const NO_ACCESS_HINT = 'Allow access to your notes to see the folders in them.';
 
 export function describeFolderFailure(error: unknown): string {
-	// The vendored sqlite layer puts the cause in the message, sometimes behind
-	// a SQLITE_ERROR label and sometimes as bare stderr; it never sets a
-	// filesystem code. A missing database does not reach here at all —
-	// readableDataFolder checks first and the picker shows the access hint.
+	// SQLite errors arrive either prefixed or as bare stderr.
 	const detail = (requestFailure(error).message ?? '').replace(/^SQLITE_ERROR:\s*/, '').trim();
 
 	if (/\block|locked|busy\b/i.test(detail)) {

--- a/src/formats/apple-notes.ts
+++ b/src/formats/apple-notes.ts
@@ -22,12 +22,10 @@ const LOCAL_STORAGE_KEY = 'apple-notes-importer-file-prefix';
 const NO_ACCESS_HINT = 'Allow access to your notes to see the folders in them.';
 
 export function describeFolderFailure(error: unknown): string {
-	// The vendored sqlite layer labels everything SQLITE_ERROR and puts what
-	// actually happened in the message — either its own 'busy DB or query too
-	// slow' or whatever the sqlite3 binary wrote to stderr. Matching on the
-	// filesystem codes instead reads well and never fires, and a missing or
-	// unreadable database never gets this far anyway: readableDataFolder
-	// checks for it first and the picker shows the access hint.
+	// The vendored sqlite layer puts the cause in the message, sometimes behind
+	// a SQLITE_ERROR label and sometimes as bare stderr; it never sets a
+	// filesystem code. A missing database does not reach here at all —
+	// readableDataFolder checks first and the picker shows the access hint.
 	const detail = (requestFailure(error).message ?? '').replace(/^SQLITE_ERROR:\s*/, '').trim();
 
 	if (/\block|locked|busy\b/i.test(detail)) {

--- a/src/formats/apple-notes/errors.ts
+++ b/src/formats/apple-notes/errors.ts
@@ -1,0 +1,17 @@
+import { extractErrorMessage } from '../../util';
+
+export const NO_ACCESS_HINT = 'Allow access to your notes to see the folders in them.';
+
+export function describeFolderFailure(error: unknown): string {
+	// SQLite errors arrive either prefixed or as bare stderr.
+	const detail = (extractErrorMessage(error) ?? '').replace(/^SQLITE_ERROR:\s*/, '').trim();
+
+	if (/\block|locked|busy\b/i.test(detail)) {
+		return 'Your Apple Notes database is in use. Quit Notes and try again.';
+	}
+	if (/unable to open|no such file|not authorized/i.test(detail)) {
+		return `Could not open your Apple Notes database. ${NO_ACCESS_HINT}`;
+	}
+
+	return detail ? `Could not read your notes: ${detail}` : 'Could not read your notes.';
+}

--- a/src/formats/notion-api.ts
+++ b/src/formats/notion-api.ts
@@ -4,6 +4,7 @@ import { ImportContext } from '../import-context';
 import { Client, PageObjectResponse } from '@notionhq/client';
 import { extractErrorMessage, sanitizeFileName, serializeFrontMatter, getUniqueFilePath, plural } from '../util';
 import { areAnySelected } from '../tree';
+import { describeRequestFailure } from '../request-failure';
 import { TreePicker } from '../tree-view';
 import type { FormulaImportStrategy } from '../base';
 import { parseFilePath } from '../filesystem';
@@ -102,7 +103,11 @@ export class NotionAPIImporter extends FormatImporter {
 			hint: 'Click "Load" to load your Notion pages and databases.',
 			loading: 'Loading pages and databases...',
 			empty: 'No pages or databases found. Make sure your connection has access to the pages you want to import.',
-			failed: 'Could not load your pages. Check your token and try again.',
+			failed: error => describeRequestFailure(error, {
+				name: 'Notion',
+				subject: 'your pages',
+				credential: 'Check that your token is current and that the connection has access to them.',
+			}),
 			view: {
 				icon: node => node.type === 'database' ? 'database'
 					: node.children.length === 0 ? 'file'

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -1,7 +1,7 @@
 import { OnenotePage, SectionGroup, User, PublicError, Notebook, OnenoteSection } from '@microsoft/microsoft-graph-types';
-import { ButtonComponent, DataWriteOptions, Notice, Setting, TFolder, ObsidianProtocolData, requestUrl, moment } from 'obsidian';
+import { ButtonComponent, DataWriteOptions, Notice, Setting, TFile, TFolder, ObsidianProtocolData, requestUrl, moment } from 'obsidian';
 import { genUid, extractErrorMessage, parseHTML, plural, sanitizeFileName } from '../util';
-import { FormatImporter } from '../format-importer';
+import { DuplicateHandling, FormatImporter } from '../format-importer';
 import { selectedNodes } from '../tree';
 import { TreePicker, ViewableNode } from '../tree-view';
 import { ATTACHMENT_EXTS, AUTH_REDIRECT_URI } from '../constants';
@@ -154,6 +154,7 @@ export class OneNoteImporter extends FormatImporter {
 	// UI
 	accountSetting: Setting;
 	private accountButton: ButtonComponent;
+	private organizationButton?: ButtonComponent;
 	private picker: TreePicker<OneNoteTreeNode>;
 	// Internal
 	selectedSections: OneNoteTreeNode[] = [];
@@ -168,9 +169,10 @@ export class OneNoteImporter extends FormatImporter {
 	private readAheadQueue: Promise<void> = Promise.resolve();
 	/** Bumped to disown reads that were started against an earlier listing. */
 	private pagesGeneration = 0;
-	private nextAccountType: MicrosoftAccountType | null = null;
 	private authenticatingAccountType: MicrosoftAccountType | null = null;
-	private storedTokenFailed = false;
+	private attachmentPaths!: Map<string, string>;
+	private attachmentOwners!: Map<string, string>;
+	private attachmentPathsChanged!: boolean;
 	refreshToken?: string;
 	lastSuccessfulFetchTime: number = performance.now();
 
@@ -191,6 +193,26 @@ export class OneNoteImporter extends FormatImporter {
 	}
 
 	async init() {
+		this.attachmentPaths = new Map();
+		this.attachmentOwners = new Map();
+		this.attachmentPathsChanged = false;
+
+		if (this.host.plugin) {
+			const data = await this.host.plugin.loadData();
+			for (const [key, path] of Object.entries(data.onenoteAttachments ?? {})) {
+				const file = this.vault.getAbstractFileByPath(path);
+				const resource = this.attachmentResource(key);
+				const owner = file instanceof TFile ? this.attachmentOwner(file.path) : null;
+				if (!(file instanceof TFile) || (owner !== null && owner !== resource)) {
+					this.attachmentPathsChanged = true;
+					continue;
+				}
+
+				this.attachmentPaths.set(key, file.path);
+				this.attachmentOwners.set(this.attachmentPathKey(file.path), resource);
+			}
+		}
+
 		this.defaultOutputFolder = 'OneNote';
 		this.idProperty = 'onenote-id';
 		this.idLabel = 'OneNote ID';
@@ -211,6 +233,16 @@ export class OneNoteImporter extends FormatImporter {
 
 		this.accountSetting = new Setting(contentEl)
 			.setName('Microsoft account')
+			.addButton(button => {
+				this.organizationButton = button;
+				button
+					.setButtonText('Use work or school access')
+					.onClick(() => {
+						this.signOut();
+						this.signIn('organization');
+					});
+				button.buttonEl.hide();
+			})
 			.addButton((button) => {
 				this.accountButton = button;
 				button.onClick(() => {
@@ -237,7 +269,6 @@ export class OneNoteImporter extends FormatImporter {
 			return true;
 		}
 		catch (error) {
-			this.storedTokenFailed = true;
 			const { status, code } = requestFailure(error);
 			if (status === 400 || status === 401 || code === 'invalid_grant') {
 				this.clearStoredRefreshToken();
@@ -268,6 +299,7 @@ export class OneNoteImporter extends FormatImporter {
 	}
 
 	private showSignedOut() {
+		this.organizationButton?.buttonEl.hide();
 		this.accountSetting.setDesc(this.microsoftAccountType === 'organization'
 			? 'Sign in to import your OneNote notebooks. A work or school account may need your organization to approve access.'
 			: 'Sign in to import your OneNote notebooks.');
@@ -276,6 +308,7 @@ export class OneNoteImporter extends FormatImporter {
 	}
 
 	async showSignedIn() {
+		this.organizationButton?.buttonEl.hide();
 		const userData = await this.fetchResource<User>('https://graph.microsoft.com/v1.0/me', 'json');
 		this.accountSetting.setDesc(`Signed in as ${userData.displayName} (${userData.mail}).`);
 		this.accountButton.setButtonText('Sign out').removeCta();
@@ -283,14 +316,10 @@ export class OneNoteImporter extends FormatImporter {
 		this.accountButton.buttonEl.addClass('mod-destructive');
 	}
 
-	private signIn() {
+	private signIn(accountType: MicrosoftAccountType = this.microsoftAccountType ?? 'personal') {
 		this.registerAuthCallback(data => void this.authenticateUser(data)
 			.catch(e => console.error('Could not complete sign in', e)));
-		this.authenticatingAccountType = this.nextAccountType
-			?? (this.storedTokenFailed ? 'personal' : this.microsoftAccountType)
-			?? 'personal';
-		this.nextAccountType = null;
-		this.storedTokenFailed = false;
+		this.authenticatingAccountType = accountType;
 
 		window.open(authorizationUrl(
 			this.authenticatingAccountType,
@@ -306,7 +335,6 @@ export class OneNoteImporter extends FormatImporter {
 		this.graphData.accessToken = '';
 		this.refreshToken = undefined;
 		this.authenticatingAccountType = null;
-		this.storedTokenFailed = false;
 
 		// Whoever signs in next is not necessarily who these belong to, and
 		// asking a personal account for the scopes an organization needs is
@@ -417,7 +445,7 @@ export class OneNoteImporter extends FormatImporter {
 			// Personal accounts cannot consent to Notes.Read.All, so escalating
 			// one leaves it unable to sign in at all.
 			if (requestFailure(e).code === SCOPE_REFUSED && this.microsoftAccountType !== 'personal') {
-				this.nextAccountType = 'organization';
+				this.organizationButton?.buttonEl.show();
 			}
 
 			console.error('An error occurred while fetching your OneNote data: ', e);
@@ -922,7 +950,7 @@ export class OneNoteImporter extends FormatImporter {
 			const extension = extensionForMime(image.getAttribute('data-fullres-src-type') ?? '') || 'png';
 			const fileName = `${parseFilePath(notePath).basename} image.${extension}`;
 			const outputPath = await this.fetchAttachment(
-				progress, fileName, contentLocation, notePath, sourceMtime);
+				progress, fileName, contentLocation, notePath, sourceMtime, true);
 			if (outputPath) {
 				image.src = encodeURI(outputPath);
 				if (!image.alt || BASE64_REGEX.test(image.alt)) {
@@ -958,9 +986,12 @@ export class OneNoteImporter extends FormatImporter {
 		contentLocation: string,
 		notePath: string,
 		sourceMtime?: number,
+		stableName = false,
 	): Promise<string | null> {
 		try {
-			const identifiedName = await resourceFilename(filename, contentLocation);
+			const outputName = stableName ? await resourceFilename(filename, contentLocation) : filename;
+			const attachmentKey = this.attachmentKey(contentLocation, notePath);
+			const attachmentResource = resourceId(contentLocation);
 			let data: ArrayBuffer | null = null;
 			const download = async (): Promise<ArrayBuffer> => {
 				if (data !== null) return data;
@@ -976,21 +1007,50 @@ export class OneNoteImporter extends FormatImporter {
 				return fetched;
 			};
 
-			const { path: outputPath, reuse } = await this.placeAttachment(identifiedName, notePath, async existing => {
-				if (sourceMtime !== undefined) {
+			if (this.duplicateHandling !== DuplicateHandling.CreateCopy) {
+				const mappedPath = this.attachmentPaths.get(attachmentKey);
+				if (mappedPath) {
+					const mapped = this.vault.getAbstractFileByPath(mappedPath);
+					if (mapped instanceof TFile && this.attachmentOwner(mapped.path) === attachmentResource) {
+						this.claimPath(mapped.path);
+						const stale = sourceMtime !== undefined && sourceMtime > mapped.stat.mtime;
+						if (!stale || this.duplicateHandling === DuplicateHandling.Skip) {
+							progress.reportSkipped(filename, 'it is already in the vault');
+							return mapped.path;
+						}
+
+						await this.writeAttachment(mapped.path, await download(), { mtime: sourceMtime });
+						progress.reportAttachmentSuccess(filename);
+						return mapped.path;
+					}
+
+					this.forgetAttachment(attachmentKey);
+				}
+			}
+
+			const { path: outputPath, reuse } = await this.placeAttachment(outputName, notePath, async existing => {
+				const owner = this.attachmentOwner(existing.path);
+				if (owner && owner !== attachmentResource) return 'another';
+
+				if (stableName && sourceMtime !== undefined) {
 					return sourceMtime > existing.stat.mtime ? 'stale' : 'same';
 				}
 
-				return sameBytes(await this.vault.readBinary(existing), await download()) ? 'same' : 'stale';
+				const downloaded = await download();
+				if (downloaded.byteLength !== existing.stat.size) return stableName ? 'stale' : 'another';
+				if (sameBytes(await this.vault.readBinary(existing), downloaded)) return 'same';
+				return stableName ? 'stale' : 'another';
 			});
 
 			if (reuse) {
+				this.rememberAttachment(attachmentKey, reuse.path);
 				progress.reportSkipped(filename, 'it is already in the vault');
 				return reuse.path;
 			}
 
 			await this.writeAttachment(
 				outputPath, await download(), sourceMtime === undefined ? undefined : { mtime: sourceMtime });
+			this.rememberAttachment(attachmentKey, outputPath);
 			progress.reportAttachmentSuccess(filename);
 			return outputPath;
 		}
@@ -998,6 +1058,66 @@ export class OneNoteImporter extends FormatImporter {
 			progress.reportFailed(filename, e);
 			console.error(e);
 			return null;
+		}
+	}
+
+	private attachmentKey(contentLocation: string, notePath: string): string {
+		const { mode, path } = this.attachmentLocation;
+		const note = mode === 'note' || mode === 'subfolder' ? notePath : '';
+		return [resourceId(contentLocation), mode, path, note].join('\n');
+	}
+
+	private attachmentResource(key: string): string {
+		const separator = key.indexOf('\n');
+		return separator < 0 ? key : key.slice(0, separator);
+	}
+
+	private attachmentPathKey(path: string): string {
+		return path.toLowerCase();
+	}
+
+	private attachmentOwner(path: string): string | null {
+		return this.attachmentOwners.get(this.attachmentPathKey(path)) ?? null;
+	}
+
+	private forgetAttachment(key: string): void {
+		const path = this.attachmentPaths.get(key);
+		if (!path) return;
+
+		this.attachmentPaths.delete(key);
+		const pathKey = this.attachmentPathKey(path);
+		if (![...this.attachmentPaths.values()].some(other => this.attachmentPathKey(other) === pathKey)) {
+			this.attachmentOwners.delete(pathKey);
+		}
+		this.attachmentPathsChanged = true;
+	}
+
+	private rememberAttachment(key: string, path: string): void {
+		const resource = this.attachmentResource(key);
+		const owner = this.attachmentOwner(path);
+		if (this.attachmentPaths.get(key) === path && owner === resource) return;
+		if (owner && owner !== resource) {
+			throw new Error(`Attachment path is already owned by another OneNote resource: ${path}`);
+		}
+
+		this.forgetAttachment(key);
+		this.attachmentPaths.set(key, path);
+		this.attachmentOwners.set(this.attachmentPathKey(path), resource);
+		this.attachmentPathsChanged = true;
+	}
+
+	async finalizeMarkdownOutput(ctx?: ImportContext): Promise<void> {
+		await super.finalizeMarkdownOutput(ctx);
+		if (!this.attachmentPathsChanged || !this.host.plugin) return;
+
+		try {
+			const data = await this.host.plugin.loadData();
+			data.onenoteAttachments = Object.fromEntries(this.attachmentPaths);
+			await this.host.plugin.saveData(data);
+			this.attachmentPathsChanged = false;
+		}
+		catch (error) {
+			console.error('Could not save OneNote attachment identities', error);
 		}
 	}
 

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -771,19 +771,23 @@ export class OneNoteImporter extends FormatImporter {
 			}
 
 			const originalName = object.getAttribute('data-attachment');
+			const extension = originalName?.split('.').pop()?.toLowerCase() ?? '';
+
+			// If the page contains an incompatible file and user doesn't want to import them, skip.
+			// This comes before the checks below so that a file the user chose
+			// not to import is passed over quietly rather than reported as a
+			// failure they did not ask for.
+			if (!ATTACHMENT_EXTS.contains(extension) && !this.importIncompatibleAttachments) {
+				continue;
+			}
+
 			const contentLocation = object.getAttribute('data');
 			if (!originalName || !contentLocation) {
 				progress.reportFailed(originalName ?? 'OneNote attachment', 'the attachment did not include a download URL');
 				continue;
 			}
 
-			const extension = originalName.split('.').pop()?.toLowerCase() ?? '';
-
-			// If the page contains an incompatible file and user doesn't want to import them, skip
-			if (!ATTACHMENT_EXTS.contains(extension) && !this.importIncompatibleAttachments) {
-				continue;
-			}
-			else {
+			{
 				const filename = await this.fetchAttachment(progress, originalName, contentLocation, notePath);
 				if (!filename) continue;
 
@@ -798,11 +802,18 @@ export class OneNoteImporter extends FormatImporter {
 
 		for (let i = 0; i < images.length; i++) {
 			const image = images[i];
-			let split: string[] = image.getAttribute('data-fullres-src-type')!.split('/');
-			const extension: string = split[1];
+			// Same reasoning as the objects above: OneNote does not always send
+			// these, and asserting they are there turns one odd image into a
+			// TypeError that costs the whole page.
+			const contentLocation = image.getAttribute('data-fullres-src');
+			if (!contentLocation) {
+				progress.reportFailed('OneNote image', 'the image did not include a download URL');
+				continue;
+			}
+
+			const extension = image.getAttribute('data-fullres-src-type')?.split('/')[1] ?? 'png';
 			const currentDate = moment().format('YYYYMMDDHHmmss');
 			const fileName: string = `Exported image ${currentDate}-${i}.${extension}`;
-			const contentLocation = image.getAttribute('data-fullres-src')!;
 			const outputPath = await this.fetchAttachment(progress, fileName, contentLocation, notePath);
 			if (outputPath) {
 				image.src = encodeURI(outputPath);

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -461,13 +461,11 @@ export class OneNoteImporter extends FormatImporter {
 					continue;
 				}
 
+				progress.status(`Importing note ${page.title}`);
+
+				let content: string;
 				try {
-					progress.status(`Importing note ${page.title}`);
-
-					await this.processFile(progress,
-						await this.fetchResource(`https://graph.microsoft.com/v1.0/me/onenote/pages/${page.id}/content?includeInkML=true`, 'text', progress),
-						page);
-
+					content = await this.fetchResource(`https://graph.microsoft.com/v1.0/me/onenote/pages/${page.id}/content?includeInkML=true`, 'text', progress);
 					consecutiveFailureCount = 0;
 				}
 				catch (e) {
@@ -498,6 +496,20 @@ export class OneNoteImporter extends FormatImporter {
 
 						return;
 					}
+
+					progress.reportProgress(++progressCurrent, progressTotal);
+					continue;
+				}
+
+				// A page that will not convert is one bad page. The counter
+				// above watches for the API going out from under us, and
+				// feeding content errors into it lets six unusual pages end an
+				// import that was otherwise working.
+				try {
+					await this.processFile(progress, content, page);
+				}
+				catch (e) {
+					progress.reportFailed(page.title, String(e));
 				}
 
 				// report progress even if page import fails or is skipped

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -9,13 +9,15 @@ import { ImportContext } from '../import-context';
 import { AccessTokenResponse } from './onenote/models';
 import { convertPageTags, pageToMarkdown } from './onenote/convert';
 import { describeNotebookFailure } from './onenote/errors';
+import { accountType, authorizationUrl, graphScopes, tokenUrl } from './onenote/auth';
+import type { MicrosoftAccountType } from './onenote/auth';
 import { inkmlToSvg } from './onenote/inkml';
 
 const ACCOUNT_SECRET_ID = 'onenote-importer';
 const PREVIOUS_SECRET_ID = 'onenote-importer-refresh-token';
+const ACCOUNT_TYPE_STORAGE_KEY = 'onenote-importer-account-type';
 const SIGNED_OUT_HINT = 'Sign in to see your OneNote notebooks.';
 const GRAPH_CLIENT_ID: string = '66553851-08fa-44f2-8bb1-1436f121a73d';
-const GRAPH_SCOPES: string[] = ['user.read', 'notes.read'];
 // Regex for fixing broken HTML returned by the OneNote API
 const SELF_CLOSING_REGEX = /<(object|iframe)([^>]*)\/>/g;
 // Maximum amount of request retries, before they're marked as failed. Does not include 429 backoff errors.
@@ -86,6 +88,7 @@ export class OneNoteImporter extends FormatImporter {
 
 	// Settings
 	importIncompatibleAttachments: boolean = false;
+	reimportLegacyPages: boolean = false;
 	// UI
 	accountSetting: Setting;
 	private accountButton: ButtonComponent;
@@ -110,6 +113,14 @@ export class OneNoteImporter extends FormatImporter {
 		return this.selectedSections.length > 0;
 	}
 
+	private get microsoftAccountType(): MicrosoftAccountType {
+		return accountType(this.app.loadLocalStorage(ACCOUNT_TYPE_STORAGE_KEY));
+	}
+
+	private set microsoftAccountType(value: MicrosoftAccountType) {
+		this.app.saveLocalStorage(ACCOUNT_TYPE_STORAGE_KEY, value);
+	}
+
 	async init() {
 		this.defaultOutputFolder = 'OneNote';
 		this.idProperty = 'onenote-id';
@@ -123,6 +134,13 @@ export class OneNoteImporter extends FormatImporter {
 				.onChange((value) => (this.importIncompatibleAttachments = value))
 			);
 
+		this.addSetting()
+			?.setName('Ignore legacy import history')
+			.setDesc('Reimport pages that older importer versions marked as imported. This can recover failed or deleted imports, but may duplicate moved or renamed notes.')
+			.addToggle(toggle => toggle
+				.setValue(false)
+				.onChange(value => this.reimportLegacyPages = value));
+
 		const contentEl = this.host.sourceEl;
 		if (!contentEl) {
 			await this.signInWithStoredToken();
@@ -131,6 +149,18 @@ export class OneNoteImporter extends FormatImporter {
 
 		this.accountSetting = new Setting(contentEl)
 			.setName('Microsoft account')
+			.addDropdown(dropdown => dropdown
+				.addOption('personal', 'Personal')
+				.addOption('organization', 'Work or school')
+				.setValue(this.microsoftAccountType)
+				.onChange(value => {
+					const selected = accountType(value);
+					if (selected === this.microsoftAccountType) return;
+
+					if (this.signedIn) this.signOut();
+					this.microsoftAccountType = selected;
+					this.showSignedOut();
+				}))
 			.addButton((button) => {
 				this.accountButton = button;
 				button.onClick(() => {
@@ -180,7 +210,8 @@ export class OneNoteImporter extends FormatImporter {
 	}
 
 	private showSignedOut() {
-		this.accountSetting.setDesc('Sign in to import your OneNote notebooks.');
+		const account = this.microsoftAccountType === 'organization' ? 'work or school' : 'personal';
+		this.accountSetting.setDesc(`Sign in with a ${account} Microsoft account to import your OneNote notebooks.`);
 		this.accountButton.setButtonText('Sign in').setCta();
 		this.accountButton.buttonEl.removeClass('mod-destructive');
 	}
@@ -197,15 +228,12 @@ export class OneNoteImporter extends FormatImporter {
 		this.registerAuthCallback(data => void this.authenticateUser(data)
 			.catch(e => console.error('Could not complete sign in', e)));
 
-		const requestBody = new URLSearchParams({
-			client_id: GRAPH_CLIENT_ID,
-			scope: 'offline_access ' + GRAPH_SCOPES.join(' '),
-			response_type: 'code',
-			redirect_uri: AUTH_REDIRECT_URI,
-			response_mode: 'query',
-			state: this.graphData.state,
-		});
-		window.open(`https://login.microsoftonline.com/common/oauth2/v2.0/authorize?${requestBody.toString()}`);
+		window.open(authorizationUrl(
+			this.microsoftAccountType,
+			GRAPH_CLIENT_ID,
+			AUTH_REDIRECT_URI,
+			this.graphData.state,
+		));
 	}
 
 	private signOut() {
@@ -228,7 +256,7 @@ export class OneNoteImporter extends FormatImporter {
 		// used if this import takes a long time, or for future imports.
 		const requestBody = new URLSearchParams({
 			client_id: GRAPH_CLIENT_ID,
-			scope: 'offline_access ' + GRAPH_SCOPES.join(' '),
+			scope: 'offline_access ' + graphScopes(this.microsoftAccountType).join(' '),
 			redirect_uri: AUTH_REDIRECT_URI,
 		});
 		if (code) {
@@ -246,7 +274,7 @@ export class OneNoteImporter extends FormatImporter {
 
 		const tokenResponse: AccessTokenResponse = await requestUrl({
 			method: 'POST',
-			url: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+			url: tokenUrl(this.microsoftAccountType),
 			contentType: 'application/x-www-form-urlencoded',
 			body: requestBody.toString(),
 		}).json;
@@ -424,7 +452,10 @@ export class OneNoteImporter extends FormatImporter {
 				if (!page.title) page.title = `Untitled-${moment().format('YYYYMMDDHHmmss')}`;
 
 				// Legacy IDs have no note paths, so they can only support Skip.
-				if (this.duplicateHandling === DuplicateHandling.Skip && page.id && this.legacyImportedIds.has(page.id)) {
+				if (!this.reimportLegacyPages
+					&& this.duplicateHandling === DuplicateHandling.Skip
+					&& page.id
+					&& this.legacyImportedIds.has(page.id)) {
 					progress.reportSkipped(page.title, 'an earlier version of the importer already brought it in');
 					progress.reportProgress(++progressCurrent, progressTotal);
 					continue;
@@ -518,64 +549,50 @@ export class OneNoteImporter extends FormatImporter {
 	}
 
 	async processFile(progress: ImportContext, content: string, page: OnenotePage) {
+		const splitContent = this.convertFormat(content);
+		const outputFolder = await this.getOutputFolder();
+		const outputPath = this.getEntityPathNoParent(page.id!, outputFolder!.name)!;
+
+		let pageFolder: TFolder;
+		if (!await this.vault.adapter.exists(outputPath)) {
+			pageFolder = await this.vault.createFolder(outputPath);
+		}
+		else {
+			const existing = this.vault.getAbstractFileByPath(outputPath);
+			if (!(existing instanceof TFolder)) throw new Error(`${outputPath} is not a folder`);
+			pageFolder = existing;
+		}
+		const notePath = `${pageFolder.path}/${sanitizeFileName(page.title)}.md`;
+
+		let inkEmbedMarkdown = '';
 		try {
-			const splitContent = this.convertFormat(content);
-			const outputFolder = await this.getOutputFolder();
-			const outputPath = this.getEntityPathNoParent(page.id!, outputFolder!.name)!;
-
-			let pageFolder: TFolder;
-			if (!await this.vault.adapter.exists(outputPath)) {
-				pageFolder = await this.vault.createFolder(outputPath);
+			const svgContent = inkmlToSvg(splitContent.inkml);
+			if (svgContent) {
+				const svgFilename = `${page.title} - Ink.svg`;
+				const svgPath = await this.getAvailablePathForAttachment(svgFilename, [], notePath);
+				await this.vault.create(svgPath, svgContent);
+				inkEmbedMarkdown = `\n\n![[${svgPath}]]\n`;
+				progress.reportAttachmentSuccess(svgFilename);
 			}
-			else {
-				const existing = this.vault.getAbstractFileByPath(outputPath);
-				if (!(existing instanceof TFolder)) throw new Error(`${outputPath} is not a folder`);
-				pageFolder = existing;
-			}
-			const notePath = `${pageFolder.path}/${sanitizeFileName(page.title)}.md`;
-
-			// Process InkML content if present and convert to SVG
-			let inkEmbedMarkdown = '';
-			try {
-				const svgContent = inkmlToSvg(splitContent.inkml);
-				if (svgContent) {
-					// Save the SVG as an attachment
-					const svgFilename = `${page.title} - Ink.svg`;
-					const svgPath = await this.getAvailablePathForAttachment(svgFilename, [], notePath);
-					await this.vault.create(svgPath, svgContent);
-
-					// Create markdown embed for the SVG
-					inkEmbedMarkdown = `\n\n![[${svgPath}]]\n`;
-					progress.reportAttachmentSuccess(svgFilename);
-				}
-			}
-			catch (e) {
-				console.error('Failed to convert InkML to SVG in page:', page.title, e);
-				progress.reportFailed(`${page.title} - Ink.svg`, e);
-			}
-
-			let html = await this.getAllAttachments(progress, convertPageTags(splitContent.html), notePath);
-			let mdContent = pageToMarkdown(html);
-
-			// OneNote seems to always place the "InkNode is not supported" comments at the top of the note.
-			// Additionally, the InkML combines all ink content into one block, so the best we can do is append
-			// it to the end of the note.
-			if (inkEmbedMarkdown) {
-				mdContent += inkEmbedMarkdown;
-			}
-
-			const lastModified = page?.lastModifiedDateTime ? Date.parse(page.lastModifiedDateTime) : null;
-			const created = page?.createdDateTime ? Date.parse(page.createdDateTime) : null;
-			const writeOptions: DataWriteOptions = {
-				ctime: created ?? lastModified ?? Date.now(),
-				mtime: lastModified ?? created ?? Date.now(),
-			};
-			const { written } = await this.writeNote(progress, pageFolder, page.title!, mdContent, { ...writeOptions, sourceId: page.id });
-			if (written) progress.reportNoteSuccess(page.title!);
 		}
 		catch (e) {
-			progress.reportFailed(page.title!, e);
+			console.error('Failed to convert InkML to SVG in page:', page.title, e);
+			progress.reportFailed(`${page.title} - Ink.svg`, e);
 		}
+
+		const html = await this.getAllAttachments(progress, convertPageTags(splitContent.html), notePath);
+		let mdContent = pageToMarkdown(html);
+
+		if (inkEmbedMarkdown) mdContent += inkEmbedMarkdown;
+
+		const lastModified = page?.lastModifiedDateTime ? Date.parse(page.lastModifiedDateTime) : null;
+		const created = page?.createdDateTime ? Date.parse(page.createdDateTime) : null;
+		const writeOptions: DataWriteOptions = {
+			ctime: created ?? lastModified ?? Date.now(),
+			mtime: lastModified ?? created ?? Date.now(),
+		};
+		const { written } = await this.writeNote(progress, pageFolder, page.title!, mdContent, { ...writeOptions, sourceId: page.id });
+		if (written) progress.reportNoteSuccess(page.title!);
 	}
 
 	// OneNote returns page data and inking data in one file, so we need to split them
@@ -732,23 +749,27 @@ export class OneNoteImporter extends FormatImporter {
 		const videos: HTMLIFrameElement[] = pageElement.findAll('iframe') as HTMLIFrameElement[];
 
 		for (const object of objects) {
-			// Objects may contain child nodes which would be lost when the object is replaced by markdown.
-			// To preserve these, move any child items to be siblings of the object
+			const next = object.nextSibling;
 			while (object.firstChild) {
-				object.parentNode?.insertBefore(object.firstChild, object.nextSibling);
+				object.parentNode?.insertBefore(object.firstChild, next);
 			}
 
-			let split: string[] = object.getAttribute('data-attachment')!.split('.');
-			const extension: string = split[split.length - 1];
+			const originalName = object.getAttribute('data-attachment');
+			const contentLocation = object.getAttribute('data');
+			if (!originalName || !contentLocation) {
+				progress.reportFailed(originalName ?? 'OneNote attachment', 'the attachment did not include a download URL');
+				continue;
+			}
+
+			const extension = originalName.split('.').pop()?.toLowerCase() ?? '';
 
 			// If the page contains an incompatible file and user doesn't want to import them, skip
 			if (!ATTACHMENT_EXTS.contains(extension) && !this.importIncompatibleAttachments) {
 				continue;
 			}
 			else {
-				const originalName = object.getAttribute('data-attachment')!;
-				const contentLocation = object.getAttribute('data')!;
 				const filename = await this.fetchAttachment(progress, originalName, contentLocation, notePath);
+				if (!filename) continue;
 
 				// Create a new <p> element with the Markdown-style link
 				const markdownLink = createEl('p');
@@ -796,7 +817,7 @@ export class OneNoteImporter extends FormatImporter {
 		return pageElement;
 	}
 
-	async fetchAttachment(progress: ImportContext, filename: string, contentLocation: string, notePath: string) {
+	async fetchAttachment(progress: ImportContext, filename: string, contentLocation: string, notePath: string): Promise<string | null> {
 		// Every 7 attachments, do a few second break to prevent rate limiting
 		if (this.attachmentsSinceBackOff === 7) {
 			this.attachmentsSinceBackOff = 0;
@@ -815,8 +836,9 @@ export class OneNoteImporter extends FormatImporter {
 			return outputPath;
 		}
 		catch (e) {
-			progress.reportFailed(filename);
+			progress.reportFailed(filename, e);
 			console.error(e);
+			return null;
 		}
 	}
 

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -425,97 +425,116 @@ export class OneNoteImporter extends FormatImporter {
 			return;
 		}
 
-		progress.status('Starting OneNote import');
-		let progressTotal = 0;
+		progress.status('Looking through the sections you chose');
+		const queue = await this.readSelectedPages(progress);
+		if (await progress.shouldStop()) return;
+
+		const progressTotal = queue.length;
 		let progressCurrent = 0;
 		let consecutiveFailureCount = 0;
 
-		for (let section of this.selectedSections) {
-			const sectionId = section.id;
-			const baseUrl = `https://graph.microsoft.com/v1.0/me/onenote/sections/${sectionId}/pages`;
+		progress.reportProgress(0, progressTotal);
+
+		for (let i = 0; i < queue.length; i++) {
+			if (await progress.shouldStop()) {
+				return;
+			}
+
+			const page = queue[i];
+			if (!page.title) page.title = `Untitled-${moment().format('YYYYMMDDHHmmss')}`;
+
+			progress.status(`Importing note ${page.title}`);
+
+			let failure: unknown = null;
+			try {
+				const content = await this.fetchResource(`https://graph.microsoft.com/v1.0/me/onenote/pages/${page.id}/content?includeInkML=true`, 'text', progress);
+				await this.processFile(progress, content, page);
+			}
+			catch (e) {
+				failure = e;
+				progress.reportFailed(page.title, String(e));
+			}
+
+			if (!failure) {
+				consecutiveFailureCount = 0;
+			}
+			// Page-specific failures do not indicate a broken import environment.
+			else if (!(failure instanceof PageContentError)) {
+				consecutiveFailureCount++;
+
+				if (consecutiveFailureCount > 5 || this.host.abortController.signal.aborted) {
+					const e = failure;
+					const status = this.host.abortController.signal.aborted
+						// The import was aborted
+						? extractErrorMessage(e) ?? String(e)
+						// Hit a string of consecutive failures, so something is
+						// wrong. This is NOT related to rate-limiting, as that
+						// is handled by the retry logic.
+						: 'Microsoft OneNote returned too many consecutive errors.';
+					progress.status(status);
+
+					// Report remaining pages as skipped
+					for (let j = i + 1; j < queue.length; j++) {
+						const remainingPage = queue[j];
+						progress.reportSkipped(
+							remainingPage.title ?? '<unknown>',
+							'import was canceled (after too many pages failed to load)'
+						);
+					}
+
+					// Report progress as complete
+					progress.reportProgress(progressTotal, progressTotal);
+
+					return;
+				}
+			}
+
+			// report progress even if page import fails or is skipped
+			progress.reportProgress(++progressCurrent, progressTotal);
+		}
+	}
+	/**
+	 * Every page in every chosen section, read before any of them is imported.
+	 *
+	 * The same requests either way — one page list per section — but doing them
+	 * first is what lets the progress bar know the real total. Counting as it
+	 * went meant the bar filled up on the first section and then jumped
+	 * backwards each time another one was opened.
+	 */
+	private async readSelectedPages(progress: ImportContext): Promise<OnenotePage[]> {
+		const queue: OnenotePage[] = [];
+
+		for (const section of this.selectedSections) {
+			if (await progress.shouldStop()) break;
+
+			progress.status(`Looking through ${section.title}`);
+
 			const params = new URLSearchParams({
 				$select: 'id,title,createdDateTime,lastModifiedDateTime,level,order,contentUrl',
 				$orderby: 'order',
-				pagelevel: 'true'
+				pagelevel: 'true',
 			});
-
-			const pagesUrl = `${baseUrl}?${params.toString()}`;
+			const pagesUrl = `https://graph.microsoft.com/v1.0/me/onenote/sections/${section.id}/pages?${params.toString()}`;
 
 			let pages: OnenotePage[] | null = null;
 			try {
-				pages = ((await this.fetchResource<OnenotePage>(pagesUrl, 'json-wrapped', progress)).value);
+				pages = (await this.fetchResource<OnenotePage>(pagesUrl, 'json-wrapped', progress)).value;
 			}
 			catch (e) {
-				console.error(`Failed to fetch pages for section ${sectionId}, skipping to next section.`, e);
+				console.error(`Failed to fetch pages for section ${section.id}, skipping to next section.`, e);
 				progress.reportFailed(section.title, e);
 				continue;
 			}
-			if (!pages) {
-				continue;
-			}
-			progressTotal += pages.length;
-			this.insertPagesToSection(pages, sectionId);
 
-			progress.reportProgress(progressCurrent, progressTotal);
+			if (!pages?.length) continue;
 
-			for (let i = 0; i < pages.length; i++) {
-				if (await progress.shouldStop()) {
-					return;
-				}
-
-				const page = pages[i];
-				if (!page.title) page.title = `Untitled-${moment().format('YYYYMMDDHHmmss')}`;
-
-				progress.status(`Importing note ${page.title}`);
-
-				let failure: unknown = null;
-				try {
-					const content = await this.fetchResource(`https://graph.microsoft.com/v1.0/me/onenote/pages/${page.id}/content?includeInkML=true`, 'text', progress);
-					await this.processFile(progress, content, page);
-				}
-				catch (e) {
-					failure = e;
-					progress.reportFailed(page.title, String(e));
-				}
-
-				if (!failure) {
-					consecutiveFailureCount = 0;
-				}
-				// Page-specific failures do not indicate a broken import environment.
-				else if (!(failure instanceof PageContentError)) {
-					consecutiveFailureCount++;
-
-					if (consecutiveFailureCount > 5 || this.host.abortController.signal.aborted) {
-						const e = failure;
-						const status = this.host.abortController.signal.aborted
-							// The import was aborted
-							? extractErrorMessage(e) ?? String(e)
-							// Hit a string of consecutive failures, so something is
-							// wrong. This is NOT related to rate-limiting, as that
-							// is handled by the retry logic.
-							: 'Microsoft OneNote returned too many consecutive errors.';
-						progress.status(status);
-
-						// Report remaining pages as skipped
-						for (let j = i + 1; j < pages.length; j++) {
-							const remainingPage = pages[j];
-							progress.reportSkipped(
-								remainingPage.title ?? '<unknown>',
-								'import was canceled (after too many pages failed to load)'
-							);
-						}
-
-						// Report progress as complete
-						progress.reportProgress(progressTotal, progressTotal);
-
-						return;
-					}
-				}
-
-				// report progress even if page import fails or is skipped
-				progress.reportProgress(++progressCurrent, progressTotal);
-			}
+			// Sub-page paths are worked out from the pages either side of one
+			// within its section, so the section needs its whole list.
+			this.insertPagesToSection(pages, section.id);
+			queue.push(...pages);
 		}
+
+		return queue;
 	}
 
 	insertPagesToSection(pages: OnenotePage[], sectionId: string, parentEntity?: Notebook | SectionGroup) {

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -8,11 +8,13 @@ import { ATTACHMENT_EXTS, AUTH_REDIRECT_URI } from '../constants';
 import { ImportContext } from '../import-context';
 import { AccessTokenResponse } from './onenote/models';
 import { convertPageTags, pageToMarkdown } from './onenote/convert';
-import { describeNotebookFailure } from './onenote/errors';
+import { describeNotebookFailure, SCOPE_REFUSED, THROTTLED } from './onenote/errors';
 import { requestFailure } from '../request-failure';
-import { accountType, accountTypeFromToken, authorizationUrl, graphScopes, tokenUrl } from './onenote/auth';
+import { accountTypeFromToken, authorizationUrl, graphScopes, storedAccountType, TOKEN_URL } from './onenote/auth';
 import type { MicrosoftAccountType } from './onenote/auth';
 import { inkmlToSvg } from './onenote/inkml';
+import { splitext } from '../filesystem';
+import { extensionForMime } from '../mime';
 
 const ACCOUNT_SECRET_ID = 'onenote-importer';
 const PREVIOUS_SECRET_ID = 'onenote-importer-refresh-token';
@@ -36,6 +38,8 @@ type JSONWrappedResponse<T> = {
 	value: T[];
 };
 
+type ResourceType = 'text' | 'file' | 'json' | 'json-wrapped';
+
 function assertUnreachable(x: never): never {
 	throw new Error(`Didn't expect to get here`);
 }
@@ -44,11 +48,6 @@ export function findingNotes(title: string, index: number, sections: number): st
 	return sections > 1
 		? `Finding notes in ${title} (section ${index + 1} of ${sections})`
 		: `Finding notes in ${title}`;
-}
-
-function worthRetrying(status: number): boolean {
-	// OneNote sometimes returns transient bare 400s for page requests.
-	return status !== 403 && status !== 404;
 }
 
 /**
@@ -145,13 +144,8 @@ export class OneNoteImporter extends FormatImporter {
 		return this.selectedSections.length > 0;
 	}
 
-	private get microsoftAccountType(): MicrosoftAccountType {
-		return accountType(this.app.loadLocalStorage(ACCOUNT_TYPE_STORAGE_KEY));
-	}
-
-	private get knownAccountType(): MicrosoftAccountType | null {
-		const stored: unknown = this.app.loadLocalStorage(ACCOUNT_TYPE_STORAGE_KEY);
-		return stored === 'organization' || stored === 'personal' ? stored : null;
+	private get microsoftAccountType(): MicrosoftAccountType | null {
+		return storedAccountType(this.app.loadLocalStorage(ACCOUNT_TYPE_STORAGE_KEY));
 	}
 
 	private set microsoftAccountType(value: MicrosoftAccountType) {
@@ -248,7 +242,7 @@ export class OneNoteImporter extends FormatImporter {
 			.catch(e => console.error('Could not complete sign in', e)));
 
 		window.open(authorizationUrl(
-			this.microsoftAccountType,
+			this.microsoftAccountType ?? 'personal',
 			GRAPH_CLIENT_ID,
 			AUTH_REDIRECT_URI,
 			this.graphData.state,
@@ -278,7 +272,7 @@ export class OneNoteImporter extends FormatImporter {
 		// used if this import takes a long time, or for future imports.
 		const requestBody = new URLSearchParams({
 			client_id: GRAPH_CLIENT_ID,
-			scope: 'offline_access ' + graphScopes(this.microsoftAccountType).join(' '),
+			scope: 'offline_access ' + graphScopes(this.microsoftAccountType ?? 'personal').join(' '),
 			redirect_uri: AUTH_REDIRECT_URI,
 		});
 		if (code) {
@@ -296,7 +290,7 @@ export class OneNoteImporter extends FormatImporter {
 
 		const tokenResponse: AccessTokenResponse = await requestUrl({
 			method: 'POST',
-			url: tokenUrl(),
+			url: TOKEN_URL,
 			contentType: 'application/x-www-form-urlencoded',
 			body: requestBody.toString(),
 		}).json;
@@ -353,7 +347,7 @@ export class OneNoteImporter extends FormatImporter {
 		catch (e) {
 			// Personal accounts cannot consent to Notes.Read.All, so escalating
 			// one leaves it unable to sign in at all.
-			if (requestFailure(e).code === '40004' && this.knownAccountType !== 'personal') {
+			if (requestFailure(e).code === SCOPE_REFUSED && this.microsoftAccountType !== 'personal') {
 				this.microsoftAccountType = 'organization';
 			}
 
@@ -393,7 +387,7 @@ export class OneNoteImporter extends FormatImporter {
 			hint: SIGNED_OUT_HINT,
 			loading: 'Loading notebooks...',
 			empty: 'No notebooks found.',
-			failed: error => describeNotebookFailure(error),
+			failed: describeNotebookFailure,
 			view: {
 				icon: node => node.type === 'notebook' ? 'book' : node.type === 'group' ? 'folder' : 'file',
 			},
@@ -462,34 +456,24 @@ export class OneNoteImporter extends FormatImporter {
 
 			progress.status(`Importing note ${page.title}`);
 
-			let failure: unknown = null;
 			try {
 				const content = await this.fetchResource(`https://graph.microsoft.com/v1.0/me/onenote/pages/${page.id}/content?includeInkML=true`, 'text', progress);
 				await this.processFile(progress, content, page);
-			}
-			catch (e) {
-				failure = e;
-				progress.reportFailed(page.title, String(e));
-			}
-
-			if (!failure) {
 				consecutiveFailureCount = 0;
 			}
-			// Page-specific failures do not indicate a broken import environment.
-			else if (!(failure instanceof PageContentError)) {
-				consecutiveFailureCount++;
+			catch (e) {
+				progress.reportFailed(page.title, String(e));
 
-				if (consecutiveFailureCount > 5 || this.host.abortController.signal.aborted) {
-					const e = failure;
-					const status = this.host.abortController.signal.aborted
+				// Page-specific failures do not indicate a broken import environment.
+				if (!(e instanceof PageContentError)
+					&& (++consecutiveFailureCount > 5 || this.host.abortController.signal.aborted)) {
+					progress.status(this.host.abortController.signal.aborted
 						? extractErrorMessage(e) ?? String(e)
-						: 'Microsoft OneNote returned too many consecutive errors.';
-					progress.status(status);
+						: 'Microsoft OneNote returned too many consecutive errors.');
 
-					for (let j = i + 1; j < queue.length; j++) {
-						const remainingPage = queue[j];
+					for (const remaining of queue.slice(i + 1)) {
 						progress.reportSkipped(
-							remainingPage.title ?? '<unknown>',
+							remaining.title ?? '<unknown>',
 							'import was canceled (after too many pages failed to load)'
 						);
 					}
@@ -551,12 +535,8 @@ export class OneNoteImporter extends FormatImporter {
 
 			progress.status(findingNotes(section.title, index, sections.length));
 
+			await this.readingAhead.get(section.id);
 			let pages = this.sectionPages.get(section.id);
-
-			if (!pages) {
-				await this.readingAhead.get(section.id);
-				pages = this.sectionPages.get(section.id);
-			}
 
 			if (!pages) {
 				try {
@@ -826,7 +806,7 @@ export class OneNoteImporter extends FormatImporter {
 				continue;
 			}
 
-			const extension = originalName.split('.').pop()?.toLowerCase() ?? '';
+			const [, extension] = splitext(originalName);
 			if (!ATTACHMENT_EXTS.contains(extension) && !this.importIncompatibleAttachments) {
 				continue;
 			}
@@ -837,17 +817,15 @@ export class OneNoteImporter extends FormatImporter {
 				continue;
 			}
 
-			{
-				const filename = await this.fetchAttachment(progress, originalName, contentLocation, notePath);
-				if (!filename) continue;
+			const filename = await this.fetchAttachment(progress, originalName, contentLocation, notePath);
+			if (!filename) continue;
 
-				// Create a new <p> element with the Markdown-style link
-				const markdownLink = createEl('p');
-				markdownLink.innerText = `![[${filename}]]`;
+			// Create a new <p> element with the Markdown-style link
+			const markdownLink = createEl('p');
+			markdownLink.innerText = `![[${filename}]]`;
 
-				// Replace the <object> tag with the new <p> element
-				object.parentNode?.replaceChild(markdownLink, object);
-			}
+			// Replace the <object> tag with the new <p> element
+			object.parentNode?.replaceChild(markdownLink, object);
 		}
 
 		for (let i = 0; i < images.length; i++) {
@@ -858,7 +836,7 @@ export class OneNoteImporter extends FormatImporter {
 				continue;
 			}
 
-			const extension = image.getAttribute('data-fullres-src-type')?.split('/')[1] ?? 'png';
+			const extension = extensionForMime(image.getAttribute('data-fullres-src-type') ?? '') || 'png';
 			const currentDate = moment().format('YYYYMMDDHHmmss');
 			const fileName: string = `Exported image ${currentDate}-${i}.${extension}`;
 			const outputPath = await this.fetchAttachment(progress, fileName, contentLocation, notePath);
@@ -892,12 +870,6 @@ export class OneNoteImporter extends FormatImporter {
 	}
 
 	async fetchAttachment(progress: ImportContext, filename: string, contentLocation: string, notePath: string): Promise<string | null> {
-		if (this.throttleSpacingMs > 0) {
-			await new Promise(resolve => window.setTimeout(resolve, this.throttleSpacingMs));
-		}
-
-		progress.status('Downloading attachment ' + filename);
-
 		try {
 			const { path: outputPath, reuse } = await this.placeAttachment(filename, notePath);
 
@@ -905,6 +877,13 @@ export class OneNoteImporter extends FormatImporter {
 				progress.reportSkipped(filename, 'it is already in the vault');
 				return reuse.path;
 			}
+
+			// Only downloads are worth spacing out; a reuse never reaches Graph.
+			if (this.throttleSpacingMs > 0) {
+				await new Promise(resolve => window.setTimeout(resolve, this.throttleSpacingMs));
+			}
+
+			progress.status('Downloading attachment ' + filename);
 
 			const data = (await this.fetchResource(contentLocation, 'file', progress));
 			await this.writeAttachment(outputPath, data);
@@ -920,11 +899,16 @@ export class OneNoteImporter extends FormatImporter {
 		}
 	}
 
-	async fetchResource<T = string>(url: string, returnType: 'text', progress?: ImportContext, retryCount?: number, refreshed?: boolean): Promise<T>;
-	async fetchResource<T = ArrayBuffer>(url: string, returnType: 'file', progress?: ImportContext, retryCount?: number, refreshed?: boolean): Promise<T>;
-	async fetchResource<T>(url: string, returnType: 'json', progress?: ImportContext, retryCount?: number, refreshed?: boolean): Promise<T>;
-	async fetchResource<T>(url: string, returnType: 'json-wrapped', progress?: ImportContext, retryCount?: number, refreshed?: boolean): Promise<JSONWrappedResponse<T>>;
-	async fetchResource<T>(url: string, returnType: 'text' | 'file' | 'json' | 'json-wrapped', progress?: ImportContext, retryCount: number = 0, refreshed: boolean = false): Promise<string | ArrayBuffer | object | JSONWrappedResponse<T>> {
+	async fetchResource<T = string>(url: string, returnType: 'text', progress?: ImportContext): Promise<T>;
+	async fetchResource<T = ArrayBuffer>(url: string, returnType: 'file', progress?: ImportContext): Promise<T>;
+	async fetchResource<T>(url: string, returnType: 'json', progress?: ImportContext): Promise<T>;
+	async fetchResource<T>(url: string, returnType: 'json-wrapped', progress?: ImportContext): Promise<JSONWrappedResponse<T>>;
+	async fetchResource<T>(url: string, returnType: ResourceType, progress?: ImportContext): Promise<string | ArrayBuffer | object | JSONWrappedResponse<T>> {
+		return this.fetchWithRetry<T>(url, returnType, progress, 0, false);
+	}
+
+	/** `retryCount` and `refreshed` are what one attempt hands the next. */
+	private async fetchWithRetry<T>(url: string, returnType: ResourceType, progress: ImportContext | undefined, retryCount: number, refreshed: boolean): Promise<string | ArrayBuffer | object | JSONWrappedResponse<T>> {
 		// Check if we need to reject early WITHOUT retrying, outside the
 		// try/catch block
 		if (retryCount >= MAX_RETRY_ATTEMPTS) {
@@ -1000,11 +984,11 @@ export class OneNoteImporter extends FormatImporter {
 					if (refreshed) throw new GraphRefusal(response.status, err);
 
 					await this.updateAccessToken();
-					return this.fetchResource(url, returnType as any, progress, retryCount + 1, true);
+					return this.fetchWithRetry<T>(url, returnType, progress, retryCount + 1, true);
 				}
 
 				// We're rate-limited - let's retry after the suggested amount of time
-				if (err?.code === '20166' || response.status === 429) {
+				if (err?.code === THROTTLED || response.status === 429) {
 					this.throttleSpacingMs = Math.min(
 						MAX_ATTACHMENT_SPACING_MS,
 						this.throttleSpacingMs + ATTACHMENT_SPACING_STEP_MS,
@@ -1029,9 +1013,9 @@ export class OneNoteImporter extends FormatImporter {
 						progress,
 					);
 
-					return this.fetchResource(
+					return this.fetchWithRetry<T>(
 						url,
-						returnType as any,
+						returnType,
 						progress,
 						// don't increment the retryCount because we were told
 						// to backoff, and we should infinitely retry on backoff
@@ -1041,13 +1025,15 @@ export class OneNoteImporter extends FormatImporter {
 					);
 				}
 
-				// A scope refusal will not change on retry.
-				const settled = !worthRetrying(response.status) || err?.code === '40004';
+				// A refusal, or a refused scope, will not change on retry — but
+				// OneNote does return transient bare 400s for page requests.
+				const settled = response.status === 403 || response.status === 404
+					|| err?.code === SCOPE_REFUSED;
 				if (settled || retryCount + 1 >= MAX_RETRY_ATTEMPTS) {
 					throw new GraphRefusal(response.status, err);
 				}
 
-				return this.fetchResource(url, returnType as any, progress, retryCount + 1, refreshed);
+				return this.fetchWithRetry<T>(url, returnType, progress, retryCount + 1, refreshed);
 			}
 		}
 		catch (e) {
@@ -1064,7 +1050,7 @@ export class OneNoteImporter extends FormatImporter {
 			// well.
 			if (retryCount + 1 >= MAX_RETRY_ATTEMPTS) throw e;
 
-			return this.fetchResource(url, returnType as any, progress, retryCount + 1, refreshed);
+			return this.fetchWithRetry<T>(url, returnType, progress, retryCount + 1, refreshed);
 		}
 	}
 }

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -274,7 +274,7 @@ export class OneNoteImporter extends FormatImporter {
 
 		const tokenResponse: AccessTokenResponse = await requestUrl({
 			method: 'POST',
-			url: tokenUrl(this.microsoftAccountType),
+			url: tokenUrl(),
 			contentType: 'application/x-www-form-urlencoded',
 			body: requestBody.toString(),
 		}).json;

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -133,6 +133,8 @@ export class OneNoteImporter extends FormatImporter {
 	private readonly sectionPages = new Map<string, OnenotePage[]>();
 	private readonly readingAhead = new Map<string, Promise<void>>();
 	private readAheadQueue: Promise<void> = Promise.resolve();
+	/** Bumped to disown reads that were started against an earlier listing. */
+	private pagesGeneration = 0;
 	refreshToken?: string;
 	lastSuccessfulFetchTime: number = performance.now();
 
@@ -148,7 +150,7 @@ export class OneNoteImporter extends FormatImporter {
 		return storedAccountType(this.app.loadLocalStorage(ACCOUNT_TYPE_STORAGE_KEY));
 	}
 
-	private set microsoftAccountType(value: MicrosoftAccountType) {
+	private set microsoftAccountType(value: MicrosoftAccountType | null) {
 		this.app.saveLocalStorage(ACCOUNT_TYPE_STORAGE_KEY, value);
 	}
 
@@ -255,8 +257,11 @@ export class OneNoteImporter extends FormatImporter {
 		this.graphData.accessToken = '';
 		this.refreshToken = undefined;
 
-		// Whoever signs in next is not necessarily who these belong to.
-		this.sectionPages.clear();
+		// Whoever signs in next is not necessarily who these belong to, and
+		// asking a personal account for the scopes an organization needs is
+		// refused before a token comes back to say which kind it was.
+		this.microsoftAccountType = null;
+		this.forgetSectionPages();
 
 		this.picker.reset();
 
@@ -335,11 +340,21 @@ export class OneNoteImporter extends FormatImporter {
 	private clearStoredRefreshToken() {
 		this.app.secretStorage.deleteSecret(ACCOUNT_SECRET_ID);
 	}
+	/** Page lists read against an earlier listing no longer describe the source. */
+	private forgetSectionPages(): void {
+		this.pagesGeneration++;
+		this.sectionPages.clear();
+		this.readingAhead.clear();
+	}
+
 	async showSectionPickerUI(): Promise<void> {
 		if (!this.signedIn) {
 			new Notice(SIGNED_OUT_HINT);
 			return;
 		}
+
+		// Reloading the notebooks is the user asking to be told again.
+		this.forgetSectionPages();
 
 		try {
 			await this.picker.load(() => this.readNotebooks());
@@ -507,13 +522,17 @@ export class OneNoteImporter extends FormatImporter {
 		for (const section of this.selectedSections) {
 			if (this.sectionPages.has(section.id) || this.readingAhead.has(section.id)) continue;
 
+			const generation = this.pagesGeneration;
+			const current = () => generation === this.pagesGeneration;
+
 			const reading = this.readAheadQueue.then(async () => {
 				// Recheck after earlier queued reads finish.
-				if (this.sectionPages.has(section.id)) return;
+				if (!current() || this.sectionPages.has(section.id)) return;
 				if (!this.selectedSections.some(selected => selected.id === section.id)) return;
 
 				try {
-					this.sectionPages.set(section.id, await this.fetchSectionPages(section.id));
+					const pages = await this.fetchSectionPages(section.id);
+					if (current()) this.sectionPages.set(section.id, pages);
 				}
 				catch {
 					// Let the import retry and report the failure.
@@ -521,7 +540,10 @@ export class OneNoteImporter extends FormatImporter {
 			});
 
 			this.readAheadQueue = reading;
-			this.readingAhead.set(section.id, reading.finally(() => this.readingAhead.delete(section.id)));
+			// A reload has already emptied the map; deleting would drop its entry.
+			this.readingAhead.set(section.id, reading.finally(() => {
+				if (current()) this.readingAhead.delete(section.id);
+			}));
 		}
 	}
 

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -38,11 +38,32 @@ function assertUnreachable(x: never): never {
 }
 
 function worthRetrying(status: number): boolean {
-	// Only a decision is worth failing fast on. OneNote answers a page request
-	// with a bare 400 often enough that PR #388 added a retry for it on
-	// purpose, and it usually succeeds on the second attempt — so the list is
-	// of what will never change, not of what might.
+	// Names what will never change, not what might: OneNote answers page
+	// requests with bare 400s that usually clear on the second attempt.
 	return status !== 403 && status !== 404;
+}
+
+/**
+ * A page whose own content defeated the conversion.
+ *
+ * Everything else that fails a page — the API refusing, a full disk, a vault
+ * that will not take the write — fails identically for every page after it,
+ * which is what the consecutive-failure stop is watching for. One
+ * unconvertible page is not that.
+ */
+class PageContentError extends Error {
+	constructor(cause: unknown) {
+		super(extractErrorMessage(cause) ?? String(cause));
+	}
+
+	static wrapping<T>(convert: () => T): T {
+		try {
+			return convert();
+		}
+		catch (e) {
+			throw new PageContentError(e);
+		}
+	}
 }
 
 class GraphRefusal extends Error {
@@ -213,8 +234,6 @@ export class OneNoteImporter extends FormatImporter {
 
 	private showSignedOut() {
 		this.accountSetting.setDesc(this.microsoftAccountType === 'organization'
-			// Only said once we know, which is after a first sign-in: the extra
-			// access is what a work or school tenant may want approving.
 			? 'Sign in to import your OneNote notebooks. A work or school account may need your organization to approve access.'
 			: 'Sign in to import your OneNote notebooks.');
 		this.accountButton.setButtonText('Sign in').setCta();
@@ -292,9 +311,8 @@ export class OneNoteImporter extends FormatImporter {
 			this.storeRefreshToken(tokenResponse.refresh_token);
 		}
 
-		// The token says which kind of account signed in. Remembering it is
-		// what lets the next sign-in ask for the access a work or school
-		// account needs, without anyone having had to say so up front.
+		// Remembering this is what lets the next sign-in ask for the wider
+		// access a work or school account needs, without anyone saying so.
 		const detected = accountTypeFromToken(tokenResponse.id_token ?? tokenResponse.access_token);
 		if (detected) this.microsoftAccountType = detected;
 
@@ -337,13 +355,11 @@ export class OneNoteImporter extends FormatImporter {
 			await this.picker.load(() => this.readNotebooks());
 		}
 		catch (e) {
-			// Being refused the notebooks is the other way to learn this, and
-			// unlike reading the token it does not depend on Microsoft handing
-			// us anything readable. But 40004 is documented only as the token
-			// lacking the scopes, not as something a work account alone is
-			// told, and notes.read.all cannot be granted to a personal account
-			// at all — so escalating one would leave it unable to sign in.
-			// A sign-in that already said personal is therefore believed.
+			// The other way to learn this, for when the token was unreadable.
+			// 40004 only means the token lacks the scopes, though, and a
+			// personal account cannot hold notes.read.all at all — escalating
+			// one would leave it unable to sign in, so a sign-in that already
+			// said personal wins.
 			if (requestFailure(e).code === '40004' && this.knownAccountType !== 'personal') {
 				this.microsoftAccountType = 'organization';
 			}
@@ -485,16 +501,27 @@ export class OneNoteImporter extends FormatImporter {
 
 				progress.status(`Importing note ${page.title}`);
 
-				let content: string;
+				let failure: unknown = null;
 				try {
-					content = await this.fetchResource(`https://graph.microsoft.com/v1.0/me/onenote/pages/${page.id}/content?includeInkML=true`, 'text', progress);
-					consecutiveFailureCount = 0;
+					const content = await this.fetchResource(`https://graph.microsoft.com/v1.0/me/onenote/pages/${page.id}/content?includeInkML=true`, 'text', progress);
+					await this.processFile(progress, content, page);
 				}
 				catch (e) {
-					consecutiveFailureCount++;
+					failure = e;
 					progress.reportFailed(page.title, String(e));
+				}
+
+				if (!failure) {
+					consecutiveFailureCount = 0;
+				}
+				// A page its own content defeated leaves the count where it
+				// was; anything else is the failure every remaining page is
+				// about to hit.
+				else if (!(failure instanceof PageContentError)) {
+					consecutiveFailureCount++;
 
 					if (consecutiveFailureCount > 5 || this.host.abortController.signal.aborted) {
+						const e = failure;
 						const status = this.host.abortController.signal.aborted
 							// The import was aborted
 							? extractErrorMessage(e) ?? String(e)
@@ -518,20 +545,6 @@ export class OneNoteImporter extends FormatImporter {
 
 						return;
 					}
-
-					progress.reportProgress(++progressCurrent, progressTotal);
-					continue;
-				}
-
-				// A page that will not convert is one bad page. The counter
-				// above watches for the API going out from under us, and
-				// feeding content errors into it lets six unusual pages end an
-				// import that was otherwise working.
-				try {
-					await this.processFile(progress, content, page);
-				}
-				catch (e) {
-					progress.reportFailed(page.title, String(e));
 				}
 
 				// report progress even if page import fails or is skipped
@@ -583,7 +596,7 @@ export class OneNoteImporter extends FormatImporter {
 	}
 
 	async processFile(progress: ImportContext, content: string, page: OnenotePage) {
-		const splitContent = this.convertFormat(content);
+		const splitContent = PageContentError.wrapping(() => this.convertFormat(content));
 		const outputFolder = await this.getOutputFolder();
 		const outputPath = this.getEntityPathNoParent(page.id!, outputFolder!.name)!;
 
@@ -615,7 +628,7 @@ export class OneNoteImporter extends FormatImporter {
 		}
 
 		const html = await this.getAllAttachments(progress, convertPageTags(splitContent.html), notePath);
-		let mdContent = pageToMarkdown(html);
+		let mdContent = PageContentError.wrapping(() => pageToMarkdown(html));
 
 		if (inkEmbedMarkdown) mdContent += inkEmbedMarkdown;
 
@@ -788,20 +801,25 @@ export class OneNoteImporter extends FormatImporter {
 				object.parentNode?.insertBefore(object.firstChild, next);
 			}
 
+			// Name first: without one there is nothing to filter on, and an
+			// empty extension would fail the check below and be dropped in
+			// silence rather than reported.
 			const originalName = object.getAttribute('data-attachment');
-			const extension = originalName?.split('.').pop()?.toLowerCase() ?? '';
+			if (!originalName) {
+				progress.reportFailed('OneNote attachment', 'the attachment did not say what it was called');
+				continue;
+			}
 
-			// If the page contains an incompatible file and user doesn't want to import them, skip.
-			// This comes before the checks below so that a file the user chose
-			// not to import is passed over quietly rather than reported as a
-			// failure they did not ask for.
+			// Then the filter, so a file the user opted out of is passed over
+			// quietly rather than reported as a failure they did not ask for.
+			const extension = originalName.split('.').pop()?.toLowerCase() ?? '';
 			if (!ATTACHMENT_EXTS.contains(extension) && !this.importIncompatibleAttachments) {
 				continue;
 			}
 
 			const contentLocation = object.getAttribute('data');
-			if (!originalName || !contentLocation) {
-				progress.reportFailed(originalName ?? 'OneNote attachment', 'the attachment did not include a download URL');
+			if (!contentLocation) {
+				progress.reportFailed(originalName, 'the attachment did not include a download URL');
 				continue;
 			}
 
@@ -820,9 +838,8 @@ export class OneNoteImporter extends FormatImporter {
 
 		for (let i = 0; i < images.length; i++) {
 			const image = images[i];
-			// Same reasoning as the objects above: OneNote does not always send
-			// these, and asserting they are there turns one odd image into a
-			// TypeError that costs the whole page.
+			// OneNote does not always send these, and asserting them turns one
+			// odd image into a TypeError that costs the whole page.
 			const contentLocation = image.getAttribute('data-fullres-src');
 			if (!contentLocation) {
 				progress.reportFailed('OneNote image', 'the image did not include a download URL');
@@ -952,10 +969,9 @@ export class OneNoteImporter extends FormatImporter {
 			}
 			else {
 				let err: PublicError | null = null;
-				// Graph does not always answer with JSON — an empty body, or an
-				// HTML page from a proxy in front of it, used to reject here and
-				// fall through to the network retry, taking the throttling
-				// branch below with it.
+				// Graph does not always answer with JSON: an empty body, or an
+				// HTML page from a proxy. Throwing here would skip every branch
+				// below, throttling included.
 				const respJson: unknown = await response.json().catch(() => null);
 				if (respJson && typeof respJson === 'object' && 'error' in respJson) {
 					err = (respJson as { error: PublicError }).error;
@@ -969,10 +985,8 @@ export class OneNoteImporter extends FormatImporter {
 					|| err?.code === 'InvalidAuthenticationToken'
 					|| response.status === 401;
 				if (isNotAuthorized) {
-					// Refreshing is the whole remedy, so a 401 that survives it
-					// is the account not being allowed to read this. Retrying
-					// four more times only replaces what Graph said with
-					// 'Exceeded maximum retry attempts'.
+					// Refreshing is the whole remedy, so a 401 surviving it means
+					// the account may not read this. Say so rather than retry.
 					if (refreshed) throw new GraphRefusal(response.status, err);
 
 					await this.updateAccessToken();
@@ -981,12 +995,9 @@ export class OneNoteImporter extends FormatImporter {
 
 				// We're rate-limited - let's retry after the suggested amount of time
 				if (err?.code === '20166' || response.status === 429) {
-					// Waiting is right during an import: the user asked for the
-					// whole notebook and the limit lifts. While the picker is
-					// loading there is nothing on screen that waiting helps, so
-					// it just sits silently for a minute an attempt — which is
-					// what issue #390 reports. Say so and let them press
-					// Refresh.
+					// Waiting is right during an import; the limit lifts. The
+					// picker has nothing on screen that waiting helps, so it
+					// would just sit silent for a minute an attempt.
 					if (!progress) throw new GraphRefusal(429, err);
 
 					const retryAfter = response.headers.get('Retry-After');

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -1,7 +1,7 @@
 import { OnenotePage, SectionGroup, User, PublicError, Notebook, OnenoteSection } from '@microsoft/microsoft-graph-types';
 import { ButtonComponent, DataWriteOptions, Notice, Setting, TFolder, ObsidianProtocolData, requestUrl, moment } from 'obsidian';
 import { genUid, extractErrorMessage, parseHTML, sanitizeFileName } from '../util';
-import { DuplicateHandling, FormatImporter } from '../format-importer';
+import { FormatImporter } from '../format-importer';
 import { selectedNodes } from '../tree';
 import { TreePicker, ViewableNode } from '../tree-view';
 import { ATTACHMENT_EXTS, AUTH_REDIRECT_URI } from '../constants';
@@ -110,7 +110,6 @@ export class OneNoteImporter extends FormatImporter {
 
 	// Settings
 	importIncompatibleAttachments: boolean = false;
-	reimportLegacyPages: boolean = false;
 	// UI
 	accountSetting: Setting;
 	private accountButton: ButtonComponent;
@@ -123,7 +122,6 @@ export class OneNoteImporter extends FormatImporter {
 		accessToken: '',
 	};
 	attachmentsSinceBackOff = 0;
-	private legacyImportedIds = new Set<string>();
 	refreshToken?: string;
 	lastSuccessfulFetchTime: number = performance.now();
 
@@ -160,13 +158,6 @@ export class OneNoteImporter extends FormatImporter {
 				.setValue(false)
 				.onChange((value) => (this.importIncompatibleAttachments = value))
 			);
-
-		this.addSetting()
-			?.setName('Ignore legacy import history')
-			.setDesc('Reimport pages that older importer versions marked as imported. This can recover failed or deleted imports, but may duplicate moved or renamed notes.')
-			.addToggle(toggle => toggle
-				.setValue(false)
-				.onChange(value => this.reimportLegacyPages = value));
 
 		const contentEl = this.host.sourceEl;
 		if (!contentEl) {
@@ -423,7 +414,6 @@ export class OneNoteImporter extends FormatImporter {
 		}
 	}
 	async import(progress: ImportContext): Promise<void> {
-		await this.readLegacyImportedIds();
 		const outputFolder = await this.getOutputFolder();
 		if (!outputFolder) {
 			new Notice('Please select a location to export to.');
@@ -475,16 +465,6 @@ export class OneNoteImporter extends FormatImporter {
 
 				const page = pages[i];
 				if (!page.title) page.title = `Untitled-${moment().format('YYYYMMDDHHmmss')}`;
-
-				// Legacy IDs have no note paths, so they can only support Skip.
-				if (!this.reimportLegacyPages
-					&& this.duplicateHandling === DuplicateHandling.Skip
-					&& page.id
-					&& this.legacyImportedIds.has(page.id)) {
-					progress.reportSkipped(page.title, 'an earlier version of the importer already brought it in');
-					progress.reportProgress(++progressCurrent, progressTotal);
-					continue;
-				}
 
 				progress.status(`Importing note ${page.title}`);
 
@@ -562,21 +542,6 @@ export class OneNoteImporter extends FormatImporter {
 					section.pages = pages;
 				}
 			}
-		}
-	}
-
-	private async readLegacyImportedIds(): Promise<void> {
-		this.legacyImportedIds.clear();
-		if (!this.host.plugin) return;
-
-		try {
-			const data = await this.host.plugin.loadData();
-			for (const id of data.importers?.onenote?.previouslyImportedIDs ?? []) {
-				this.legacyImportedIds.add(id);
-			}
-		}
-		catch (e) {
-			console.error('Could not read the ids of previously imported pages', e);
 		}
 	}
 

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -1,6 +1,6 @@
 import { OnenotePage, SectionGroup, User, PublicError, Notebook, OnenoteSection } from '@microsoft/microsoft-graph-types';
 import { ButtonComponent, DataWriteOptions, Notice, Setting, TFolder, ObsidianProtocolData, requestUrl, moment } from 'obsidian';
-import { genUid, extractErrorMessage, parseHTML, sanitizeFileName } from '../util';
+import { genUid, extractErrorMessage, parseHTML, plural, sanitizeFileName } from '../util';
 import { FormatImporter } from '../format-importer';
 import { selectedNodes } from '../tree';
 import { TreePicker, ViewableNode } from '../tree-view';
@@ -122,6 +122,9 @@ export class OneNoteImporter extends FormatImporter {
 		accessToken: '',
 	};
 	attachmentsSinceBackOff = 0;
+	/** Page lists read ahead of the import, by section id. */
+	private readonly sectionPages = new Map<string, OnenotePage[]>();
+	private prefetching: Promise<void> = Promise.resolve();
 	refreshToken?: string;
 	lastSuccessfulFetchTime: number = performance.now();
 
@@ -248,6 +251,9 @@ export class OneNoteImporter extends FormatImporter {
 
 		this.graphData.accessToken = '';
 		this.refreshToken = undefined;
+
+		// Whoever signs in next is not necessarily who these belong to.
+		this.sectionPages.clear();
 
 		this.picker.reset();
 
@@ -384,6 +390,7 @@ export class OneNoteImporter extends FormatImporter {
 			},
 			onChange: () => {
 				this.selectedSections = selectedNodes(this.picker.nodes, node => node.type === 'section');
+				this.prefetchSelectedPages();
 				this.sourceChanged();
 			},
 		});
@@ -425,11 +432,12 @@ export class OneNoteImporter extends FormatImporter {
 			return;
 		}
 
-		progress.status('Looking through the sections you chose');
+		progress.status('Finding notes to import');
 		const queue = await this.readSelectedPages(progress);
 		if (await progress.shouldStop()) return;
 
 		const progressTotal = queue.length;
+		progress.status(`Importing ${plural(progressTotal, 'note')}`);
 		let progressCurrent = 0;
 		let consecutiveFailureCount = 0;
 
@@ -493,40 +501,85 @@ export class OneNoteImporter extends FormatImporter {
 			progress.reportProgress(++progressCurrent, progressTotal);
 		}
 	}
+	private async fetchSectionPages(sectionId: string, progress?: ImportContext): Promise<OnenotePage[]> {
+		const params = new URLSearchParams({
+			$select: 'id,title,createdDateTime,lastModifiedDateTime,level,order,contentUrl',
+			$orderby: 'order',
+			pagelevel: 'true',
+			// OneNote sends 20 pages at a time unless asked otherwise, and caps
+			// this at 100. A section of 500 is 5 requests rather than 25.
+			$top: '100',
+		});
+
+		const url = `https://graph.microsoft.com/v1.0/me/onenote/sections/${sectionId}/pages?${params.toString()}`;
+		return (await this.fetchResource<OnenotePage>(url, 'json-wrapped', progress)).value ?? [];
+	}
+
+	/**
+	 * Start reading the page lists for whatever is selected, so that the wait
+	 * happens while the output and options steps are being filled in rather
+	 * than after Import is pressed. The import needs these lists regardless, so
+	 * nothing here is speculative work — only work moved earlier.
+	 *
+	 * One section at a time, because a notebook selected all at once would
+	 * otherwise open dozens of parallel requests at the API most likely to
+	 * throttle them. Failures are left for the import to hit and report.
+	 */
+	private prefetchSelectedPages(): void {
+		if (!this.signedIn) return;
+
+		for (const section of this.selectedSections) {
+			if (this.sectionPages.has(section.id)) continue;
+
+			this.prefetching = this.prefetching.then(async () => {
+				// Both may have changed while this waited its turn.
+				if (this.sectionPages.has(section.id)) return;
+				if (!this.selectedSections.some(selected => selected.id === section.id)) return;
+
+				try {
+					this.sectionPages.set(section.id, await this.fetchSectionPages(section.id));
+				}
+				catch {
+					// Left uncached, so the import asks again and reports it there.
+				}
+			});
+		}
+	}
+
 	/**
 	 * Every page in every chosen section, read before any of them is imported.
 	 *
-	 * The same requests either way — one page list per section — but doing them
-	 * first is what lets the progress bar know the real total. Counting as it
-	 * went meant the bar filled up on the first section and then jumped
+	 * The same requests either way — one page list per section — but having
+	 * them all is what lets the progress bar know the real total. Counting as
+	 * it went meant the bar filled up on the first section and then jumped
 	 * backwards each time another one was opened.
 	 */
 	private async readSelectedPages(progress: ImportContext): Promise<OnenotePage[]> {
 		const queue: OnenotePage[] = [];
 
+		// Anything still being read ahead is about to be needed.
+		await this.prefetching;
+
 		for (const section of this.selectedSections) {
 			if (await progress.shouldStop()) break;
 
-			progress.status(`Looking through ${section.title}`);
+			let pages = this.sectionPages.get(section.id);
+			if (!pages) {
+				progress.status(queue.length
+					? `Finding notes in ${section.title} (${queue.length} so far)`
+					: `Finding notes in ${section.title}`);
 
-			const params = new URLSearchParams({
-				$select: 'id,title,createdDateTime,lastModifiedDateTime,level,order,contentUrl',
-				$orderby: 'order',
-				pagelevel: 'true',
-			});
-			const pagesUrl = `https://graph.microsoft.com/v1.0/me/onenote/sections/${section.id}/pages?${params.toString()}`;
-
-			let pages: OnenotePage[] | null = null;
-			try {
-				pages = (await this.fetchResource<OnenotePage>(pagesUrl, 'json-wrapped', progress)).value;
-			}
-			catch (e) {
-				console.error(`Failed to fetch pages for section ${section.id}, skipping to next section.`, e);
-				progress.reportFailed(section.title, e);
-				continue;
+				try {
+					pages = await this.fetchSectionPages(section.id, progress);
+				}
+				catch (e) {
+					console.error(`Failed to fetch pages for section ${section.id}, skipping to next section.`, e);
+					progress.reportFailed(section.title, e);
+					continue;
+				}
 			}
 
-			if (!pages?.length) continue;
+			if (!pages.length) continue;
 
 			// Sub-page paths are worked out from the pages either side of one
 			// within its section, so the section needs its whole list.

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -8,6 +8,7 @@ import { ATTACHMENT_EXTS, AUTH_REDIRECT_URI } from '../constants';
 import { ImportContext } from '../import-context';
 import { AccessTokenResponse } from './onenote/models';
 import { convertPageTags, pageToMarkdown } from './onenote/convert';
+import { describeNotebookFailure } from './onenote/errors';
 import { inkmlToSvg } from './onenote/inkml';
 
 const ACCOUNT_SECRET_ID = 'onenote-importer';
@@ -318,7 +319,7 @@ export class OneNoteImporter extends FormatImporter {
 			hint: SIGNED_OUT_HINT,
 			loading: 'Loading notebooks...',
 			empty: 'No notebooks found.',
-			failed: 'Could not load your notebooks. OneNote may be limiting how fast they can be read; try again shortly.',
+			failed: error => describeNotebookFailure(error),
 			view: {
 				icon: node => node.type === 'notebook' ? 'book' : node.type === 'group' ? 'folder' : 'file',
 			},

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -23,8 +23,7 @@ const GRAPH_CLIENT_ID: string = '66553851-08fa-44f2-8bb1-1436f121a73d';
 const SELF_CLOSING_REGEX = /<(object|iframe)([^>]*)\/>/g;
 // Maximum amount of request retries, before they're marked as failed. Does not include 429 backoff errors.
 const MAX_RETRY_ATTEMPTS = 5;
-// How much each throttled request slows attachment downloads, and how far that
-// can go. One step is given back for every attachment that comes down cleanly.
+// Increase spacing after throttling and reduce it after successful downloads.
 const ATTACHMENT_SPACING_STEP_MS = 500;
 const MAX_ATTACHMENT_SPACING_MS = 3_000;
 
@@ -41,10 +40,6 @@ function assertUnreachable(x: never): never {
 	throw new Error(`Didn't expect to get here`);
 }
 
-/**
- * What to say while the sections are being counted. How many notes have turned
- * up is left to the remaining count, which climbs alongside this.
- */
 export function findingNotes(title: string, index: number, sections: number): string {
 	return sections > 1
 		? `Finding notes in ${title} (section ${index + 1} of ${sections})`
@@ -135,18 +130,9 @@ export class OneNoteImporter extends FormatImporter {
 		state: genUid(32),
 		accessToken: '',
 	};
-	/**
-	 * How long to leave between attachment downloads, which is nothing until
-	 * OneNote actually throttles. A fixed pause every few attachments spent the
-	 * same minutes whether or not anything was rate limiting, and on a notebook
-	 * with hundreds of attachments that was most of the import.
-	 */
 	private throttleSpacingMs = 0;
-	/** Page lists read ahead of the import, by section id. */
 	private readonly sectionPages = new Map<string, OnenotePage[]>();
-	/** Read-aheads still in flight, so an import can wait on one at a time. */
 	private readonly readingAhead = new Map<string, Promise<void>>();
-	/** Keeps those read-aheads to one request at a time. */
 	private readAheadQueue: Promise<void> = Promise.resolve();
 	refreshToken?: string;
 	lastSuccessfulFetchTime: number = performance.now();
@@ -496,15 +482,10 @@ export class OneNoteImporter extends FormatImporter {
 				if (consecutiveFailureCount > 5 || this.host.abortController.signal.aborted) {
 					const e = failure;
 					const status = this.host.abortController.signal.aborted
-						// The import was aborted
 						? extractErrorMessage(e) ?? String(e)
-						// Hit a string of consecutive failures, so something is
-						// wrong. This is NOT related to rate-limiting, as that
-						// is handled by the retry logic.
 						: 'Microsoft OneNote returned too many consecutive errors.';
 					progress.status(status);
 
-					// Report remaining pages as skipped
 					for (let j = i + 1; j < queue.length; j++) {
 						const remainingPage = queue[j];
 						progress.reportSkipped(
@@ -513,14 +494,12 @@ export class OneNoteImporter extends FormatImporter {
 						);
 					}
 
-					// Report progress as complete
 					progress.reportProgress(progressTotal, progressTotal);
 
 					return;
 				}
 			}
 
-			// report progress even if page import fails or is skipped
 			progress.reportProgress(++progressCurrent, progressTotal);
 		}
 	}
@@ -529,8 +508,7 @@ export class OneNoteImporter extends FormatImporter {
 			$select: 'id,title,createdDateTime,lastModifiedDateTime,level,order,contentUrl',
 			$orderby: 'order',
 			pagelevel: 'true',
-			// OneNote sends 20 pages at a time unless asked otherwise, and caps
-			// this at 100. A section of 500 is 5 requests rather than 25.
+			// Graph defaults to 20 pages and caps $top at 100.
 			$top: '100',
 		});
 
@@ -538,16 +516,7 @@ export class OneNoteImporter extends FormatImporter {
 		return (await this.fetchResource<OnenotePage>(url, 'json-wrapped', progress)).value ?? [];
 	}
 
-	/**
-	 * Start reading the page lists for whatever is selected, so that the wait
-	 * happens while the output and options steps are being filled in rather
-	 * than after Import is pressed. The import needs these lists regardless, so
-	 * nothing here is speculative work — only work moved earlier.
-	 *
-	 * One section at a time, because a notebook selected all at once would
-	 * otherwise open dozens of parallel requests at the API most likely to
-	 * throttle them. Failures are left for the import to hit and report.
-	 */
+	/** Read selected page lists serially while the remaining settings are completed. */
 	private prefetchSelectedPages(): void {
 		if (!this.signedIn) return;
 
@@ -555,7 +524,7 @@ export class OneNoteImporter extends FormatImporter {
 			if (this.sectionPages.has(section.id) || this.readingAhead.has(section.id)) continue;
 
 			const reading = this.readAheadQueue.then(async () => {
-				// Both may have changed while this waited its turn.
+				// Recheck after earlier queued reads finish.
 				if (this.sectionPages.has(section.id)) return;
 				if (!this.selectedSections.some(selected => selected.id === section.id)) return;
 
@@ -563,7 +532,7 @@ export class OneNoteImporter extends FormatImporter {
 					this.sectionPages.set(section.id, await this.fetchSectionPages(section.id));
 				}
 				catch {
-					// Left uncached, so the import asks again and reports it there.
+					// Let the import retry and report the failure.
 				}
 			});
 
@@ -572,14 +541,7 @@ export class OneNoteImporter extends FormatImporter {
 		}
 	}
 
-	/**
-	 * Every page in every chosen section, read before any of them is imported.
-	 *
-	 * The same requests either way — one page list per section — but having
-	 * them all is what lets the progress bar know the real total. Counting as
-	 * it went meant the bar filled up on the first section and then jumped
-	 * backwards each time another one was opened.
-	 */
+	/** Read every selected page list before importing so the total stays fixed. */
 	private async readSelectedPages(progress: ImportContext): Promise<OnenotePage[]> {
 		const queue: OnenotePage[] = [];
 
@@ -587,14 +549,10 @@ export class OneNoteImporter extends FormatImporter {
 		for (const [index, section] of sections.entries()) {
 			if (await progress.shouldStop()) break;
 
-			// Said for every section, not only the ones still to be read, so the
-			// count carries on climbing through the ones already read ahead.
 			progress.status(findingNotes(section.title, index, sections.length));
 
 			let pages = this.sectionPages.get(section.id);
 
-			// Waiting on this one rather than the whole read-ahead is what
-			// keeps the message above true while it waits.
 			if (!pages) {
 				await this.readingAhead.get(section.id);
 				pages = this.sectionPages.get(section.id);
@@ -613,13 +571,10 @@ export class OneNoteImporter extends FormatImporter {
 
 			if (!pages.length) continue;
 
-			// Sub-page paths are worked out from the pages either side of one
-			// within its section, so the section needs its whole list.
 			this.insertPagesToSection(pages, section.id);
 			queue.push(...pages);
 
-			// Let the remaining count climb as the sections come in, rather
-			// than sitting at nothing until the last one has been read.
+			// Grow the remaining total before importing.
 			progress.reportProgress(0, queue.length);
 		}
 
@@ -946,8 +901,6 @@ export class OneNoteImporter extends FormatImporter {
 		try {
 			const { path: outputPath, reuse } = await this.placeAttachment(filename, notePath);
 
-			// Deciding before downloading is the point: an attachment already
-			// brought across costs nothing on a second import.
 			if (reuse) {
 				progress.reportSkipped(filename, 'it is already in the vault');
 				return reuse.path;
@@ -957,7 +910,6 @@ export class OneNoteImporter extends FormatImporter {
 			await this.writeAttachment(outputPath, data);
 			progress.reportAttachmentSuccess(filename);
 
-			// Earn the speed back once it stops complaining.
 			this.throttleSpacingMs = Math.max(0, this.throttleSpacingMs - ATTACHMENT_SPACING_STEP_MS);
 			return outputPath;
 		}

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -41,6 +41,18 @@ function assertUnreachable(x: never): never {
 	throw new Error(`Didn't expect to get here`);
 }
 
+/**
+ * What to say while the sections are being counted. Both numbers are dropped
+ * when they would say nothing: how far through, and how much has been found.
+ */
+export function findingNotes(title: string, index: number, sections: number, found: number): string {
+	const detail: string[] = [];
+	if (sections > 1) detail.push(`section ${index + 1} of ${sections}`);
+	if (found > 0) detail.push(`${plural(found, 'note')} so far`);
+
+	return `Finding notes in ${title}${detail.length ? ` (${detail.join(', ')})` : ''}`;
+}
+
 function worthRetrying(status: number): boolean {
 	// OneNote sometimes returns transient bare 400s for page requests.
 	return status !== 403 && status !== 404;
@@ -574,11 +586,12 @@ export class OneNoteImporter extends FormatImporter {
 		for (const [index, section] of sections.entries()) {
 			if (await progress.shouldStop()) break;
 
+			// Said for every section, not only the ones still to be read, so the
+			// count carries on climbing through the ones already read ahead.
+			progress.status(findingNotes(section.title, index, sections.length, queue.length));
+
 			let pages = this.sectionPages.get(section.id);
 			if (!pages) {
-				const position = sections.length > 1 ? ` (section ${index + 1} of ${sections.length})` : '';
-				progress.status(`Finding notes in ${section.title}${position}`);
-
 				try {
 					pages = await this.fetchSectionPages(section.id, progress);
 				}

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -38,18 +38,14 @@ function assertUnreachable(x: never): never {
 }
 
 function worthRetrying(status: number): boolean {
-	// Names what will never change, not what might: OneNote answers page
-	// requests with bare 400s that usually clear on the second attempt.
+	// OneNote sometimes returns transient bare 400s for page requests.
 	return status !== 403 && status !== 404;
 }
 
 /**
- * A page whose own content defeated the conversion.
- *
- * Everything else that fails a page — the API refusing, a full disk, a vault
- * that will not take the write — fails identically for every page after it,
- * which is what the consecutive-failure stop is watching for. One
- * unconvertible page is not that.
+ * A failure caused by one page's content rather than the import environment.
+ * Only these are kept out of the consecutive-failure stop, which exists to
+ * catch whatever is about to fail every remaining page the same way.
  */
 class PageContentError extends Error {
 	constructor(cause: unknown) {
@@ -143,10 +139,6 @@ export class OneNoteImporter extends FormatImporter {
 		return accountType(this.app.loadLocalStorage(ACCOUNT_TYPE_STORAGE_KEY));
 	}
 
-	/**
-	 * What a sign-in established, as opposed to what to ask for by default.
-	 * Nothing having established it yet is a different thing from personal.
-	 */
 	private get knownAccountType(): MicrosoftAccountType | null {
 		const stored: unknown = this.app.loadLocalStorage(ACCOUNT_TYPE_STORAGE_KEY);
 		return stored === 'organization' || stored === 'personal' ? stored : null;
@@ -311,8 +303,6 @@ export class OneNoteImporter extends FormatImporter {
 			this.storeRefreshToken(tokenResponse.refresh_token);
 		}
 
-		// Remembering this is what lets the next sign-in ask for the wider
-		// access a work or school account needs, without anyone saying so.
 		const detected = accountTypeFromToken(tokenResponse.id_token ?? tokenResponse.access_token);
 		if (detected) this.microsoftAccountType = detected;
 
@@ -355,11 +345,8 @@ export class OneNoteImporter extends FormatImporter {
 			await this.picker.load(() => this.readNotebooks());
 		}
 		catch (e) {
-			// The other way to learn this, for when the token was unreadable.
-			// 40004 only means the token lacks the scopes, though, and a
-			// personal account cannot hold notes.read.all at all — escalating
-			// one would leave it unable to sign in, so a sign-in that already
-			// said personal wins.
+			// Personal accounts cannot consent to Notes.Read.All, so escalating
+			// one leaves it unable to sign in at all.
 			if (requestFailure(e).code === '40004' && this.knownAccountType !== 'personal') {
 				this.microsoftAccountType = 'organization';
 			}
@@ -514,9 +501,7 @@ export class OneNoteImporter extends FormatImporter {
 				if (!failure) {
 					consecutiveFailureCount = 0;
 				}
-				// A page its own content defeated leaves the count where it
-				// was; anything else is the failure every remaining page is
-				// about to hit.
+				// Page-specific failures do not indicate a broken import environment.
 				else if (!(failure instanceof PageContentError)) {
 					consecutiveFailureCount++;
 
@@ -801,17 +786,12 @@ export class OneNoteImporter extends FormatImporter {
 				object.parentNode?.insertBefore(object.firstChild, next);
 			}
 
-			// Name first: without one there is nothing to filter on, and an
-			// empty extension would fail the check below and be dropped in
-			// silence rather than reported.
 			const originalName = object.getAttribute('data-attachment');
 			if (!originalName) {
 				progress.reportFailed('OneNote attachment', 'the attachment did not say what it was called');
 				continue;
 			}
 
-			// Then the filter, so a file the user opted out of is passed over
-			// quietly rather than reported as a failure they did not ask for.
 			const extension = originalName.split('.').pop()?.toLowerCase() ?? '';
 			if (!ATTACHMENT_EXTS.contains(extension) && !this.importIncompatibleAttachments) {
 				continue;
@@ -838,8 +818,6 @@ export class OneNoteImporter extends FormatImporter {
 
 		for (let i = 0; i < images.length; i++) {
 			const image = images[i];
-			// OneNote does not always send these, and asserting them turns one
-			// odd image into a TypeError that costs the whole page.
 			const contentLocation = image.getAttribute('data-fullres-src');
 			if (!contentLocation) {
 				progress.reportFailed('OneNote image', 'the image did not include a download URL');
@@ -904,8 +882,6 @@ export class OneNoteImporter extends FormatImporter {
 		}
 	}
 
-	// Fetches an Microsoft Graph resource and automatically handles rate-limits/errors.
-	// `refreshed` records that this chain has already spent its one token refresh.
 	async fetchResource<T = string>(url: string, returnType: 'text', progress?: ImportContext, retryCount?: number, refreshed?: boolean): Promise<T>;
 	async fetchResource<T = ArrayBuffer>(url: string, returnType: 'file', progress?: ImportContext, retryCount?: number, refreshed?: boolean): Promise<T>;
 	async fetchResource<T>(url: string, returnType: 'json', progress?: ImportContext, retryCount?: number, refreshed?: boolean): Promise<T>;
@@ -969,9 +945,7 @@ export class OneNoteImporter extends FormatImporter {
 			}
 			else {
 				let err: PublicError | null = null;
-				// Graph does not always answer with JSON: an empty body, or an
-				// HTML page from a proxy. Throwing here would skip every branch
-				// below, throttling included.
+				// Graph error bodies may be empty or non-JSON.
 				const respJson: unknown = await response.json().catch(() => null);
 				if (respJson && typeof respJson === 'object' && 'error' in respJson) {
 					err = (respJson as { error: PublicError }).error;
@@ -985,8 +959,6 @@ export class OneNoteImporter extends FormatImporter {
 					|| err?.code === 'InvalidAuthenticationToken'
 					|| response.status === 401;
 				if (isNotAuthorized) {
-					// Refreshing is the whole remedy, so a 401 surviving it means
-					// the account may not read this. Say so rather than retry.
 					if (refreshed) throw new GraphRefusal(response.status, err);
 
 					await this.updateAccessToken();
@@ -995,9 +967,7 @@ export class OneNoteImporter extends FormatImporter {
 
 				// We're rate-limited - let's retry after the suggested amount of time
 				if (err?.code === '20166' || response.status === 429) {
-					// Waiting is right during an import; the limit lifts. The
-					// picker has nothing on screen that waiting helps, so it
-					// would just sit silent for a minute an attempt.
+					// Imports can wait; picker loads should fail visibly.
 					if (!progress) throw new GraphRefusal(429, err);
 
 					const retryAfter = response.headers.get('Retry-After');
@@ -1028,9 +998,7 @@ export class OneNoteImporter extends FormatImporter {
 					);
 				}
 
-				// 40004 is the sign-in not having been granted these notebooks,
-				// which no number of attempts changes, whatever status it came
-				// with. It is the failure behind issues #440 and #462.
+				// A scope refusal will not change on retry.
 				const settled = !worthRetrying(response.status) || err?.code === '40004';
 				if (settled || retryCount + 1 >= MAX_RETRY_ATTEMPTS) {
 					throw new GraphRefusal(response.status, err);

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -42,15 +42,13 @@ function assertUnreachable(x: never): never {
 }
 
 /**
- * What to say while the sections are being counted. Both numbers are dropped
- * when they would say nothing: how far through, and how much has been found.
+ * What to say while the sections are being counted. How many notes have turned
+ * up is left to the remaining count, which climbs alongside this.
  */
-export function findingNotes(title: string, index: number, sections: number, found: number): string {
-	const detail: string[] = [];
-	if (sections > 1) detail.push(`section ${index + 1} of ${sections}`);
-	if (found > 0) detail.push(`${plural(found, 'note')} so far`);
-
-	return `Finding notes in ${title}${detail.length ? ` (${detail.join(', ')})` : ''}`;
+export function findingNotes(title: string, index: number, sections: number): string {
+	return sections > 1
+		? `Finding notes in ${title} (section ${index + 1} of ${sections})`
+		: `Finding notes in ${title}`;
 }
 
 function worthRetrying(status: number): boolean {
@@ -591,7 +589,7 @@ export class OneNoteImporter extends FormatImporter {
 
 			// Said for every section, not only the ones still to be read, so the
 			// count carries on climbing through the ones already read ahead.
-			progress.status(findingNotes(section.title, index, sections.length, queue.length));
+			progress.status(findingNotes(section.title, index, sections.length));
 
 			let pages = this.sectionPages.get(section.id);
 

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -122,6 +122,15 @@ export class OneNoteImporter extends FormatImporter {
 		return accountType(this.app.loadLocalStorage(ACCOUNT_TYPE_STORAGE_KEY));
 	}
 
+	/**
+	 * What a sign-in established, as opposed to what to ask for by default.
+	 * Nothing having established it yet is a different thing from personal.
+	 */
+	private get knownAccountType(): MicrosoftAccountType | null {
+		const stored: unknown = this.app.loadLocalStorage(ACCOUNT_TYPE_STORAGE_KEY);
+		return stored === 'organization' || stored === 'personal' ? stored : null;
+	}
+
 	private set microsoftAccountType(value: MicrosoftAccountType) {
 		this.app.saveLocalStorage(ACCOUNT_TYPE_STORAGE_KEY, value);
 	}
@@ -328,12 +337,16 @@ export class OneNoteImporter extends FormatImporter {
 			await this.picker.load(() => this.readNotebooks());
 		}
 		catch (e) {
-			// Being refused the notebooks is itself the answer: only a work or
-			// school account is told 40004, and the remedy is to ask for the
-			// wider access next time. Remembering it here is what makes the
-			// message's 'sign in again' true, and unlike reading the token it
-			// does not depend on Microsoft handing us anything readable.
-			if (requestFailure(e).code === '40004') this.microsoftAccountType = 'organization';
+			// Being refused the notebooks is the other way to learn this, and
+			// unlike reading the token it does not depend on Microsoft handing
+			// us anything readable. But 40004 is documented only as the token
+			// lacking the scopes, not as something a work account alone is
+			// told, and notes.read.all cannot be granted to a personal account
+			// at all — so escalating one would leave it unable to sign in.
+			// A sign-in that already said personal is therefore believed.
+			if (requestFailure(e).code === '40004' && this.knownAccountType !== 'personal') {
+				this.microsoftAccountType = 'organization';
+			}
 
 			console.error('An error occurred while fetching your OneNote data: ', e);
 		}

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -37,7 +37,11 @@ function assertUnreachable(x: never): never {
 }
 
 function worthRetrying(status: number): boolean {
-	return status === 408 || status === 429 || status >= 500;
+	// Only a decision is worth failing fast on. OneNote answers a page request
+	// with a bare 400 often enough that PR #388 added a retry for it on
+	// purpose, and it usually succeeds on the second attempt — so the list is
+	// of what will never change, not of what might.
+	return status !== 403 && status !== 404;
 }
 
 class GraphRefusal extends Error {
@@ -854,12 +858,13 @@ export class OneNoteImporter extends FormatImporter {
 		}
 	}
 
-	// Fetches an Microsoft Graph resource and automatically handles rate-limits/errors
-	async fetchResource<T = string>(url: string, returnType: 'text', progress?: ImportContext, retryCount?: number): Promise<T>;
-	async fetchResource<T = ArrayBuffer>(url: string, returnType: 'file', progress?: ImportContext, retryCount?: number): Promise<T>;
-	async fetchResource<T>(url: string, returnType: 'json', progress?: ImportContext, retryCount?: number): Promise<T>;
-	async fetchResource<T>(url: string, returnType: 'json-wrapped', progress?: ImportContext, retryCount?: number): Promise<JSONWrappedResponse<T>>;
-	async fetchResource<T>(url: string, returnType: 'text' | 'file' | 'json' | 'json-wrapped', progress?: ImportContext, retryCount: number = 0): Promise<string | ArrayBuffer | object | JSONWrappedResponse<T>> {
+	// Fetches an Microsoft Graph resource and automatically handles rate-limits/errors.
+	// `refreshed` records that this chain has already spent its one token refresh.
+	async fetchResource<T = string>(url: string, returnType: 'text', progress?: ImportContext, retryCount?: number, refreshed?: boolean): Promise<T>;
+	async fetchResource<T = ArrayBuffer>(url: string, returnType: 'file', progress?: ImportContext, retryCount?: number, refreshed?: boolean): Promise<T>;
+	async fetchResource<T>(url: string, returnType: 'json', progress?: ImportContext, retryCount?: number, refreshed?: boolean): Promise<T>;
+	async fetchResource<T>(url: string, returnType: 'json-wrapped', progress?: ImportContext, retryCount?: number, refreshed?: boolean): Promise<JSONWrappedResponse<T>>;
+	async fetchResource<T>(url: string, returnType: 'text' | 'file' | 'json' | 'json-wrapped', progress?: ImportContext, retryCount: number = 0, refreshed: boolean = false): Promise<string | ArrayBuffer | object | JSONWrappedResponse<T>> {
 		// Check if we need to reject early WITHOUT retrying, outside the
 		// try/catch block
 		if (retryCount >= MAX_RETRY_ATTEMPTS) {
@@ -918,9 +923,13 @@ export class OneNoteImporter extends FormatImporter {
 			}
 			else {
 				let err: PublicError | null = null;
-				const respJson = await response.json();
-				if (Object.prototype.hasOwnProperty.call(respJson, 'error')) {
-					err = respJson.error;
+				// Graph does not always answer with JSON — an empty body, or an
+				// HTML page from a proxy in front of it, used to reject here and
+				// fall through to the network retry, taking the throttling
+				// branch below with it.
+				const respJson: unknown = await response.json().catch(() => null);
+				if (respJson && typeof respJson === 'object' && 'error' in respJson) {
+					err = (respJson as { error: PublicError }).error;
 				}
 				console.error('An error has occurred while fetching an resource:', err ? err : respJson);
 
@@ -931,12 +940,26 @@ export class OneNoteImporter extends FormatImporter {
 					|| err?.code === 'InvalidAuthenticationToken'
 					|| response.status === 401;
 				if (isNotAuthorized) {
+					// Refreshing is the whole remedy, so a 401 that survives it
+					// is the account not being allowed to read this. Retrying
+					// four more times only replaces what Graph said with
+					// 'Exceeded maximum retry attempts'.
+					if (refreshed) throw new GraphRefusal(response.status, err);
+
 					await this.updateAccessToken();
-					return this.fetchResource(url, returnType as any, progress, retryCount + 1);
+					return this.fetchResource(url, returnType as any, progress, retryCount + 1, true);
 				}
 
 				// We're rate-limited - let's retry after the suggested amount of time
 				if (err?.code === '20166' || response.status === 429) {
+					// Waiting is right during an import: the user asked for the
+					// whole notebook and the limit lifts. While the picker is
+					// loading there is nothing on screen that waiting helps, so
+					// it just sits silently for a minute an attempt — which is
+					// what issue #390 reports. Say so and let them press
+					// Refresh.
+					if (!progress) throw new GraphRefusal(429, err);
+
 					const retryAfter = response.headers.get('Retry-After');
 					// If we're rate-limited, the soonest we'll be able to make
 					// the request again is the next minute, so wait either as
@@ -960,15 +983,20 @@ export class OneNoteImporter extends FormatImporter {
 						// don't increment the retryCount because we were told
 						// to backoff, and we should infinitely retry on backoff
 						// errors.
-						retryCount
+						retryCount,
+						refreshed
 					);
 				}
 
-				if (!worthRetrying(response.status) || retryCount + 1 >= MAX_RETRY_ATTEMPTS) {
+				// 40004 is the sign-in not having been granted these notebooks,
+				// which no number of attempts changes, whatever status it came
+				// with. It is the failure behind issues #440 and #462.
+				const settled = !worthRetrying(response.status) || err?.code === '40004';
+				if (settled || retryCount + 1 >= MAX_RETRY_ATTEMPTS) {
 					throw new GraphRefusal(response.status, err);
 				}
 
-				return this.fetchResource(url, returnType as any, progress, retryCount + 1);
+				return this.fetchResource(url, returnType as any, progress, retryCount + 1, refreshed);
 			}
 		}
 		catch (e) {
@@ -985,7 +1013,7 @@ export class OneNoteImporter extends FormatImporter {
 			// well.
 			if (retryCount + 1 >= MAX_RETRY_ATTEMPTS) throw e;
 
-			return this.fetchResource(url, returnType as any, progress, retryCount + 1);
+			return this.fetchResource(url, returnType as any, progress, retryCount + 1, refreshed);
 		}
 	}
 }

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -34,6 +34,18 @@ function assertUnreachable(x: never): never {
 	throw new Error(`Didn't expect to get here`);
 }
 
+function worthRetrying(status: number): boolean {
+	return status === 408 || status === 429 || status >= 500;
+}
+
+/** An error carrying what Graph said, for whoever has to describe it. */
+function graphError(status: number, err: PublicError | null): Error {
+	return Object.assign(
+		new Error(err?.message || `OneNote returned ${status}`),
+		{ status, code: err?.code ?? undefined },
+	);
+}
+
 function assertJSONWrappedResponse<T>(res: unknown): asserts res is JSONWrappedResponse<T> {
 	if (res == null) {
 		throw new Error(`response is nullish`);
@@ -915,7 +927,10 @@ export class OneNoteImporter extends FormatImporter {
 					);
 				}
 
-				// for all other errors, retry.
+				if (!worthRetrying(response.status) || retryCount + 1 >= MAX_RETRY_ATTEMPTS) {
+					throw graphError(response.status, err);
+				}
+
 				return this.fetchResource(url, returnType as any, progress, retryCount + 1);
 			}
 		}
@@ -929,6 +944,8 @@ export class OneNoteImporter extends FormatImporter {
 			// I'm seeing such failures in normal imports where I'm not noticing
 			// any network instability on my end, let's retry those failures as
 			// well.
+			if (retryCount + 1 >= MAX_RETRY_ATTEMPTS) throw e;
+
 			return this.fetchResource(url, returnType as any, progress, retryCount + 1);
 		}
 	}

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -146,7 +146,10 @@ export class OneNoteImporter extends FormatImporter {
 	private throttleSpacingMs = 0;
 	/** Page lists read ahead of the import, by section id. */
 	private readonly sectionPages = new Map<string, OnenotePage[]>();
-	private prefetching: Promise<void> = Promise.resolve();
+	/** Read-aheads still in flight, so an import can wait on one at a time. */
+	private readonly readingAhead = new Map<string, Promise<void>>();
+	/** Keeps those read-aheads to one request at a time. */
+	private readAheadQueue: Promise<void> = Promise.resolve();
 	refreshToken?: string;
 	lastSuccessfulFetchTime: number = performance.now();
 
@@ -551,9 +554,9 @@ export class OneNoteImporter extends FormatImporter {
 		if (!this.signedIn) return;
 
 		for (const section of this.selectedSections) {
-			if (this.sectionPages.has(section.id)) continue;
+			if (this.sectionPages.has(section.id) || this.readingAhead.has(section.id)) continue;
 
-			this.prefetching = this.prefetching.then(async () => {
+			const reading = this.readAheadQueue.then(async () => {
 				// Both may have changed while this waited its turn.
 				if (this.sectionPages.has(section.id)) return;
 				if (!this.selectedSections.some(selected => selected.id === section.id)) return;
@@ -565,6 +568,9 @@ export class OneNoteImporter extends FormatImporter {
 					// Left uncached, so the import asks again and reports it there.
 				}
 			});
+
+			this.readAheadQueue = reading;
+			this.readingAhead.set(section.id, reading.finally(() => this.readingAhead.delete(section.id)));
 		}
 	}
 
@@ -579,9 +585,6 @@ export class OneNoteImporter extends FormatImporter {
 	private async readSelectedPages(progress: ImportContext): Promise<OnenotePage[]> {
 		const queue: OnenotePage[] = [];
 
-		// Anything still being read ahead is about to be needed.
-		await this.prefetching;
-
 		const sections = this.selectedSections;
 		for (const [index, section] of sections.entries()) {
 			if (await progress.shouldStop()) break;
@@ -591,6 +594,14 @@ export class OneNoteImporter extends FormatImporter {
 			progress.status(findingNotes(section.title, index, sections.length, queue.length));
 
 			let pages = this.sectionPages.get(section.id);
+
+			// Waiting on this one rather than the whole read-ahead is what
+			// keeps the message above true while it waits.
+			if (!pages) {
+				await this.readingAhead.get(section.id);
+				pages = this.sectionPages.get(section.id);
+			}
+
 			if (!pages) {
 				try {
 					pages = await this.fetchSectionPages(section.id, progress);
@@ -608,6 +619,10 @@ export class OneNoteImporter extends FormatImporter {
 			// within its section, so the section needs its whole list.
 			this.insertPagesToSection(pages, section.id);
 			queue.push(...pages);
+
+			// Let the remaining count climb as the sections come in, rather
+			// than sitting at nothing until the last one has been read.
+			progress.reportProgress(0, queue.length);
 		}
 
 		return queue;

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -9,7 +9,8 @@ import { ImportContext } from '../import-context';
 import { AccessTokenResponse } from './onenote/models';
 import { convertPageTags, pageToMarkdown } from './onenote/convert';
 import { describeNotebookFailure } from './onenote/errors';
-import { accountType, authorizationUrl, graphScopes, tokenUrl } from './onenote/auth';
+import { requestFailure } from '../request-failure';
+import { accountType, accountTypeFromToken, authorizationUrl, graphScopes, tokenUrl } from './onenote/auth';
 import type { MicrosoftAccountType } from './onenote/auth';
 import { inkmlToSvg } from './onenote/inkml';
 
@@ -153,18 +154,6 @@ export class OneNoteImporter extends FormatImporter {
 
 		this.accountSetting = new Setting(contentEl)
 			.setName('Microsoft account')
-			.addDropdown(dropdown => dropdown
-				.addOption('personal', 'Personal')
-				.addOption('organization', 'Work or school')
-				.setValue(this.microsoftAccountType)
-				.onChange(value => {
-					const selected = accountType(value);
-					if (selected === this.microsoftAccountType) return;
-
-					if (this.signedIn) this.signOut();
-					this.microsoftAccountType = selected;
-					this.showSignedOut();
-				}))
 			.addButton((button) => {
 				this.accountButton = button;
 				button.onClick(() => {
@@ -214,8 +203,11 @@ export class OneNoteImporter extends FormatImporter {
 	}
 
 	private showSignedOut() {
-		const account = this.microsoftAccountType === 'organization' ? 'work or school' : 'personal';
-		this.accountSetting.setDesc(`Sign in with a ${account} Microsoft account to import your OneNote notebooks.`);
+		this.accountSetting.setDesc(this.microsoftAccountType === 'organization'
+			// Only said once we know, which is after a first sign-in: the extra
+			// access is what a work or school tenant may want approving.
+			? 'Sign in to import your OneNote notebooks. A work or school account may need your organization to approve access.'
+			: 'Sign in to import your OneNote notebooks.');
 		this.accountButton.setButtonText('Sign in').setCta();
 		this.accountButton.buttonEl.removeClass('mod-destructive');
 	}
@@ -291,6 +283,12 @@ export class OneNoteImporter extends FormatImporter {
 			this.storeRefreshToken(tokenResponse.refresh_token);
 		}
 
+		// The token says which kind of account signed in. Remembering it is
+		// what lets the next sign-in ask for the access a work or school
+		// account needs, without anyone having had to say so up front.
+		const detected = accountTypeFromToken(tokenResponse.id_token ?? tokenResponse.access_token);
+		if (detected) this.microsoftAccountType = detected;
+
 		this.graphData.accessToken = tokenResponse.access_token;
 		this.sourceChanged();
 	}
@@ -330,6 +328,13 @@ export class OneNoteImporter extends FormatImporter {
 			await this.picker.load(() => this.readNotebooks());
 		}
 		catch (e) {
+			// Being refused the notebooks is itself the answer: only a work or
+			// school account is told 40004, and the remedy is to ask for the
+			// wider access next time. Remembering it here is what makes the
+			// message's 'sign in again' true, and unlike reading the token it
+			// does not depend on Microsoft handing us anything readable.
+			if (requestFailure(e).code === '40004') this.microsoftAccountType = 'organization';
+
 			console.error('An error occurred while fetching your OneNote data: ', e);
 		}
 	}

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -13,7 +13,7 @@ import { requestFailure } from '../request-failure';
 import { accountTypeFromToken, authorizationUrl, graphScopes, storedAccountType, TOKEN_URL } from './onenote/auth';
 import type { MicrosoftAccountType } from './onenote/auth';
 import { inkmlToSvg } from './onenote/inkml';
-import { splitext } from '../filesystem';
+import { parseFilePath, splitext } from '../filesystem';
 import { extensionForMime } from '../mime';
 
 const ACCOUNT_SECRET_ID = 'onenote-importer';
@@ -38,7 +38,21 @@ type JSONWrappedResponse<T> = {
 	value: T[];
 };
 
-type ResourceType = 'text' | 'file' | 'json' | 'json-wrapped';
+type ResourceType = 'text' | 'file' | 'json' | 'json-wrapped' | 'range';
+
+type FetchedResource<T> = string | ArrayBuffer | object | JSONWrappedResponse<T> | number | null;
+
+/**
+ * The length a partial response reports, which the whole attachment has. A
+ * response that is not partial ignored the range and sent everything, and says
+ * so by answering with nothing.
+ */
+function totalFromContentRange(response: Response): number | null {
+	if (response.status !== 206) return null;
+
+	const total = /\/(\d+)\s*$/.exec(response.headers.get('Content-Range') ?? '')?.[1];
+	return total ? Number(total) : null;
+}
 
 function assertUnreachable(x: never): never {
 	throw new Error(`Didn't expect to get here`);
@@ -135,6 +149,8 @@ export class OneNoteImporter extends FormatImporter {
 	private readAheadQueue: Promise<void> = Promise.resolve();
 	/** Bumped to disown reads that were started against an earlier listing. */
 	private pagesGeneration = 0;
+	/** Cleared by the first response that ignores a range, so the rest go straight to the download. */
+	private sizeProbeAnswered = true;
 	refreshToken?: string;
 	lastSuccessfulFetchTime: number = performance.now();
 
@@ -631,7 +647,10 @@ export class OneNoteImporter extends FormatImporter {
 			const svgContent = inkmlToSvg(splitContent.inkml);
 			if (svgContent) {
 				const svgFilename = `${page.title} - Ink.svg`;
-				const { path: svgPath, reuse } = await this.placeAttachment(svgFilename, notePath);
+				// The drawing was built here, so what is on disk can be compared
+				// against it outright rather than guessed at from its name.
+				const { path: svgPath, reuse } = await this.placeAttachment(svgFilename, notePath,
+					async existing => await this.vault.read(existing) === svgContent ? 'same' : 'another');
 
 				if (reuse) {
 					inkEmbedMarkdown = `\n\n![[${reuse.path}]]\n`;
@@ -859,8 +878,9 @@ export class OneNoteImporter extends FormatImporter {
 			}
 
 			const extension = extensionForMime(image.getAttribute('data-fullres-src-type') ?? '') || 'png';
-			const currentDate = moment().format('YYYYMMDDHHmmss');
-			const fileName: string = `Exported image ${currentDate}-${i}.${extension}`;
+			// Named after the note rather than the moment of import: a name that
+			// changes every second can never match what the last import wrote.
+			const fileName = `${parseFilePath(notePath).basename} image ${i + 1}.${extension}`;
 			const outputPath = await this.fetchAttachment(progress, fileName, contentLocation, notePath);
 			if (outputPath) {
 				image.src = encodeURI(outputPath);
@@ -891,9 +911,41 @@ export class OneNoteImporter extends FormatImporter {
 		return pageElement;
 	}
 
+	/**
+	 * How big the attachment is, without fetching it. OneNote gives no size in
+	 * the page HTML, and a name alone cannot say whether the file already at it
+	 * is this attachment, so the size is asked for and compared.
+	 */
+	private async attachmentSize(contentLocation: string, progress: ImportContext): Promise<number | null> {
+		if (!this.sizeProbeAnswered) return null;
+
+		try {
+			const range = await this.fetchResource(contentLocation, 'range', progress);
+			// A response that ignored the range downloaded the whole attachment,
+			// which is what asking first set out to avoid. One is enough to learn.
+			if (range === null) this.sizeProbeAnswered = false;
+			return range;
+		}
+		catch {
+			// Nothing is known about the attachment; treat it as unrecognised.
+			return null;
+		}
+	}
+
 	async fetchAttachment(progress: ImportContext, filename: string, contentLocation: string, notePath: string): Promise<string | null> {
 		try {
-			const { path: outputPath, reuse } = await this.placeAttachment(filename, notePath);
+			// However many names it has to pass over, the size is asked for once.
+			let size: number | null;
+			let asked = false;
+
+			const { path: outputPath, reuse } = await this.placeAttachment(filename, notePath, async existing => {
+				if (!asked) {
+					size = await this.attachmentSize(contentLocation, progress);
+					asked = true;
+				}
+
+				return size !== null && size === existing.stat.size ? 'same' : 'another';
+			});
 
 			if (reuse) {
 				progress.reportSkipped(filename, 'it is already in the vault');
@@ -925,12 +977,13 @@ export class OneNoteImporter extends FormatImporter {
 	async fetchResource<T = ArrayBuffer>(url: string, returnType: 'file', progress?: ImportContext): Promise<T>;
 	async fetchResource<T>(url: string, returnType: 'json', progress?: ImportContext): Promise<T>;
 	async fetchResource<T>(url: string, returnType: 'json-wrapped', progress?: ImportContext): Promise<JSONWrappedResponse<T>>;
-	async fetchResource<T>(url: string, returnType: ResourceType, progress?: ImportContext): Promise<string | ArrayBuffer | object | JSONWrappedResponse<T>> {
+	async fetchResource(url: string, returnType: 'range', progress?: ImportContext): Promise<number | null>;
+	async fetchResource<T>(url: string, returnType: ResourceType, progress?: ImportContext): Promise<FetchedResource<T>> {
 		return this.fetchWithRetry<T>(url, returnType, progress, 0, false);
 	}
 
 	/** `retryCount` and `refreshed` are what one attempt hands the next. */
-	private async fetchWithRetry<T>(url: string, returnType: ResourceType, progress: ImportContext | undefined, retryCount: number, refreshed: boolean): Promise<string | ArrayBuffer | object | JSONWrappedResponse<T>> {
+	private async fetchWithRetry<T>(url: string, returnType: ResourceType, progress: ImportContext | undefined, retryCount: number, refreshed: boolean): Promise<FetchedResource<T>> {
 		// Check if we need to reject early WITHOUT retrying, outside the
 		// try/catch block
 		if (retryCount >= MAX_RETRY_ATTEMPTS) {
@@ -955,15 +1008,23 @@ export class OneNoteImporter extends FormatImporter {
 			let response = await fetch(
 				url,
 				{
-					headers: { Authorization: `Bearer ${this.graphData.accessToken}` },
+					headers: {
+						Authorization: `Bearer ${this.graphData.accessToken}`,
+						// Asking for the first byte is a GET, which a resource
+						// URL allows where it may refuse a HEAD.
+						...(returnType === 'range' ? { Range: 'bytes=0-0' } : {}),
+					},
 					signal: this.host.abortController.signal,
 				}
 			);
 
 			if (response.ok) {
-				let result: string | ArrayBuffer | object | JSONWrappedResponse<T>;
+				let result: FetchedResource<T>;
 
 				switch (returnType) {
+					case 'range':
+						result = totalFromContentRange(response);
+						break;
 					case 'text':
 						result = await response.text();
 						break;

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -648,10 +648,16 @@ export class OneNoteImporter extends FormatImporter {
 			const svgContent = inkmlToSvg(splitContent.inkml);
 			if (svgContent) {
 				const svgFilename = `${page.title} - Ink.svg`;
-				const svgPath = await this.getAvailablePathForAttachment(svgFilename, [], notePath);
-				await this.vault.create(svgPath, svgContent);
-				inkEmbedMarkdown = `\n\n![[${svgPath}]]\n`;
-				progress.reportAttachmentSuccess(svgFilename);
+				const { path: svgPath, reuse } = await this.placeAttachment(svgFilename, notePath);
+
+				if (reuse) {
+					inkEmbedMarkdown = `\n\n![[${reuse.path}]]\n`;
+				}
+				else {
+					await this.writeAttachment(svgPath, svgContent);
+					inkEmbedMarkdown = `\n\n![[${svgPath}]]\n`;
+					progress.reportAttachmentSuccess(svgFilename);
+				}
 			}
 		}
 		catch (e) {
@@ -912,10 +918,17 @@ export class OneNoteImporter extends FormatImporter {
 		progress.status('Downloading attachment ' + filename);
 
 		try {
-			// We don't need to remember claimedPaths because we're writing the attachments immediately.
-			const outputPath = await this.getAvailablePathForAttachment(filename, [], notePath);
+			const { path: outputPath, reuse } = await this.placeAttachment(filename, notePath);
+
+			// Deciding before downloading is the point: an attachment already
+			// brought across costs nothing on a second import.
+			if (reuse) {
+				progress.reportSkipped(filename, 'it is already in the vault');
+				return reuse.path;
+			}
+
 			const data = (await this.fetchResource(contentLocation, 'file', progress));
-			await this.app.vault.createBinary(outputPath, data);
+			await this.writeAttachment(outputPath, data);
 			progress.reportAttachmentSuccess(filename);
 
 			// Earn the speed back once it stops complaining.

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -38,12 +38,15 @@ function worthRetrying(status: number): boolean {
 	return status === 408 || status === 429 || status >= 500;
 }
 
-/** An error carrying what Graph said, for whoever has to describe it. */
-function graphError(status: number, err: PublicError | null): Error {
-	return Object.assign(
-		new Error(err?.message || `OneNote returned ${status}`),
-		{ status, code: err?.code ?? undefined },
-	);
+class GraphRefusal extends Error {
+	readonly status: number;
+	readonly code?: string;
+
+	constructor(status: number, err: PublicError | null) {
+		super(err?.message || `OneNote returned ${status}`);
+		this.status = status;
+		this.code = err?.code ?? undefined;
+	}
 }
 
 function assertJSONWrappedResponse<T>(res: unknown): asserts res is JSONWrappedResponse<T> {
@@ -928,13 +931,15 @@ export class OneNoteImporter extends FormatImporter {
 				}
 
 				if (!worthRetrying(response.status) || retryCount + 1 >= MAX_RETRY_ATTEMPTS) {
-					throw graphError(response.status, err);
+					throw new GraphRefusal(response.status, err);
 				}
 
 				return this.fetchResource(url, returnType as any, progress, retryCount + 1);
 			}
 		}
 		catch (e) {
+			if (e instanceof GraphRefusal) throw e;
+
 			console.error(`An internal error occurred while trying to fetch '${url}'. Error details: `, e);
 
 			// Attachments sometimes just fail to download

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -38,20 +38,39 @@ type JSONWrappedResponse<T> = {
 	value: T[];
 };
 
-type ResourceType = 'text' | 'file' | 'json' | 'json-wrapped' | 'range';
+type ResourceType = 'text' | 'file' | 'json' | 'json-wrapped';
 
-type FetchedResource<T> = string | ArrayBuffer | object | JSONWrappedResponse<T> | number | null;
+type FetchedResource<T> = string | ArrayBuffer | object | JSONWrappedResponse<T>;
 
-/**
- * The length a partial response reports, which the whole attachment has. A
- * response that is not partial ignored the range and sent everything, and says
- * so by answering with nothing.
- */
-function totalFromContentRange(response: Response): number | null {
-	if (response.status !== 206) return null;
+function resourceId(contentLocation: string): string {
+	try {
+		const parts = new URL(contentLocation).pathname.split('/');
+		const resources = parts.lastIndexOf('resources');
+		return resources >= 0 && parts[resources + 1]
+			? decodeURIComponent(parts[resources + 1])
+			: contentLocation;
+	}
+	catch {
+		return contentLocation;
+	}
+}
 
-	const total = /\/(\d+)\s*$/.exec(response.headers.get('Content-Range') ?? '')?.[1];
-	return total ? Number(total) : null;
+async function resourceKey(contentLocation: string): Promise<string> {
+	const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(resourceId(contentLocation)));
+	return Array.from(new Uint8Array(digest).slice(0, 8), byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+async function resourceFilename(filename: string, contentLocation: string): Promise<string> {
+	const { basename, extension } = parseFilePath(filename);
+	return `${basename} ${await resourceKey(contentLocation)}${extension ? `.${extension}` : ''}`;
+}
+
+function sameBytes(left: ArrayBuffer, right: ArrayBuffer): boolean {
+	if (left.byteLength !== right.byteLength) return false;
+
+	const a = new Uint8Array(left);
+	const b = new Uint8Array(right);
+	return a.every((byte, index) => byte === b[index]);
 }
 
 function assertUnreachable(x: never): never {
@@ -149,8 +168,9 @@ export class OneNoteImporter extends FormatImporter {
 	private readAheadQueue: Promise<void> = Promise.resolve();
 	/** Bumped to disown reads that were started against an earlier listing. */
 	private pagesGeneration = 0;
-	/** Cleared by the first response that ignores a range, so the rest go straight to the download. */
-	private sizeProbeAnswered = true;
+	private nextAccountType: MicrosoftAccountType | null = null;
+	private authenticatingAccountType: MicrosoftAccountType | null = null;
+	private storedTokenFailed = false;
 	refreshToken?: string;
 	lastSuccessfulFetchTime: number = performance.now();
 
@@ -216,7 +236,14 @@ export class OneNoteImporter extends FormatImporter {
 			await this.updateAccessToken();
 			return true;
 		}
-		catch {
+		catch (error) {
+			this.storedTokenFailed = true;
+			const { status, code } = requestFailure(error);
+			if (status === 400 || status === 401 || code === 'invalid_grant') {
+				this.clearStoredRefreshToken();
+				this.refreshToken = undefined;
+				this.microsoftAccountType = null;
+			}
 			return false;
 		}
 	}
@@ -232,6 +259,7 @@ export class OneNoteImporter extends FormatImporter {
 			await this.showSectionPickerUI();
 		}
 		catch (e) {
+			this.authenticatingAccountType = null;
 			console.error('An error occurred while we were trying to sign you in. Error details: ', e);
 			this.host.sourceEl?.createDiv({ text: 'An error occurred while trying to sign you in.' })
 				.createEl('details', { text: String(e) })
@@ -258,9 +286,14 @@ export class OneNoteImporter extends FormatImporter {
 	private signIn() {
 		this.registerAuthCallback(data => void this.authenticateUser(data)
 			.catch(e => console.error('Could not complete sign in', e)));
+		this.authenticatingAccountType = this.nextAccountType
+			?? (this.storedTokenFailed ? 'personal' : this.microsoftAccountType)
+			?? 'personal';
+		this.nextAccountType = null;
+		this.storedTokenFailed = false;
 
 		window.open(authorizationUrl(
-			this.microsoftAccountType ?? 'personal',
+			this.authenticatingAccountType,
 			GRAPH_CLIENT_ID,
 			AUTH_REDIRECT_URI,
 			this.graphData.state,
@@ -272,6 +305,8 @@ export class OneNoteImporter extends FormatImporter {
 
 		this.graphData.accessToken = '';
 		this.refreshToken = undefined;
+		this.authenticatingAccountType = null;
+		this.storedTokenFailed = false;
 
 		// Whoever signs in next is not necessarily who these belong to, and
 		// asking a personal account for the scopes an organization needs is
@@ -293,7 +328,9 @@ export class OneNoteImporter extends FormatImporter {
 		// used if this import takes a long time, or for future imports.
 		const requestBody = new URLSearchParams({
 			client_id: GRAPH_CLIENT_ID,
-			scope: 'offline_access ' + graphScopes(this.microsoftAccountType ?? 'personal').join(' '),
+			scope: 'offline_access ' + graphScopes(
+				code ? this.authenticatingAccountType ?? 'personal' : this.microsoftAccountType ?? 'personal'
+			).join(' '),
 			redirect_uri: AUTH_REDIRECT_URI,
 		});
 		if (code) {
@@ -326,6 +363,7 @@ export class OneNoteImporter extends FormatImporter {
 
 		const detected = accountTypeFromToken(tokenResponse.id_token ?? tokenResponse.access_token);
 		if (detected) this.microsoftAccountType = detected;
+		this.authenticatingAccountType = null;
 
 		this.graphData.accessToken = tokenResponse.access_token;
 		this.sourceChanged();
@@ -379,7 +417,7 @@ export class OneNoteImporter extends FormatImporter {
 			// Personal accounts cannot consent to Notes.Read.All, so escalating
 			// one leaves it unable to sign in at all.
 			if (requestFailure(e).code === SCOPE_REFUSED && this.microsoftAccountType !== 'personal') {
-				this.microsoftAccountType = 'organization';
+				this.nextAccountType = 'organization';
 			}
 
 			console.error('An error occurred while fetching your OneNote data: ', e);
@@ -628,6 +666,8 @@ export class OneNoteImporter extends FormatImporter {
 
 	async processFile(progress: ImportContext, content: string, page: OnenotePage) {
 		const splitContent = PageContentError.wrapping(() => this.convertFormat(content));
+		const lastModified = page.lastModifiedDateTime ? Date.parse(page.lastModifiedDateTime) : null;
+		const created = page.createdDateTime ? Date.parse(page.createdDateTime) : null;
 		const outputFolder = await this.getOutputFolder();
 		const outputPath = this.getEntityPathNoParent(page.id!, outputFolder!.name)!;
 
@@ -667,13 +707,12 @@ export class OneNoteImporter extends FormatImporter {
 			progress.reportFailed(`${page.title} - Ink.svg`, e);
 		}
 
-		const html = await this.getAllAttachments(progress, convertPageTags(splitContent.html), notePath);
+		const html = await this.getAllAttachments(
+			progress, convertPageTags(splitContent.html), notePath, lastModified ?? undefined);
 		let mdContent = PageContentError.wrapping(() => pageToMarkdown(html));
 
 		if (inkEmbedMarkdown) mdContent += inkEmbedMarkdown;
 
-		const lastModified = page?.lastModifiedDateTime ? Date.parse(page.lastModifiedDateTime) : null;
-		const created = page?.createdDateTime ? Date.parse(page.createdDateTime) : null;
 		const writeOptions: DataWriteOptions = {
 			ctime: created ?? lastModified ?? Date.now(),
 			mtime: lastModified ?? created ?? Date.now(),
@@ -827,7 +866,9 @@ export class OneNoteImporter extends FormatImporter {
 	}
 
 	// Download all attachments and add embedding syntax for supported file formats.
-	async getAllAttachments(progress: ImportContext, pageHTML: string, notePath: string): Promise<HTMLElement> {
+	async getAllAttachments(
+		progress: ImportContext, pageHTML: string, notePath: string, sourceMtime?: number
+	): Promise<HTMLElement> {
 		const pageElement = parseHTML(pageHTML.replace(SELF_CLOSING_REGEX, '<$1$2></$1>'));
 
 		const objects: HTMLElement[] = pageElement.findAll('object');
@@ -858,7 +899,8 @@ export class OneNoteImporter extends FormatImporter {
 				continue;
 			}
 
-			const filename = await this.fetchAttachment(progress, originalName, contentLocation, notePath);
+			const filename = await this.fetchAttachment(
+				progress, originalName, contentLocation, notePath, sourceMtime);
 			if (!filename) continue;
 
 			// Create a new <p> element with the Markdown-style link
@@ -878,10 +920,9 @@ export class OneNoteImporter extends FormatImporter {
 			}
 
 			const extension = extensionForMime(image.getAttribute('data-fullres-src-type') ?? '') || 'png';
-			// Named after the note rather than the moment of import: a name that
-			// changes every second can never match what the last import wrote.
-			const fileName = `${parseFilePath(notePath).basename} image ${i + 1}.${extension}`;
-			const outputPath = await this.fetchAttachment(progress, fileName, contentLocation, notePath);
+			const fileName = `${parseFilePath(notePath).basename} image.${extension}`;
+			const outputPath = await this.fetchAttachment(
+				progress, fileName, contentLocation, notePath, sourceMtime);
 			if (outputPath) {
 				image.src = encodeURI(outputPath);
 				if (!image.alt || BASE64_REGEX.test(image.alt)) {
@@ -911,40 +952,36 @@ export class OneNoteImporter extends FormatImporter {
 		return pageElement;
 	}
 
-	/**
-	 * How big the attachment is, without fetching it. OneNote gives no size in
-	 * the page HTML, and a name alone cannot say whether the file already at it
-	 * is this attachment, so the size is asked for and compared.
-	 */
-	private async attachmentSize(contentLocation: string, progress: ImportContext): Promise<number | null> {
-		if (!this.sizeProbeAnswered) return null;
-
+	async fetchAttachment(
+		progress: ImportContext,
+		filename: string,
+		contentLocation: string,
+		notePath: string,
+		sourceMtime?: number,
+	): Promise<string | null> {
 		try {
-			const range = await this.fetchResource(contentLocation, 'range', progress);
-			// A response that ignored the range downloaded the whole attachment,
-			// which is what asking first set out to avoid. One is enough to learn.
-			if (range === null) this.sizeProbeAnswered = false;
-			return range;
-		}
-		catch {
-			// Nothing is known about the attachment; treat it as unrecognised.
-			return null;
-		}
-	}
+			const identifiedName = await resourceFilename(filename, contentLocation);
+			let data: ArrayBuffer | null = null;
+			const download = async (): Promise<ArrayBuffer> => {
+				if (data !== null) return data;
 
-	async fetchAttachment(progress: ImportContext, filename: string, contentLocation: string, notePath: string): Promise<string | null> {
-		try {
-			// However many names it has to pass over, the size is asked for once.
-			let size: number | null;
-			let asked = false;
-
-			const { path: outputPath, reuse } = await this.placeAttachment(filename, notePath, async existing => {
-				if (!asked) {
-					size = await this.attachmentSize(contentLocation, progress);
-					asked = true;
+				if (this.throttleSpacingMs > 0) {
+					await new Promise(resolve => window.setTimeout(resolve, this.throttleSpacingMs));
 				}
 
-				return size !== null && size === existing.stat.size ? 'same' : 'another';
+				progress.status('Downloading attachment ' + filename);
+				const fetched = await this.fetchResource(contentLocation, 'file', progress);
+				data = fetched;
+				this.throttleSpacingMs = Math.max(0, this.throttleSpacingMs - ATTACHMENT_SPACING_STEP_MS);
+				return fetched;
+			};
+
+			const { path: outputPath, reuse } = await this.placeAttachment(identifiedName, notePath, async existing => {
+				if (sourceMtime !== undefined) {
+					return sourceMtime > existing.stat.mtime ? 'stale' : 'same';
+				}
+
+				return sameBytes(await this.vault.readBinary(existing), await download()) ? 'same' : 'stale';
 			});
 
 			if (reuse) {
@@ -952,18 +989,9 @@ export class OneNoteImporter extends FormatImporter {
 				return reuse.path;
 			}
 
-			// Only downloads are worth spacing out; a reuse never reaches Graph.
-			if (this.throttleSpacingMs > 0) {
-				await new Promise(resolve => window.setTimeout(resolve, this.throttleSpacingMs));
-			}
-
-			progress.status('Downloading attachment ' + filename);
-
-			const data = (await this.fetchResource(contentLocation, 'file', progress));
-			await this.writeAttachment(outputPath, data);
+			await this.writeAttachment(
+				outputPath, await download(), sourceMtime === undefined ? undefined : { mtime: sourceMtime });
 			progress.reportAttachmentSuccess(filename);
-
-			this.throttleSpacingMs = Math.max(0, this.throttleSpacingMs - ATTACHMENT_SPACING_STEP_MS);
 			return outputPath;
 		}
 		catch (e) {
@@ -977,7 +1005,6 @@ export class OneNoteImporter extends FormatImporter {
 	async fetchResource<T = ArrayBuffer>(url: string, returnType: 'file', progress?: ImportContext): Promise<T>;
 	async fetchResource<T>(url: string, returnType: 'json', progress?: ImportContext): Promise<T>;
 	async fetchResource<T>(url: string, returnType: 'json-wrapped', progress?: ImportContext): Promise<JSONWrappedResponse<T>>;
-	async fetchResource(url: string, returnType: 'range', progress?: ImportContext): Promise<number | null>;
 	async fetchResource<T>(url: string, returnType: ResourceType, progress?: ImportContext): Promise<FetchedResource<T>> {
 		return this.fetchWithRetry<T>(url, returnType, progress, 0, false);
 	}
@@ -1010,9 +1037,6 @@ export class OneNoteImporter extends FormatImporter {
 				{
 					headers: {
 						Authorization: `Bearer ${this.graphData.accessToken}`,
-						// Asking for the first byte is a GET, which a resource
-						// URL allows where it may refuse a HEAD.
-						...(returnType === 'range' ? { Range: 'bytes=0-0' } : {}),
 					},
 					signal: this.host.abortController.signal,
 				}
@@ -1022,9 +1046,6 @@ export class OneNoteImporter extends FormatImporter {
 				let result: FetchedResource<T>;
 
 				switch (returnType) {
-					case 'range':
-						result = totalFromContentRange(response);
-						break;
 					case 'text':
 						result = await response.text();
 						break;

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -560,14 +560,14 @@ export class OneNoteImporter extends FormatImporter {
 		// Anything still being read ahead is about to be needed.
 		await this.prefetching;
 
-		for (const section of this.selectedSections) {
+		const sections = this.selectedSections;
+		for (const [index, section] of sections.entries()) {
 			if (await progress.shouldStop()) break;
 
 			let pages = this.sectionPages.get(section.id);
 			if (!pages) {
-				progress.status(queue.length
-					? `Finding notes in ${section.title} (${queue.length} so far)`
-					: `Finding notes in ${section.title}`);
+				const position = sections.length > 1 ? ` (section ${index + 1} of ${sections.length})` : '';
+				progress.status(`Finding notes in ${section.title}${position}`);
 
 				try {
 					pages = await this.fetchSectionPages(section.id, progress);

--- a/src/formats/onenote.ts
+++ b/src/formats/onenote.ts
@@ -23,6 +23,10 @@ const GRAPH_CLIENT_ID: string = '66553851-08fa-44f2-8bb1-1436f121a73d';
 const SELF_CLOSING_REGEX = /<(object|iframe)([^>]*)\/>/g;
 // Maximum amount of request retries, before they're marked as failed. Does not include 429 backoff errors.
 const MAX_RETRY_ATTEMPTS = 5;
+// How much each throttled request slows attachment downloads, and how far that
+// can go. One step is given back for every attachment that comes down cleanly.
+const ATTACHMENT_SPACING_STEP_MS = 500;
+const MAX_ATTACHMENT_SPACING_MS = 3_000;
 
 const BASE64_REGEX = new RegExp(/^data:[\w\d]+\/[\w\d]+;base64,/);
 
@@ -121,7 +125,13 @@ export class OneNoteImporter extends FormatImporter {
 		state: genUid(32),
 		accessToken: '',
 	};
-	attachmentsSinceBackOff = 0;
+	/**
+	 * How long to leave between attachment downloads, which is nothing until
+	 * OneNote actually throttles. A fixed pause every few attachments spent the
+	 * same minutes whether or not anything was rate limiting, and on a notebook
+	 * with hundreds of attachments that was most of the import.
+	 */
+	private throttleSpacingMs = 0;
 	/** Page lists read ahead of the import, by section id. */
 	private readonly sectionPages = new Map<string, OnenotePage[]>();
 	private prefetching: Promise<void> = Promise.resolve();
@@ -895,12 +905,9 @@ export class OneNoteImporter extends FormatImporter {
 	}
 
 	async fetchAttachment(progress: ImportContext, filename: string, contentLocation: string, notePath: string): Promise<string | null> {
-		// Every 7 attachments, do a few second break to prevent rate limiting
-		if (this.attachmentsSinceBackOff === 7) {
-			this.attachmentsSinceBackOff = 0;
-			await this.backOff(3, 'staying under OneNote rate limits', progress);
+		if (this.throttleSpacingMs > 0) {
+			await new Promise(resolve => window.setTimeout(resolve, this.throttleSpacingMs));
 		}
-		this.attachmentsSinceBackOff++;
 
 		progress.status('Downloading attachment ' + filename);
 
@@ -910,6 +917,9 @@ export class OneNoteImporter extends FormatImporter {
 			const data = (await this.fetchResource(contentLocation, 'file', progress));
 			await this.app.vault.createBinary(outputPath, data);
 			progress.reportAttachmentSuccess(filename);
+
+			// Earn the speed back once it stops complaining.
+			this.throttleSpacingMs = Math.max(0, this.throttleSpacingMs - ATTACHMENT_SPACING_STEP_MS);
 			return outputPath;
 		}
 		catch (e) {
@@ -1004,6 +1014,11 @@ export class OneNoteImporter extends FormatImporter {
 
 				// We're rate-limited - let's retry after the suggested amount of time
 				if (err?.code === '20166' || response.status === 429) {
+					this.throttleSpacingMs = Math.min(
+						MAX_ATTACHMENT_SPACING_MS,
+						this.throttleSpacingMs + ATTACHMENT_SPACING_STEP_MS,
+					);
+
 					// Imports can wait; picker loads should fail visibly.
 					if (!progress) throw new GraphRefusal(429, err);
 

--- a/src/formats/onenote/auth.ts
+++ b/src/formats/onenote/auth.ts
@@ -15,14 +15,62 @@ const AUTHORITY = 'https://login.microsoftonline.com/common/oauth2/v2.0';
 const SCOPES = {
 	// A personal account holds its own notebooks and nothing else, so the
 	// narrower scope covers it and keeps the consent screen honest.
-	personal: ['user.read', 'notes.read'],
+	// openid is what makes an id_token come back; the Graph access token is
+	// opaque for personal accounts, so it is the only thing that says which
+	// tenant signed in.
+	personal: ['openid', 'user.read', 'notes.read'],
 	// Work and school notebooks commonly live on SharePoint or in Teams, which
 	// notes.read alone cannot reach — the 40004 behind issues #440 and #462.
-	organization: ['user.read', 'notes.read.all'],
+	organization: ['openid', 'user.read', 'notes.read.all'],
 } satisfies Record<MicrosoftAccountType, string[]>;
 
 export function accountType(value: unknown): MicrosoftAccountType {
 	return value === 'organization' ? value : 'personal';
+}
+
+/**
+ * The tenant every personal Microsoft account signs in under. Anything else is
+ * a work or school tenant.
+ */
+const CONSUMER_TENANT = '9188040d-6c67-4c5b-b112-36a304b66dad';
+
+function decodeSegment(segment: string): unknown {
+	// A JWT pads with base64url, which atob does not accept.
+	const base64 = segment.replace(/-/g, '+').replace(/_/g, '/');
+	return JSON.parse(atob(base64 + '='.repeat((4 - base64.length % 4) % 4)));
+}
+
+/**
+ * Which kind of account a token was issued to, or null if it does not say.
+ *
+ * Asking the user is the obvious alternative and it gets answered wrong in
+ * both directions: a work account left on Personal is refused the notebooks it
+ * came for, and a personal account set to Work or school is refused at consent
+ * outright, because notes.read.all is not offered to personal accounts at all.
+ * The token already carries the answer.
+ */
+export function accountTypeFromToken(token: string | undefined): MicrosoftAccountType | null {
+	// Only an id_token is reliably readable here. The Graph access token is
+	// opaque for personal accounts — a single segment, nothing to decode — so
+	// reading that instead looks like it works and always answers null.
+	const segments = token?.split('.') ?? [];
+	const payload = segments.length === 3 ? segments[1] : undefined;
+	if (!payload) return null;
+
+	try {
+		const claims = decodeSegment(payload);
+		if (typeof claims !== 'object' || claims === null || !('tid' in claims)) return null;
+
+		const tenant = (claims as { tid: unknown }).tid;
+		if (typeof tenant !== 'string') return null;
+
+		return tenant === CONSUMER_TENANT ? 'personal' : 'organization';
+	}
+	catch {
+		// Microsoft does not promise this token is a readable JWT, and the
+		// account type is only used to choose what to ask for next time.
+		return null;
+	}
 }
 
 export function graphScopes(type: MicrosoftAccountType): string[] {

--- a/src/formats/onenote/auth.ts
+++ b/src/formats/onenote/auth.ts
@@ -1,26 +1,36 @@
 export type MicrosoftAccountType = 'personal' | 'organization';
 
-const ACCOUNT = {
-	personal: {
-		tenant: 'consumers',
-		scopes: ['user.read', 'notes.read'],
-	},
-	organization: {
-		tenant: 'organizations',
-		scopes: ['user.read', 'notes.read.all'],
-	},
-} satisfies Record<MicrosoftAccountType, { tenant: string, scopes: string[] }>;
+/**
+ * Both account kinds sign in through the same authority.
+ *
+ * Pinning each kind to its own tenant (`consumers` / `organizations`) looks
+ * tidier and breaks every existing sign-in: a refresh token issued by `common`
+ * is rejected by either of them, and since the stored account type defaults to
+ * personal, a work account would be signed out on upgrade and then refused at
+ * the consumer endpoint it was sent to. `common` accepts both, so what the
+ * account type selects is the access being asked for, not where to ask.
+ */
+const AUTHORITY = 'https://login.microsoftonline.com/common/oauth2/v2.0';
+
+const SCOPES = {
+	// A personal account holds its own notebooks and nothing else, so the
+	// narrower scope covers it and keeps the consent screen honest.
+	personal: ['user.read', 'notes.read'],
+	// Work and school notebooks commonly live on SharePoint or in Teams, which
+	// notes.read alone cannot reach — the 40004 behind issues #440 and #462.
+	organization: ['user.read', 'notes.read.all'],
+} satisfies Record<MicrosoftAccountType, string[]>;
 
 export function accountType(value: unknown): MicrosoftAccountType {
 	return value === 'organization' ? value : 'personal';
 }
 
 export function graphScopes(type: MicrosoftAccountType): string[] {
-	return ACCOUNT[type].scopes;
+	return SCOPES[type];
 }
 
-export function tokenUrl(type: MicrosoftAccountType): string {
-	return `https://login.microsoftonline.com/${ACCOUNT[type].tenant}/oauth2/v2.0/token`;
+export function tokenUrl(): string {
+	return `${AUTHORITY}/token`;
 }
 
 export function authorizationUrl(
@@ -35,9 +45,11 @@ export function authorizationUrl(
 		response_type: 'code',
 		redirect_uri: redirectUri,
 		response_mode: 'query',
+		// Without this, Microsoft silently reuses whichever account the browser
+		// is already signed in to, which is issue #278.
 		prompt: 'select_account',
 		state,
 	});
 
-	return `https://login.microsoftonline.com/${ACCOUNT[type].tenant}/oauth2/v2.0/authorize?${params.toString()}`;
+	return `${AUTHORITY}/authorize?${params.toString()}`;
 }

--- a/src/formats/onenote/auth.ts
+++ b/src/formats/onenote/auth.ts
@@ -9,8 +9,9 @@ const SCOPES = {
 	organization: ['openid', 'user.read', 'notes.read.all'],
 } satisfies Record<MicrosoftAccountType, string[]>;
 
-export function accountType(value: unknown): MicrosoftAccountType {
-	return value === 'organization' ? value : 'personal';
+/** What was stored for the account, or null when nothing recognisable was. */
+export function storedAccountType(value: unknown): MicrosoftAccountType | null {
+	return value === 'organization' || value === 'personal' ? value : null;
 }
 
 const MICROSOFT_CONSUMER_TENANT_ID = '9188040d-6c67-4c5b-b112-36a304b66dad';
@@ -43,9 +44,7 @@ export function graphScopes(type: MicrosoftAccountType): string[] {
 	return SCOPES[type];
 }
 
-export function tokenUrl(): string {
-	return `${AUTHORITY}/token`;
-}
+export const TOKEN_URL = `${AUTHORITY}/token`;
 
 export function authorizationUrl(
 	type: MicrosoftAccountType,

--- a/src/formats/onenote/auth.ts
+++ b/src/formats/onenote/auth.ts
@@ -1,0 +1,43 @@
+export type MicrosoftAccountType = 'personal' | 'organization';
+
+const ACCOUNT = {
+	personal: {
+		tenant: 'consumers',
+		scopes: ['user.read', 'notes.read'],
+	},
+	organization: {
+		tenant: 'organizations',
+		scopes: ['user.read', 'notes.read.all'],
+	},
+} satisfies Record<MicrosoftAccountType, { tenant: string, scopes: string[] }>;
+
+export function accountType(value: unknown): MicrosoftAccountType {
+	return value === 'organization' ? value : 'personal';
+}
+
+export function graphScopes(type: MicrosoftAccountType): string[] {
+	return ACCOUNT[type].scopes;
+}
+
+export function tokenUrl(type: MicrosoftAccountType): string {
+	return `https://login.microsoftonline.com/${ACCOUNT[type].tenant}/oauth2/v2.0/token`;
+}
+
+export function authorizationUrl(
+	type: MicrosoftAccountType,
+	clientId: string,
+	redirectUri: string,
+	state: string,
+): string {
+	const params = new URLSearchParams({
+		client_id: clientId,
+		scope: `offline_access ${graphScopes(type).join(' ')}`,
+		response_type: 'code',
+		redirect_uri: redirectUri,
+		response_mode: 'query',
+		prompt: 'select_account',
+		state,
+	});
+
+	return `https://login.microsoftonline.com/${ACCOUNT[type].tenant}/oauth2/v2.0/authorize?${params.toString()}`;
+}

--- a/src/formats/onenote/auth.ts
+++ b/src/formats/onenote/auth.ts
@@ -1,26 +1,11 @@
 export type MicrosoftAccountType = 'personal' | 'organization';
 
-/**
- * Both account kinds sign in through the same authority.
- *
- * Pinning each kind to its own tenant (`consumers` / `organizations`) looks
- * tidier and breaks every existing sign-in: a refresh token issued by `common`
- * is rejected by either of them, and since the stored account type defaults to
- * personal, a work account would be signed out on upgrade and then refused at
- * the consumer endpoint it was sent to. `common` accepts both, so what the
- * account type selects is the access being asked for, not where to ask.
- */
+// Keep the common authority so existing refresh tokens remain valid.
 const AUTHORITY = 'https://login.microsoftonline.com/common/oauth2/v2.0';
 
+// openid returns the ID token used to identify the account type.
 const SCOPES = {
-	// A personal account holds its own notebooks and nothing else, so the
-	// narrower scope covers it and keeps the consent screen honest.
-	// openid is what makes an id_token come back; the Graph access token is
-	// opaque for personal accounts, so it is the only thing that says which
-	// tenant signed in.
 	personal: ['openid', 'user.read', 'notes.read'],
-	// Work and school notebooks commonly live on SharePoint or in Teams, which
-	// notes.read alone cannot reach — the 40004 behind issues #440 and #462.
 	organization: ['openid', 'user.read', 'notes.read.all'],
 } satisfies Record<MicrosoftAccountType, string[]>;
 
@@ -28,31 +13,14 @@ export function accountType(value: unknown): MicrosoftAccountType {
 	return value === 'organization' ? value : 'personal';
 }
 
-/**
- * The tenant every personal Microsoft account signs in under. Anything else is
- * a work or school tenant.
- */
-const CONSUMER_TENANT = '9188040d-6c67-4c5b-b112-36a304b66dad';
+const MICROSOFT_CONSUMER_TENANT_ID = '9188040d-6c67-4c5b-b112-36a304b66dad';
 
 function decodeSegment(segment: string): unknown {
-	// A JWT pads with base64url, which atob does not accept.
 	const base64 = segment.replace(/-/g, '+').replace(/_/g, '/');
 	return JSON.parse(atob(base64 + '='.repeat((4 - base64.length % 4) % 4)));
 }
 
-/**
- * Which kind of account a token was issued to, or null if it does not say.
- *
- * Asking the user is the obvious alternative and it gets answered wrong in
- * both directions: a work account left on Personal is refused the notebooks it
- * came for, and a personal account set to Work or school is refused at consent
- * outright, because notes.read.all is not offered to personal accounts at all.
- * The token already carries the answer.
- */
 export function accountTypeFromToken(token: string | undefined): MicrosoftAccountType | null {
-	// Only an id_token is reliably readable here. The Graph access token is
-	// opaque for personal accounts — a single segment, nothing to decode — so
-	// reading that instead looks like it works and always answers null.
 	const segments = token?.split('.') ?? [];
 	const payload = segments.length === 3 ? segments[1] : undefined;
 	if (!payload) return null;
@@ -64,11 +32,9 @@ export function accountTypeFromToken(token: string | undefined): MicrosoftAccoun
 		const tenant = (claims as { tid: unknown }).tid;
 		if (typeof tenant !== 'string') return null;
 
-		return tenant === CONSUMER_TENANT ? 'personal' : 'organization';
+		return tenant === MICROSOFT_CONSUMER_TENANT_ID ? 'personal' : 'organization';
 	}
 	catch {
-		// Microsoft does not promise this token is a readable JWT, and the
-		// account type is only used to choose what to ask for next time.
 		return null;
 	}
 }
@@ -93,8 +59,6 @@ export function authorizationUrl(
 		response_type: 'code',
 		redirect_uri: redirectUri,
 		response_mode: 'query',
-		// Without this, Microsoft silently reuses whichever account the browser
-		// is already signed in to, which is issue #278.
 		prompt: 'select_account',
 		state,
 	});

--- a/src/formats/onenote/errors.ts
+++ b/src/formats/onenote/errors.ts
@@ -1,0 +1,20 @@
+import { describeRequestFailure, requestFailure } from '../../request-failure';
+
+const ONENOTE = {
+	name: 'OneNote',
+	subject: 'your notebooks',
+	credential: 'Sign out and back in to try again.',
+};
+
+export function describeNotebookFailure(error: unknown): string {
+	const failure = requestFailure(error);
+
+	if (failure.code === '40004') {
+		return 'OneNote did not grant this sign-in access to your notebooks. This usually means a work or school account whose notebooks need an administrator to allow access; a personal Microsoft account does not.';
+	}
+
+	// OneNote may report throttling without an HTTP 429 status.
+	if (failure.code === '20166') failure.status ??= 429;
+
+	return describeRequestFailure(failure, ONENOTE);
+}

--- a/src/formats/onenote/errors.ts
+++ b/src/formats/onenote/errors.ts
@@ -10,7 +10,7 @@ export function describeNotebookFailure(error: unknown): string {
 	const failure = requestFailure(error);
 
 	if (failure.code === '40004') {
-		return 'OneNote did not grant this sign-in access to your notebooks. This usually means a work or school account whose notebooks need an administrator to allow access; a personal Microsoft account does not.';
+		return 'OneNote did not grant this sign-in access to your notebooks. If this is a work or school account, sign out, choose Work or school, and sign in again. Your organization may require approval.';
 	}
 
 	// OneNote may report throttling without an HTTP 429 status.

--- a/src/formats/onenote/errors.ts
+++ b/src/formats/onenote/errors.ts
@@ -9,10 +9,6 @@ const ONENOTE = {
 export function describeNotebookFailure(error: unknown): string {
 	const failure = requestFailure(error);
 
-	// The sign-in was not granted these notebooks, which is what a work or
-	// school account gets when it has only been given personal access. Signing
-	// in again now asks for the wider access, because the account type was
-	// recognised from the token the first time round.
 	if (failure.code === '40004') {
 		return 'OneNote did not grant this sign-in access to your notebooks. Sign out and sign in again to ask for work or school access, which your organization may need to approve.';
 	}

--- a/src/formats/onenote/errors.ts
+++ b/src/formats/onenote/errors.ts
@@ -1,5 +1,10 @@
 import { describeRequestFailure, requestFailure } from '../../request-failure';
 
+/** The OAuth token was not granted the scopes the notebooks need. */
+export const SCOPE_REFUSED = '40004';
+/** OneNote reports throttling with this code, sometimes without an HTTP 429. */
+export const THROTTLED = '20166';
+
 const ONENOTE = {
 	name: 'OneNote',
 	subject: 'your notebooks',
@@ -9,12 +14,11 @@ const ONENOTE = {
 export function describeNotebookFailure(error: unknown): string {
 	const failure = requestFailure(error);
 
-	if (failure.code === '40004') {
+	if (failure.code === SCOPE_REFUSED) {
 		return 'OneNote did not grant this sign-in access to your notebooks. Sign out and sign in again to ask for work or school access, which your organization may need to approve.';
 	}
 
-	// OneNote may report throttling without an HTTP 429 status.
-	if (failure.code === '20166') failure.status ??= 429;
+	if (failure.code === THROTTLED) failure.status ??= 429;
 
 	return describeRequestFailure(failure, ONENOTE);
 }

--- a/src/formats/onenote/errors.ts
+++ b/src/formats/onenote/errors.ts
@@ -9,8 +9,12 @@ const ONENOTE = {
 export function describeNotebookFailure(error: unknown): string {
 	const failure = requestFailure(error);
 
+	// The sign-in was not granted these notebooks, which is what a work or
+	// school account gets when it has only been given personal access. Signing
+	// in again now asks for the wider access, because the account type was
+	// recognised from the token the first time round.
 	if (failure.code === '40004') {
-		return 'OneNote did not grant this sign-in access to your notebooks. If this is a work or school account, sign out, choose Work or school, and sign in again. Your organization may require approval.';
+		return 'OneNote did not grant this sign-in access to your notebooks. Sign out and sign in again to ask for work or school access, which your organization may need to approve.';
 	}
 
 	// OneNote may report throttling without an HTTP 429 status.

--- a/src/plugin-data.ts
+++ b/src/plugin-data.ts
@@ -9,12 +9,6 @@ export interface OutputSettings {
 }
 
 export interface ImporterData {
-	/** Legacy OneNote import data. */
-	importers: {
-		onenote?: {
-			previouslyImportedIDs: string[];
-		};
-	};
 	secrets: Record<string, string>;
 	/** Legacy output folders. */
 	outputLocations: Record<string, string>;
@@ -24,11 +18,6 @@ export interface ImporterData {
 }
 
 export const DEFAULT_DATA: ImporterData = {
-	importers: {
-		onenote: {
-			previouslyImportedIDs: [],
-		},
-	},
 	secrets: {},
 	outputLocations: {},
 	outputSettings: {},

--- a/src/plugin-data.ts
+++ b/src/plugin-data.ts
@@ -13,6 +13,7 @@ export interface ImporterData {
 	/** Legacy output folders. */
 	outputLocations: Record<string, string>;
 	outputSettings: Record<string, OutputSettings>;
+	onenoteAttachments: Record<string, string>;
 	sourceFolders: Record<string, string>;
 	lastSourceFolder: string;
 }
@@ -21,6 +22,7 @@ export const DEFAULT_DATA: ImporterData = {
 	secrets: {},
 	outputLocations: {},
 	outputSettings: {},
+	onenoteAttachments: {},
 	sourceFolders: {},
 	lastSourceFolder: '',
 };

--- a/src/request-failure.ts
+++ b/src/request-failure.ts
@@ -1,0 +1,84 @@
+export interface RequestFailure {
+	status?: number;
+	code?: string;
+	message?: string;
+}
+
+export interface RequestedService {
+	name: string;
+	subject: string;
+	credential: string;
+}
+
+function property(error: object, key: string): unknown {
+	return key in error ? (error as Record<string, unknown>)[key] : undefined;
+}
+
+function asStatus(value: unknown): number | undefined {
+	if (typeof value === 'number' && Number.isFinite(value)) return value;
+	if (typeof value === 'string' && /^\d{3}$/.test(value)) return Number(value);
+	return undefined;
+}
+
+function asText(value: unknown): string | undefined {
+	if (typeof value === 'string' && value !== '') return value;
+	if (typeof value === 'number') return String(value);
+	return undefined;
+}
+
+export function requestFailure(error: unknown): RequestFailure {
+	if (typeof error !== 'object' || error === null) {
+		return typeof error === 'string' && error !== '' ? { message: error } : {};
+	}
+
+	const failure: RequestFailure = {
+		status: asStatus(property(error, 'status')),
+		code: asText(property(error, 'code')),
+		message: asText(property(error, 'message')),
+	};
+
+	// Graph nests the service error; prefer it to the generic wrapper.
+	const nested = property(error, 'error');
+	if (typeof nested === 'object' && nested !== null) {
+		failure.status ??= asStatus(property(nested, 'status'));
+		failure.code ??= asText(property(nested, 'code'));
+		failure.message = asText(property(nested, 'message')) ?? failure.message;
+	}
+
+	return failure;
+}
+
+export function describeRequestFailure(error: unknown, service: RequestedService): string {
+	const { name, subject, credential } = service;
+	const { status, code, message } = requestFailure(error);
+
+	if (status === 401) {
+		return `${name} did not accept the request for ${subject}. ${credential}`;
+	}
+	if (status === 403) {
+		return `${name} would not give access to ${subject}. ${credential}`;
+	}
+	if (status === 404) {
+		return `${name} could not find ${subject}.`;
+	}
+	if (status === 429) {
+		return `${name} is limiting how fast ${subject} can be read. Wait a few minutes and try again.`;
+	}
+	if (status === 408 || status === 504) {
+		return `${name} took too long to return ${subject}. Try again shortly.`;
+	}
+	if (status !== undefined && status >= 500) {
+		return `${name} could not return ${subject} right now. Try again shortly.`;
+	}
+
+	if (message) {
+		return code
+			? `Could not read ${subject}: ${message} (${code})`
+			: `Could not read ${subject}: ${message}`;
+	}
+	if (code) {
+		return `Could not read ${subject}. ${name} reported ${code}.`;
+	}
+
+	return `Could not read ${subject}.`;
+}

--- a/src/tree-view.ts
+++ b/src/tree-view.ts
@@ -30,7 +30,7 @@ export interface TreePickerOptions<T extends ViewableNode<T>> {
 	hint: string;
 	loading: string;
 	empty: string;
-	failed: string;
+	failed(error: unknown): string;
 	view: Omit<TreeView<T>, 'redraw'>;
 	onChange?(): void;
 }
@@ -84,7 +84,7 @@ export class TreePicker<T extends ViewableNode<T>> {
 			if (this.nodes.length > 0) this.toggleButton.buttonEl.show();
 		}
 		catch (e) {
-			this.setStatus(this.options.failed);
+			this.setStatus(this.options.failed(e));
 			this.options.onChange?.();
 			throw e;
 		}

--- a/tests/apple-notes/attachments.test.ts
+++ b/tests/apple-notes/attachments.test.ts
@@ -335,6 +335,23 @@ test('a drawing that was never downloaded is skipped, not failed', async () => {
 	}
 });
 
+test('drawings that share a name stay separate files when updating', async () => {
+	// Three different drawings all want to be called Drawing.png. The check for
+	// one already in the folder is meant to recognise a previous import, but
+	// within a single run it also matches a different attachment that merely
+	// got there first.
+	const run = await importing(DRAWINGS);
+	try {
+		await run.reimport(DuplicateHandling.Update)(run.notePks[0]);
+
+		const drawings = run.vault.paths().filter(path => path.endsWith('.png'));
+		assert.deepEqual(drawings, ['Drawing.png', 'Drawing 1.png', 'Drawing 2.png']);
+	}
+	finally {
+		run.close();
+	}
+});
+
 test('a drawing is imported whichever UTI it carries', async () => {
 	const run = await importing(DRAWINGS);
 	try {

--- a/tests/apple-notes/attachments.test.ts
+++ b/tests/apple-notes/attachments.test.ts
@@ -336,10 +336,6 @@ test('a drawing that was never downloaded is skipped, not failed', async () => {
 });
 
 test('drawings that share a name stay separate files when updating', async () => {
-	// Three different drawings all want to be called Drawing.png. The check for
-	// one already in the folder is meant to recognise a previous import, but
-	// within a single run it also matches a different attachment that merely
-	// got there first.
 	const run = await importing(DRAWINGS);
 	try {
 		await run.reimport(DuplicateHandling.Update)(run.notePks[0]);

--- a/tests/apple-notes/attachments.test.ts
+++ b/tests/apple-notes/attachments.test.ts
@@ -348,6 +348,34 @@ test('drawings that share a name stay separate files when updating', async () =>
 	}
 });
 
+test('drawings that share a name are not multiplied by a later import', async () => {
+	const run = await importing(DRAWINGS);
+	try {
+		await run.resolve(run.notePks[0]);
+		const first = run.vault.paths().filter(path => path.endsWith('.png'));
+		assert.deepEqual(first, ['Drawing.png', 'Drawing 1.png', 'Drawing 2.png']);
+
+		// Age the note so the second run reimports it rather than skipping it.
+		const note = run.vault.getAbstractFileByPath('Sketches.md');
+		assert.ok(note instanceof TFile);
+		note.stat.mtime = 0;
+
+		await run.reimport(DuplicateHandling.Update)(run.notePks[0]);
+
+		assert.deepEqual(
+			run.vault.paths().filter(path => path.endsWith('.png')), first,
+			'each drawing should have found the copy it wrote last time',
+		);
+
+		const held = (path: string) => Buffer.from(run.vault.contents.get(path) as ArrayBuffer).toString();
+		assert.equal(held('Drawing.png'), 'DRAWING-PAPER', 'and kept hold of its own bytes');
+		assert.equal(held('Drawing 2.png'), 'DRAWING-LEGACY-2');
+	}
+	finally {
+		run.close();
+	}
+});
+
 test('a drawing is imported whichever UTI it carries', async () => {
 	const run = await importing(DRAWINGS);
 	try {

--- a/tests/apple-notes/failures.test.ts
+++ b/tests/apple-notes/failures.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { describeFolderFailure } from '../../src/formats/apple-notes';
+import { describeFolderFailure } from '../../src/formats/apple-notes/errors';
 
 function sqliteError(reason: string): Error {
 	return Object.assign(new Error(`SQLITE_ERROR: ${reason}`), { code: 'SQLITE_ERROR' });

--- a/tests/apple-notes/failures.test.ts
+++ b/tests/apple-notes/failures.test.ts
@@ -1,0 +1,44 @@
+/**
+ * What the folder picker says when the notes database will not open.
+ *
+ * The shapes here are the ones the vendored sqlite layer really produces: it
+ * labels every failure SQLITE_ERROR and carries the cause in the message,
+ * either its own wording or a line of the sqlite3 binary's stderr. An earlier
+ * version of this branched on ENOENT and EACCES, which read plausibly and
+ * could never fire.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { describeFolderFailure } from '../../src/formats/apple-notes';
+
+/** What src/formats/apple-notes/sqlite/utils.js builds. */
+function sqliteError(reason: string): Error {
+	return Object.assign(new Error(`SQLITE_ERROR: ${reason}`), { code: 'SQLITE_ERROR' });
+}
+
+test('a database Notes still has open says to quit Notes', () => {
+	// index.js reports a non-zero exit this way, and the binary's own stderr
+	// for the same situation reads differently.
+	for (const reason of ['busy DB or query too slow', 'database is locked']) {
+		assert.match(describeFolderFailure(sqliteError(reason)), /Quit Notes/, `for ${reason}`);
+	}
+});
+
+test('a database that will not open points at the access hint', () => {
+	const message = describeFolderFailure(sqliteError('unable to open database file'));
+
+	assert.match(message, /Could not open your Apple Notes database/);
+	assert.match(message, /Allow access to your notes/);
+});
+
+test('anything else repeats what sqlite said, without its label', () => {
+	const message = describeFolderFailure(sqliteError('no such table: ZICCLOUDSYNCINGOBJECT'));
+
+	assert.equal(message, 'Could not read your notes: no such table: ZICCLOUDSYNCINGOBJECT');
+});
+
+test('an error with nothing to say still names what failed', () => {
+	assert.equal(describeFolderFailure(new Error('')), 'Could not read your notes.');
+	assert.equal(describeFolderFailure(sqliteError('')), 'Could not read your notes.');
+});

--- a/tests/apple-notes/failures.test.ts
+++ b/tests/apple-notes/failures.test.ts
@@ -1,9 +1,10 @@
 /**
  * What the folder picker says when the notes database will not open.
  *
- * The shapes here are the ones the vendored sqlite layer really produces: it
- * labels every failure SQLITE_ERROR and carries the cause in the message,
- * either its own wording or a line of the sqlite3 binary's stderr. An earlier
+ * The vendored sqlite layer fails in two shapes, and both are covered here.
+ * Its error helper labels the message SQLITE_ERROR and sets a matching code
+ * (sqlite/utils.js), but the persistent path rejects with a plain Error
+ * carrying the raw stderr and no code at all (sqlite/index.js). An earlier
  * version of this branched on ENOENT and EACCES, which read plausibly and
  * could never fire.
  */
@@ -12,17 +13,31 @@ import assert from 'node:assert/strict';
 
 import { describeFolderFailure } from '../../src/formats/apple-notes';
 
-/** What src/formats/apple-notes/sqlite/utils.js builds. */
+/** What the error helper in sqlite/utils.js builds. */
 function sqliteError(reason: string): Error {
 	return Object.assign(new Error(`SQLITE_ERROR: ${reason}`), { code: 'SQLITE_ERROR' });
 }
 
+/** What the persistent path in sqlite/index.js rejects with: stderr, no code. */
+function stderrError(reason: string): Error {
+	return new Error(reason);
+}
+
 test('a database Notes still has open says to quit Notes', () => {
-	// index.js reports a non-zero exit this way, and the binary's own stderr
-	// for the same situation reads differently.
 	for (const reason of ['busy DB or query too slow', 'database is locked']) {
-		assert.match(describeFolderFailure(sqliteError(reason)), /Quit Notes/, `for ${reason}`);
+		assert.match(describeFolderFailure(sqliteError(reason)), /Quit Notes/, `labelled: ${reason}`);
+		assert.match(describeFolderFailure(stderrError(reason)), /Quit Notes/, `bare: ${reason}`);
 	}
+});
+
+test('a bare stderr rejection is described the same as a labelled one', () => {
+	// Nothing may strip a prefix that is not there, or lose the message for
+	// want of a code.
+	assert.match(describeFolderFailure(stderrError('unable to open database file')), /Could not open your Apple Notes database/);
+	assert.equal(
+		describeFolderFailure(stderrError('no such table: ZICCLOUDSYNCINGOBJECT')),
+		'Could not read your notes: no such table: ZICCLOUDSYNCINGOBJECT',
+	);
 });
 
 test('a database that will not open points at the access hint', () => {

--- a/tests/apple-notes/failures.test.ts
+++ b/tests/apple-notes/failures.test.ts
@@ -1,24 +1,12 @@
-/**
- * What the folder picker says when the notes database will not open.
- *
- * The vendored sqlite layer fails in two shapes, and both are covered here.
- * Its error helper labels the message SQLITE_ERROR and sets a matching code
- * (sqlite/utils.js), but the persistent path rejects with a plain Error
- * carrying the raw stderr and no code at all (sqlite/index.js). An earlier
- * version of this branched on ENOENT and EACCES, which read plausibly and
- * could never fire.
- */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { describeFolderFailure } from '../../src/formats/apple-notes';
 
-/** What the error helper in sqlite/utils.js builds. */
 function sqliteError(reason: string): Error {
 	return Object.assign(new Error(`SQLITE_ERROR: ${reason}`), { code: 'SQLITE_ERROR' });
 }
 
-/** What the persistent path in sqlite/index.js rejects with: stderr, no code. */
 function stderrError(reason: string): Error {
 	return new Error(reason);
 }
@@ -31,8 +19,6 @@ test('a database Notes still has open says to quit Notes', () => {
 });
 
 test('a bare stderr rejection is described the same as a labelled one', () => {
-	// Nothing may strip a prefix that is not there, or lose the message for
-	// want of a code.
 	assert.match(describeFolderFailure(stderrError('unable to open database file')), /Could not open your Apple Notes database/);
 	assert.equal(
 		describeFolderFailure(stderrError('no such table: ZICCLOUDSYNCINGOBJECT')),

--- a/tests/onenote/attachments.test.ts
+++ b/tests/onenote/attachments.test.ts
@@ -74,8 +74,6 @@ test('a failed attachment download does not create an undefined embed', async ()
 });
 
 test('an attachment already in the vault is not downloaded again', async () => {
-	// Re-importing used to fetch every attachment afresh and write it beside
-	// the one already there, so a second run doubled every image.
 	const downloads: string[] = [];
 	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
 	const existing = { path: 'Notebook/Document.pdf' };

--- a/tests/onenote/attachments.test.ts
+++ b/tests/onenote/attachments.test.ts
@@ -30,6 +30,25 @@ test('3gp audio recordings are downloaded and embedded', async () => {
 	assert.equal(page.textContent, '![[Audio Recording.3GP]]');
 });
 
+test('the audio formats Obsidian plays are imported, not skipped', async () => {
+	// Issue #226: recordings were skipped as incompatible because the list of
+	// embeddable extensions had most of the audio formats missing.
+	const downloaded: string[] = [];
+	const subject = importer(name => {
+		downloaded.push(name);
+		return name;
+	});
+
+	const names = ['Recording.mp3', 'Recording.m4a', 'Recording.flac', 'Recording.ogg', 'Recording.oga', 'Recording.opus', 'Recording.wav'];
+	await subject.getAllAttachments(
+		new ImportContext(),
+		`<html><body>${names.map(n => `<object data-attachment="${n}" data="https://example.com/audio" />`).join('')}</body></html>`,
+		'Notebook/Page.md',
+	);
+
+	assert.deepEqual(downloaded, names);
+});
+
 test('attachment fallback content stays in order', async () => {
 	const subject = importer(name => name);
 	const page = await subject.getAllAttachments(
@@ -53,6 +72,56 @@ test('a failed attachment download does not create an undefined embed', async ()
 	assert.doesNotMatch(page.textContent ?? '', /undefined/);
 	assert.match(page.textContent ?? '', /Before/);
 	assert.match(page.textContent ?? '', /After/);
+});
+
+test('a file the user chose not to import is passed over, not reported failed', async () => {
+	// The missing-URL check has to come after the extension filter. Ahead of
+	// it, every incompatible attachment with no download URL lands in the
+	// failure list of a user who asked not to import incompatible attachments.
+	const subject = importer(name => name);
+	const progress = new ImportContext();
+
+	await subject.getAllAttachments(
+		progress,
+		'<html><body><object data-attachment="budget.xlsx"><p>Fallback</p></object></body></html>',
+		'Notebook/Page.md',
+	);
+
+	assert.deepEqual(progress.failed, []);
+});
+
+test('an image without a download URL is reported rather than losing the page', async () => {
+	// OneNote does not always send these attributes, and asserting them turns
+	// one odd image into a TypeError that costs the whole note.
+	const subject = importer(name => name);
+	const progress = new ImportContext();
+
+	const page = await subject.getAllAttachments(
+		progress,
+		'<html><body><p>Before</p><img alt="Missing"><p>After</p></body></html>',
+		'Notebook/Page.md',
+	);
+
+	assert.deepEqual(progress.failed, ['OneNote image']);
+	assert.match(page.textContent ?? '', /Before/);
+	assert.match(page.textContent ?? '', /After/);
+});
+
+test('an image with no declared type still downloads', async () => {
+	const downloaded: string[] = [];
+	const subject = importer(name => {
+		downloaded.push(name);
+		return name;
+	});
+
+	await subject.getAllAttachments(
+		new ImportContext(),
+		'<html><body><img src="x" data-fullres-src="https://example.com/image"></body></html>',
+		'Notebook/Page.md',
+	);
+
+	assert.equal(downloaded.length, 1);
+	assert.match(downloaded[0], /\.png$/);
 });
 
 test('an attachment without a download URL is reported and keeps its fallback content', async () => {

--- a/tests/onenote/attachments.test.ts
+++ b/tests/onenote/attachments.test.ts
@@ -31,8 +31,8 @@ test('3gp audio recordings are downloaded and embedded', async () => {
 });
 
 test('the audio formats Obsidian plays are imported, not skipped', async () => {
-	// Issue #226: recordings were skipped as incompatible because the list of
-	// embeddable extensions had most of the audio formats missing.
+	// Most of them counted as incompatible, so an mp3 needed the
+	// incompatible-attachment setting turned on to come across at all.
 	const downloaded: string[] = [];
 	const subject = importer(name => {
 		downloaded.push(name);
@@ -88,6 +88,21 @@ test('a file the user chose not to import is passed over, not reported failed', 
 	);
 
 	assert.deepEqual(progress.failed, []);
+});
+
+test('an attachment with no name is reported, not dropped in silence', async () => {
+	// It has no extension either, so filtering first would fail it against the
+	// embeddable list and skip it without a word.
+	const subject = importer(name => name);
+	const progress = new ImportContext();
+
+	await subject.getAllAttachments(
+		progress,
+		'<html><body><object data="https://example.com/thing"><p>Fallback</p></object></body></html>',
+		'Notebook/Page.md',
+	);
+
+	assert.deepEqual(progress.failed, ['OneNote attachment']);
 });
 
 test('an image without a download URL is reported rather than losing the page', async () => {

--- a/tests/onenote/attachments.test.ts
+++ b/tests/onenote/attachments.test.ts
@@ -6,12 +6,38 @@ import assert from 'node:assert/strict';
 import { OneNoteImporter } from '../../src/formats/onenote';
 import { ImportContext } from '../../src/import-context';
 import { DuplicateHandling } from '../../src/format-importer';
+import { MemoryVault, memoryApp } from '../shims/vault';
 
 function importer(download: (name: string) => string | null): OneNoteImporter {
 	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
 	subject.importIncompatibleAttachments = false;
 	subject.fetchAttachment = async (_progress, name) => download(name);
 	return subject;
+}
+
+function binaryImporter(resources: Map<string, ArrayBuffer>) {
+	const vault = new MemoryVault();
+	const downloads: string[] = [];
+	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
+
+	Object.assign(subject, {
+		app: memoryApp(vault),
+		vault,
+		host: { abortController: new AbortController() },
+		attachmentLocation: { mode: 'vault', path: '' },
+		duplicateHandling: DuplicateHandling.Update,
+		throttleSpacingMs: 0,
+		claimed: new Set<string>(),
+		fetchResource: async (url: string, returnType: string) => {
+			assert.equal(returnType, 'file');
+			downloads.push(url);
+			const data = resources.get(url);
+			if (!data) throw new Error(`No resource at ${url}`);
+			return data;
+		},
+	});
+
+	return { downloads, subject, vault };
 }
 
 test('3gp audio recordings are downloaded and embedded', async () => {
@@ -152,119 +178,88 @@ test('an image with no declared type still downloads', async () => {
 	assert.match(downloaded[0], /\.png$/);
 });
 
-test('an image is named after its note, so a later import can recognise it', async () => {
-	const downloaded: string[] = [];
-	const subject = importer(name => {
-		downloaded.push(name);
-		return name;
+test('images use their resource ids rather than note names or positions', async () => {
+	const names: string[] = [];
+	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
+
+	Object.assign(subject, {
+		importIncompatibleAttachments: false,
+		duplicateHandling: DuplicateHandling.Update,
+		throttleSpacingMs: 0,
+		placeAttachment: async (
+			name: string,
+			_notePath: string,
+		) => {
+			names.push(name);
+			return { path: name, reuse: { path: name } };
+		},
 	});
 
 	const page = '<html><body>'
-		+ '<img data-fullres-src="https://example.com/a" data-fullres-src-type="image/png">'
-		+ '<img data-fullres-src="https://example.com/b" data-fullres-src-type="image/jpeg">'
+		+ '<img data-fullres-src="https://graph.microsoft.com/v1.0/me/onenote/resources/a/$value" data-fullres-src-type="image/png">'
+		+ '<img data-fullres-src="https://graph.microsoft.com/v1.0/me/onenote/resources/b/$value" data-fullres-src-type="image/png">'
 		+ '</body></html>';
 
-	await subject.getAllAttachments(new ImportContext(), page, 'Notebook/Recipes.md');
-	await subject.getAllAttachments(new ImportContext(), page, 'Notebook/Recipes.md');
+	await subject.getAllAttachments(new ImportContext(), page, 'One/Recipes.md', 1_000);
+	await subject.getAllAttachments(new ImportContext(), page, 'Two/Recipes.md', 1_000);
 
-	assert.deepEqual(downloaded, [
-		'Recipes image 1.png', 'Recipes image 2.jpeg',
-		'Recipes image 1.png', 'Recipes image 2.jpeg',
-	], 'the same image asks for the same name every import');
+	assert.match(names[0], /^Recipes image [0-9a-f]{16}\.png$/);
+	assert.notEqual(names[0], names[1]);
+	assert.deepEqual(names.slice(0, 2), names.slice(2), 'the same resources keep their names in another note');
 });
 
-test('the size is asked for before the attachment is fetched', async () => {
-	const asked: Array<[string, string]> = [];
-	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
+test('equal-sized attachments from different resources never share a file', async () => {
+	const firstUrl = 'https://graph.microsoft.com/v1.0/me/onenote/resources/first/$value';
+	const secondUrl = 'https://graph.microsoft.com/v1.0/me/onenote/resources/second/$value';
+	const resources = new Map([
+		[firstUrl, Uint8Array.from([1, 2]).buffer],
+		[secondUrl, Uint8Array.from([3, 4]).buffer],
+	]);
+	const { downloads, subject, vault } = binaryImporter(resources);
 
-	Object.assign(subject, {
-		duplicateHandling: DuplicateHandling.Update,
-		throttleSpacingMs: 0,
-		sizeProbeAnswered: true,
-		placeAttachment: async (
-			_name: string,
-			_notePath: string,
-			recognise: (existing: { stat: { size: number } }) => Promise<string>,
-		) => {
-			const verdict = await recognise({ stat: { size: 4096 } });
-			return verdict === 'same'
-				? { path: 'Notebook/Document.pdf', reuse: { path: 'Notebook/Document.pdf' } }
-				: { path: 'Notebook/Document 1.pdf', reuse: null };
-		},
-		fetchResource: async (url: string, returnType: string) => {
-			asked.push([returnType, url]);
-			return returnType === 'range' ? 4096 : new ArrayBuffer(0);
-		},
-	});
+	const first = await subject.fetchAttachment(
+		new ImportContext(), 'Document.pdf', firstUrl, 'First.md', 1_000);
+	subject.indexImportedNotes();
+	const second = await subject.fetchAttachment(
+		new ImportContext(), 'Document.pdf', secondUrl, 'Second.md', 1_000);
 
-	const progress = new ImportContext();
-	const path = await subject.fetchAttachment(progress, 'Document.pdf', 'https://example.com/pdf', 'Notebook/Page.md');
+	assert.notEqual(first, second);
+	assert.deepEqual(new Uint8Array(vault.contents.get(first!) as ArrayBuffer), Uint8Array.from([1, 2]));
+	assert.deepEqual(new Uint8Array(vault.contents.get(second!) as ArrayBuffer), Uint8Array.from([3, 4]));
 
-	assert.deepEqual(asked, [['range', 'https://example.com/pdf']], 'the bytes were never fetched');
-	assert.equal(path, 'Notebook/Document.pdf');
-	assert.deepEqual(progress.skipped, ['Document.pdf']);
+	subject.indexImportedNotes();
+	assert.equal(await subject.fetchAttachment(
+		new ImportContext(), 'Document.pdf', secondUrl, 'Second.md', 1_000), second);
+	assert.deepEqual(downloads, [firstUrl, secondUrl], 'an unchanged resource is not downloaded again');
 });
 
-test('a size that does not match is downloaded rather than taken for this one', async () => {
-	const asked: string[] = [];
-	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
-
-	Object.assign(subject, {
-		duplicateHandling: DuplicateHandling.Update,
-		throttleSpacingMs: 0,
-		sizeProbeAnswered: true,
-		placeAttachment: async (
-			_name: string,
-			_notePath: string,
-			recognise: (existing: { stat: { size: number } }) => Promise<string>,
-		) => {
-			// A file of another size is sitting on the name this one wants.
-			await recognise({ stat: { size: 11 } });
-			return { path: 'Notebook/Document 1.pdf', reuse: null };
-		},
-		fetchResource: async (url: string, returnType: string) => {
-			asked.push(returnType);
-			return returnType === 'range' ? 4096 : new ArrayBuffer(4096);
-		},
-		writeAttachment: async () => {},
-	});
+test('an updated attachment replaces its old bytes even when its size is unchanged', async () => {
+	const url = 'https://graph.microsoft.com/v1.0/me/onenote/resources/document/$value';
+	const resources = new Map([[url, Uint8Array.from([1, 2]).buffer]]);
+	const { subject, vault } = binaryImporter(resources);
 
 	const path = await subject.fetchAttachment(
-		new ImportContext(), 'Document.pdf', 'https://example.com/pdf', 'Notebook/Page.md');
+		new ImportContext(), 'Document.pdf', url, 'Page.md', 1_000);
+	resources.set(url, Uint8Array.from([3, 4]).buffer);
+	subject.indexImportedNotes();
 
-	assert.deepEqual(asked, ['range', 'file']);
-	assert.equal(path, 'Notebook/Document 1.pdf', 'the other file is left as it stands');
+	assert.equal(await subject.fetchAttachment(
+		new ImportContext(), 'Document.pdf', url, 'Page.md', 2_000), path);
+	assert.deepEqual(new Uint8Array(vault.contents.get(path!) as ArrayBuffer), Uint8Array.from([3, 4]));
+	assert.equal(vault.paths().length, 1);
 });
 
-test('a service that ignores the range is only asked the once', async () => {
-	const asked: string[] = [];
-	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
+test('attachments without a source time compare their bytes before reuse', async () => {
+	const url = 'https://graph.microsoft.com/v1.0/me/onenote/resources/document/$value';
+	const resources = new Map([[url, Uint8Array.from([1, 2]).buffer]]);
+	const { downloads, subject, vault } = binaryImporter(resources);
 
-	Object.assign(subject, {
-		duplicateHandling: DuplicateHandling.Update,
-		throttleSpacingMs: 0,
-		sizeProbeAnswered: true,
-		placeAttachment: async (
-			_name: string,
-			_notePath: string,
-			recognise: (existing: { stat: { size: number } }) => Promise<string>,
-		) => {
-			await recognise({ stat: { size: 11 } });
-			return { path: 'Notebook/Document.pdf', reuse: null };
-		},
-		fetchResource: async (_url: string, returnType: string) => {
-			asked.push(returnType);
-			// null is what a response that sent the whole file reports.
-			return returnType === 'range' ? null : new ArrayBuffer(11);
-		},
-		writeAttachment: async () => {},
-	});
+	const path = await subject.fetchAttachment(new ImportContext(), 'Document.pdf', url, 'Page.md');
+	subject.indexImportedNotes();
 
-	const progress = new ImportContext();
-	await subject.fetchAttachment(progress, 'A.pdf', 'https://example.com/a', 'Notebook/Page.md');
-	await subject.fetchAttachment(progress, 'B.pdf', 'https://example.com/b', 'Notebook/Page.md');
-
-	assert.deepEqual(asked, ['range', 'file', 'file'], 'the probe stops after the first refusal');
+	assert.equal(await subject.fetchAttachment(new ImportContext(), 'Document.pdf', url, 'Page.md'), path);
+	assert.deepEqual(downloads, [url, url]);
+	assert.equal(vault.paths().length, 1);
 });
 
 test('an attachment without a download URL is reported and keeps its fallback content', async () => {

--- a/tests/onenote/attachments.test.ts
+++ b/tests/onenote/attachments.test.ts
@@ -31,8 +31,6 @@ test('3gp audio recordings are downloaded and embedded', async () => {
 });
 
 test('the audio formats Obsidian plays are imported, not skipped', async () => {
-	// Most of them counted as incompatible, so an mp3 needed the
-	// incompatible-attachment setting turned on to come across at all.
 	const downloaded: string[] = [];
 	const subject = importer(name => {
 		downloaded.push(name);
@@ -75,9 +73,6 @@ test('a failed attachment download does not create an undefined embed', async ()
 });
 
 test('a file the user chose not to import is passed over, not reported failed', async () => {
-	// The missing-URL check has to come after the extension filter. Ahead of
-	// it, every incompatible attachment with no download URL lands in the
-	// failure list of a user who asked not to import incompatible attachments.
 	const subject = importer(name => name);
 	const progress = new ImportContext();
 
@@ -91,8 +86,6 @@ test('a file the user chose not to import is passed over, not reported failed', 
 });
 
 test('an attachment with no name is reported, not dropped in silence', async () => {
-	// It has no extension either, so filtering first would fail it against the
-	// embeddable list and skip it without a word.
 	const subject = importer(name => name);
 	const progress = new ImportContext();
 
@@ -106,8 +99,6 @@ test('an attachment with no name is reported, not dropped in silence', async () 
 });
 
 test('an image without a download URL is reported rather than losing the page', async () => {
-	// OneNote does not always send these attributes, and asserting them turns
-	// one odd image into a TypeError that costs the whole note.
 	const subject = importer(name => name);
 	const progress = new ImportContext();
 

--- a/tests/onenote/attachments.test.ts
+++ b/tests/onenote/attachments.test.ts
@@ -6,6 +6,8 @@ import assert from 'node:assert/strict';
 import { OneNoteImporter } from '../../src/formats/onenote';
 import { ImportContext } from '../../src/import-context';
 import { DuplicateHandling } from '../../src/format-importer';
+import { DEFAULT_DATA } from '../../src/plugin-data';
+import type { ImporterData } from '../../src/plugin-data';
 import { MemoryVault, memoryApp } from '../shims/vault';
 
 function importer(download: (name: string) => string | null): OneNoteImporter {
@@ -28,16 +30,41 @@ function binaryImporter(resources: Map<string, ArrayBuffer>) {
 		duplicateHandling: DuplicateHandling.Update,
 		throttleSpacingMs: 0,
 		claimed: new Set<string>(),
+		attachmentPaths: new Map<string, string>(),
+		attachmentOwners: new Map<string, string>(),
+		attachmentPathsChanged: false,
 		fetchResource: async (url: string, returnType: string) => {
-			assert.equal(returnType, 'file');
-			downloads.push(url);
 			const data = resources.get(url);
 			if (!data) throw new Error(`No resource at ${url}`);
+			assert.equal(returnType, 'file');
+			downloads.push(url);
 			return data;
 		},
 	});
 
 	return { downloads, subject, vault };
+}
+
+function constructedImporter(vault: MemoryVault, loadData: () => Promise<ImporterData>): OneNoteImporter {
+	const app = memoryApp(vault) as unknown as Record<string, unknown>;
+	app.secretStorage = {
+		getSecret: () => null,
+		setSecret: () => {},
+		deleteSecret: () => {},
+	};
+
+	return new OneNoteImporter(app as never, {
+		sourceEl: null,
+		outputEl: null,
+		optionsEl: null,
+		plugin: {
+			loadData,
+			saveData: async () => {},
+			registerAuthCallback: () => {},
+		},
+		importerId: 'onenote',
+		abortController: new AbortController(),
+	});
 }
 
 test('3gp audio recordings are downloaded and embedded', async () => {
@@ -106,8 +133,12 @@ test('an attachment already in the vault is not downloaded again', async () => {
 
 	Object.assign(subject, {
 		importIncompatibleAttachments: false,
+		attachmentLocation: { mode: 'vault', path: '' },
 		duplicateHandling: DuplicateHandling.Update,
 		throttleSpacingMs: 0,
+		attachmentPaths: new Map<string, string>(),
+		attachmentOwners: new Map<string, string>(),
+		attachmentPathsChanged: false,
 		placeAttachment: async () => ({ path: existing.path, reuse: existing }),
 		fetchResource: async () => { downloads.push('fetched'); return new ArrayBuffer(0); },
 	});
@@ -184,8 +215,12 @@ test('images use their resource ids rather than note names or positions', async 
 
 	Object.assign(subject, {
 		importIncompatibleAttachments: false,
-		duplicateHandling: DuplicateHandling.Update,
+		attachmentLocation: { mode: 'vault', path: '' },
+		duplicateHandling: DuplicateHandling.CreateCopy,
 		throttleSpacingMs: 0,
+		attachmentPaths: new Map<string, string>(),
+		attachmentOwners: new Map<string, string>(),
+		attachmentPathsChanged: false,
 		placeAttachment: async (
 			name: string,
 			_notePath: string,
@@ -219,6 +254,7 @@ test('equal-sized attachments from different resources never share a file', asyn
 
 	const first = await subject.fetchAttachment(
 		new ImportContext(), 'Document.pdf', firstUrl, 'First.md', 1_000);
+	assert.equal(first, 'Document.pdf');
 	subject.indexImportedNotes();
 	const second = await subject.fetchAttachment(
 		new ImportContext(), 'Document.pdf', secondUrl, 'Second.md', 1_000);
@@ -249,7 +285,7 @@ test('an updated attachment replaces its old bytes even when its size is unchang
 	assert.equal(vault.paths().length, 1);
 });
 
-test('attachments without a source time compare their bytes before reuse', async () => {
+test('a known attachment is reused without a source time or another download', async () => {
 	const url = 'https://graph.microsoft.com/v1.0/me/onenote/resources/document/$value';
 	const resources = new Map([[url, Uint8Array.from([1, 2]).buffer]]);
 	const { downloads, subject, vault } = binaryImporter(resources);
@@ -258,8 +294,149 @@ test('attachments without a source time compare their bytes before reuse', async
 	subject.indexImportedNotes();
 
 	assert.equal(await subject.fetchAttachment(new ImportContext(), 'Document.pdf', url, 'Page.md'), path);
+	assert.deepEqual(downloads, [url]);
+	assert.equal(vault.paths().length, 1);
+});
+
+test('a legacy attachment is compared once before its resource is remembered', async () => {
+	const url = 'https://graph.microsoft.com/v1.0/me/onenote/resources/document/$value';
+	const resources = new Map([[url, Uint8Array.from([1, 2]).buffer]]);
+	const { downloads, subject, vault } = binaryImporter(resources);
+
+	const path = await subject.fetchAttachment(new ImportContext(), 'Document.pdf', url, 'Page.md');
+	const identity = subject as unknown as {
+		attachmentPaths: Map<string, string>,
+		attachmentOwners: Map<string, string>,
+	};
+	identity.attachmentPaths.clear();
+	identity.attachmentOwners.clear();
+	subject.indexImportedNotes();
+
+	assert.equal(await subject.fetchAttachment(new ImportContext(), 'Document.pdf', url, 'Page.md'), path);
 	assert.deepEqual(downloads, [url, url]);
 	assert.equal(vault.paths().length, 1);
+});
+
+test('a different-sized legacy candidate is rejected without reading its bytes', async () => {
+	const url = 'https://graph.microsoft.com/v1.0/me/onenote/resources/document/$value';
+	const { downloads, subject, vault } = binaryImporter(new Map([
+		[url, Uint8Array.from([1, 2, 3]).buffer],
+	]));
+	await vault.createBinary('Document.pdf', Uint8Array.from([4, 5]).buffer);
+	const readBinary = vault.readBinary.bind(vault);
+	let reads = 0;
+	vault.readBinary = async file => {
+		reads++;
+		return readBinary(file);
+	};
+
+	const path = await subject.fetchAttachment(new ImportContext(), 'Document.pdf', url, 'Page.md');
+
+	assert.equal(path, 'Document 1.pdf');
+	assert.equal(reads, 0);
+	assert.deepEqual(downloads, [url]);
+});
+
+test('attachment identities loaded during construction keep the same map', async () => {
+	const vault = new MemoryVault();
+	await vault.createBinary('Document.pdf', Uint8Array.from([1]).buffer);
+	let release!: (data: ImporterData) => void;
+	const loading = new Promise<ImporterData>(resolve => release = resolve);
+	let calls = 0;
+	const subject = constructedImporter(vault, () => calls++ === 0 ? loading : Promise.resolve(DEFAULT_DATA));
+	const before = (subject as unknown as { attachmentPaths: Map<string, string> }).attachmentPaths;
+
+	release({
+		...structuredClone(DEFAULT_DATA),
+		onenoteAttachments: { 'document\nvault\n\n': 'Document.pdf' },
+	});
+	await subject.ready;
+
+	const after = (subject as unknown as { attachmentPaths: Map<string, string> }).attachmentPaths;
+	assert.equal(after, before);
+	assert.equal(after.get('document\nvault\n\n'), 'Document.pdf');
+});
+
+test('loading attachment identities drops missing files and conflicting owners', async () => {
+	const vault = new MemoryVault();
+	await vault.createBinary('Document.pdf', Uint8Array.from([1]).buffer);
+	const data: ImporterData = {
+		...structuredClone(DEFAULT_DATA),
+		onenoteAttachments: {
+			'first\nvault\n\n': 'Document.pdf',
+			'second\nvault\n\n': 'Document.pdf',
+			'missing\nvault\n\n': 'Missing.pdf',
+		},
+	};
+	const subject = constructedImporter(vault, async () => data);
+
+	await subject.ready;
+
+	const identity = subject as unknown as {
+		attachmentPaths: Map<string, string>,
+		attachmentPathsChanged: boolean,
+	};
+	assert.deepEqual([...identity.attachmentPaths], [['first\nvault\n\n', 'Document.pdf']]);
+	assert.equal(identity.attachmentPathsChanged, true);
+});
+
+test('different resources cannot inherit the same mapped path', async () => {
+	const firstUrl = 'https://graph.microsoft.com/v1.0/me/onenote/resources/first/$value';
+	const secondUrl = 'https://graph.microsoft.com/v1.0/me/onenote/resources/second/$value';
+	const resources = new Map([
+		[firstUrl, Uint8Array.from([1, 2]).buffer],
+		[secondUrl, Uint8Array.from([3, 4]).buffer],
+	]);
+	const { subject, vault } = binaryImporter(resources);
+	const first = await subject.fetchAttachment(new ImportContext(), 'Document.pdf', firstUrl, 'First.md');
+	const paths = (subject as unknown as { attachmentPaths: Map<string, string> }).attachmentPaths;
+	paths.set('second\nvault\n\n', first!);
+	subject.indexImportedNotes();
+
+	const second = await subject.fetchAttachment(new ImportContext(), 'Document.pdf', secondUrl, 'Second.md');
+
+	assert.notEqual(second, first);
+	assert.deepEqual(new Uint8Array(vault.contents.get(first!) as ArrayBuffer), Uint8Array.from([1, 2]));
+	assert.deepEqual(new Uint8Array(vault.contents.get(second!) as ArrayBuffer), Uint8Array.from([3, 4]));
+});
+
+test('byte-identical resources imported separately keep distinct ownership', async () => {
+	const firstUrl = 'https://graph.microsoft.com/v1.0/me/onenote/resources/first/$value';
+	const secondUrl = 'https://graph.microsoft.com/v1.0/me/onenote/resources/second/$value';
+	const bytes = Uint8Array.from([1, 2]).buffer;
+	const { downloads, subject, vault } = binaryImporter(new Map([
+		[firstUrl, bytes],
+		[secondUrl, bytes],
+	]));
+
+	const first = await subject.fetchAttachment(new ImportContext(), 'Document.pdf', firstUrl, 'First.md');
+	subject.indexImportedNotes();
+	const second = await subject.fetchAttachment(new ImportContext(), 'Document.pdf', secondUrl, 'Second.md');
+
+	assert.notEqual(second, first);
+	assert.deepEqual(downloads, [firstUrl, secondUrl]);
+	assert.equal(vault.paths().length, 2);
+});
+
+test('attachment resource paths are saved for the next import', async () => {
+	const url = 'https://graph.microsoft.com/v1.0/me/onenote/resources/document/$value';
+	const { subject } = binaryImporter(new Map([[url, Uint8Array.from([1, 2]).buffer]]));
+	const saved: ImporterData[] = [];
+	Object.assign(subject, {
+		markdownFiles: new Set<string>(),
+		host: {
+			abortController: new AbortController(),
+			plugin: {
+				loadData: async () => structuredClone(DEFAULT_DATA),
+				saveData: async (data: ImporterData) => void saved.push(data),
+			},
+		},
+	});
+
+	const path = await subject.fetchAttachment(new ImportContext(), 'Document.pdf', url, 'Page.md');
+	await subject.finalizeMarkdownOutput();
+
+	assert.deepEqual(Object.values(saved[0]?.onenoteAttachments ?? {}), [path]);
 });
 
 test('an attachment without a download URL is reported and keeps its fallback content', async () => {

--- a/tests/onenote/attachments.test.ts
+++ b/tests/onenote/attachments.test.ts
@@ -1,0 +1,69 @@
+import '../shims/dom';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { OneNoteImporter } from '../../src/formats/onenote';
+import { ImportContext } from '../../src/import-context';
+
+function importer(download: (name: string) => string | null): OneNoteImporter {
+	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
+	subject.importIncompatibleAttachments = false;
+	subject.fetchAttachment = async (_progress, name) => download(name);
+	return subject;
+}
+
+test('3gp audio recordings are downloaded and embedded', async () => {
+	const downloaded: string[] = [];
+	const subject = importer(name => {
+		downloaded.push(name);
+		return name;
+	});
+
+	const page = await subject.getAllAttachments(
+		new ImportContext(),
+		'<html><body><object data-attachment="Audio Recording.3GP" data="https://example.com/audio" /></body></html>',
+		'Notebook/Page.md',
+	);
+
+	assert.deepEqual(downloaded, ['Audio Recording.3GP']);
+	assert.equal(page.textContent, '![[Audio Recording.3GP]]');
+});
+
+test('attachment fallback content stays in order', async () => {
+	const subject = importer(name => name);
+	const page = await subject.getAllAttachments(
+		new ImportContext(),
+		'<html><body><p>Before</p><object data-attachment="Document.pdf" data="https://example.com/pdf"><p>First</p><p>Second</p></object><p>After</p></body></html>',
+		'Notebook/Page.md',
+	);
+
+	const paragraphs = Array.from(page.querySelectorAll('p'), el => el.textContent);
+	assert.deepEqual(paragraphs, ['Before', '![[Document.pdf]]', 'First', 'Second', 'After']);
+});
+
+test('a failed attachment download does not create an undefined embed', async () => {
+	const subject = importer(() => null);
+	const page = await subject.getAllAttachments(
+		new ImportContext(),
+		'<html><body><p>Before</p><object data-attachment="Audio Recording.3gp" data="https://example.com/audio" /><p>After</p></body></html>',
+		'Notebook/Page.md',
+	);
+
+	assert.doesNotMatch(page.textContent ?? '', /undefined/);
+	assert.match(page.textContent ?? '', /Before/);
+	assert.match(page.textContent ?? '', /After/);
+});
+
+test('an attachment without a download URL is reported and keeps its fallback content', async () => {
+	const subject = importer(name => name);
+	const progress = new ImportContext();
+	const page = await subject.getAllAttachments(
+		progress,
+		'<html><body><object data-attachment="Document.pdf"><p>Fallback</p></object></body></html>',
+		'Notebook/Page.md',
+	);
+
+	assert.deepEqual(progress.failed, ['Document.pdf']);
+	assert.equal(page.textContent, 'Fallback');
+});

--- a/tests/onenote/attachments.test.ts
+++ b/tests/onenote/attachments.test.ts
@@ -152,6 +152,121 @@ test('an image with no declared type still downloads', async () => {
 	assert.match(downloaded[0], /\.png$/);
 });
 
+test('an image is named after its note, so a later import can recognise it', async () => {
+	const downloaded: string[] = [];
+	const subject = importer(name => {
+		downloaded.push(name);
+		return name;
+	});
+
+	const page = '<html><body>'
+		+ '<img data-fullres-src="https://example.com/a" data-fullres-src-type="image/png">'
+		+ '<img data-fullres-src="https://example.com/b" data-fullres-src-type="image/jpeg">'
+		+ '</body></html>';
+
+	await subject.getAllAttachments(new ImportContext(), page, 'Notebook/Recipes.md');
+	await subject.getAllAttachments(new ImportContext(), page, 'Notebook/Recipes.md');
+
+	assert.deepEqual(downloaded, [
+		'Recipes image 1.png', 'Recipes image 2.jpeg',
+		'Recipes image 1.png', 'Recipes image 2.jpeg',
+	], 'the same image asks for the same name every import');
+});
+
+test('the size is asked for before the attachment is fetched', async () => {
+	const asked: Array<[string, string]> = [];
+	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
+
+	Object.assign(subject, {
+		duplicateHandling: DuplicateHandling.Update,
+		throttleSpacingMs: 0,
+		sizeProbeAnswered: true,
+		placeAttachment: async (
+			_name: string,
+			_notePath: string,
+			recognise: (existing: { stat: { size: number } }) => Promise<string>,
+		) => {
+			const verdict = await recognise({ stat: { size: 4096 } });
+			return verdict === 'same'
+				? { path: 'Notebook/Document.pdf', reuse: { path: 'Notebook/Document.pdf' } }
+				: { path: 'Notebook/Document 1.pdf', reuse: null };
+		},
+		fetchResource: async (url: string, returnType: string) => {
+			asked.push([returnType, url]);
+			return returnType === 'range' ? 4096 : new ArrayBuffer(0);
+		},
+	});
+
+	const progress = new ImportContext();
+	const path = await subject.fetchAttachment(progress, 'Document.pdf', 'https://example.com/pdf', 'Notebook/Page.md');
+
+	assert.deepEqual(asked, [['range', 'https://example.com/pdf']], 'the bytes were never fetched');
+	assert.equal(path, 'Notebook/Document.pdf');
+	assert.deepEqual(progress.skipped, ['Document.pdf']);
+});
+
+test('a size that does not match is downloaded rather than taken for this one', async () => {
+	const asked: string[] = [];
+	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
+
+	Object.assign(subject, {
+		duplicateHandling: DuplicateHandling.Update,
+		throttleSpacingMs: 0,
+		sizeProbeAnswered: true,
+		placeAttachment: async (
+			_name: string,
+			_notePath: string,
+			recognise: (existing: { stat: { size: number } }) => Promise<string>,
+		) => {
+			// A file of another size is sitting on the name this one wants.
+			await recognise({ stat: { size: 11 } });
+			return { path: 'Notebook/Document 1.pdf', reuse: null };
+		},
+		fetchResource: async (url: string, returnType: string) => {
+			asked.push(returnType);
+			return returnType === 'range' ? 4096 : new ArrayBuffer(4096);
+		},
+		writeAttachment: async () => {},
+	});
+
+	const path = await subject.fetchAttachment(
+		new ImportContext(), 'Document.pdf', 'https://example.com/pdf', 'Notebook/Page.md');
+
+	assert.deepEqual(asked, ['range', 'file']);
+	assert.equal(path, 'Notebook/Document 1.pdf', 'the other file is left as it stands');
+});
+
+test('a service that ignores the range is only asked the once', async () => {
+	const asked: string[] = [];
+	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
+
+	Object.assign(subject, {
+		duplicateHandling: DuplicateHandling.Update,
+		throttleSpacingMs: 0,
+		sizeProbeAnswered: true,
+		placeAttachment: async (
+			_name: string,
+			_notePath: string,
+			recognise: (existing: { stat: { size: number } }) => Promise<string>,
+		) => {
+			await recognise({ stat: { size: 11 } });
+			return { path: 'Notebook/Document.pdf', reuse: null };
+		},
+		fetchResource: async (_url: string, returnType: string) => {
+			asked.push(returnType);
+			// null is what a response that sent the whole file reports.
+			return returnType === 'range' ? null : new ArrayBuffer(11);
+		},
+		writeAttachment: async () => {},
+	});
+
+	const progress = new ImportContext();
+	await subject.fetchAttachment(progress, 'A.pdf', 'https://example.com/a', 'Notebook/Page.md');
+	await subject.fetchAttachment(progress, 'B.pdf', 'https://example.com/b', 'Notebook/Page.md');
+
+	assert.deepEqual(asked, ['range', 'file', 'file'], 'the probe stops after the first refusal');
+});
+
 test('an attachment without a download URL is reported and keeps its fallback content', async () => {
 	const subject = importer(name => name);
 	const progress = new ImportContext();

--- a/tests/onenote/attachments.test.ts
+++ b/tests/onenote/attachments.test.ts
@@ -5,6 +5,7 @@ import assert from 'node:assert/strict';
 
 import { OneNoteImporter } from '../../src/formats/onenote';
 import { ImportContext } from '../../src/import-context';
+import { DuplicateHandling } from '../../src/format-importer';
 
 function importer(download: (name: string) => string | null): OneNoteImporter {
 	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
@@ -70,6 +71,29 @@ test('a failed attachment download does not create an undefined embed', async ()
 	assert.doesNotMatch(page.textContent ?? '', /undefined/);
 	assert.match(page.textContent ?? '', /Before/);
 	assert.match(page.textContent ?? '', /After/);
+});
+
+test('an attachment already in the vault is not downloaded again', async () => {
+	// Re-importing used to fetch every attachment afresh and write it beside
+	// the one already there, so a second run doubled every image.
+	const downloads: string[] = [];
+	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
+	const existing = { path: 'Notebook/Document.pdf' };
+
+	Object.assign(subject, {
+		importIncompatibleAttachments: false,
+		duplicateHandling: DuplicateHandling.Update,
+		throttleSpacingMs: 0,
+		placeAttachment: async () => ({ path: existing.path, reuse: existing }),
+		fetchResource: async () => { downloads.push('fetched'); return new ArrayBuffer(0); },
+	});
+
+	const progress = new ImportContext();
+	const path = await subject.fetchAttachment(progress, 'Document.pdf', 'https://example.com/pdf', 'Notebook/Page.md');
+
+	assert.deepEqual(downloads, [], 'nothing should have been fetched');
+	assert.equal(path, existing.path, 'the note should embed the copy already there');
+	assert.deepEqual(progress.skipped, ['Document.pdf']);
 });
 
 test('a file the user chose not to import is passed over, not reported failed', async () => {

--- a/tests/onenote/auth.test.ts
+++ b/tests/onenote/auth.test.ts
@@ -22,17 +22,12 @@ test('work and school accounts request organization notebook access', () => {
 });
 
 test('both kinds ask for openid, which is what returns a readable token', () => {
-	// The Graph access token is opaque for a personal account, so the id_token
-	// is the only thing that says which tenant signed in.
 	for (const type of ['personal', 'organization'] as const) {
 		assert.ok(graphScopes(type).includes('openid'), `for ${type}`);
 	}
 });
 
 test('both account kinds sign in through the common authority', () => {
-	// A tenant-specific authority rejects a refresh token issued by common, so
-	// choosing one per account type signs out everyone who upgrades — and then
-	// refuses the work accounts it sent to the consumer endpoint.
 	for (const type of ['personal', 'organization'] as const) {
 		const url = new URL(authorizationUrl(type, CLIENT_ID, REDIRECT_URI, 'state'));
 		assert.equal(url.pathname, '/common/oauth2/v2.0/authorize', `for ${type}`);
@@ -55,7 +50,6 @@ test('an unknown stored account type falls back to personal', () => {
 	assert.equal(accountType('organization'), 'organization');
 });
 
-/** A JWT with the given claims, signature omitted the way we never check it. */
 function token(claims: Record<string, unknown>): string {
 	const encode = (value: object) => Buffer.from(JSON.stringify(value))
 		.toString('base64')
@@ -65,31 +59,22 @@ function token(claims: Record<string, unknown>): string {
 }
 
 test('the tenant in the token says which kind of account signed in', () => {
-	// Every personal Microsoft account signs in under this one tenant.
 	assert.equal(accountTypeFromToken(token({ tid: '9188040d-6c67-4c5b-b112-36a304b66dad' })), 'personal');
 	assert.equal(accountTypeFromToken(token({ tid: '72f988bf-86f1-41af-91ab-2d7cd011db47' })), 'organization');
 });
 
 test('a token that does not say leaves the choice alone', () => {
-	// Nothing promises a readable token, and the answer only decides what to
-	// ask for next time, so not knowing is a valid state.
 	for (const value of [undefined, '', 'not-a-jwt', 'a.b', token({}), `${token({})}`.replace(/\..*/, '.!!!.x')]) {
 		assert.equal(accountTypeFromToken(value), null, `for ${JSON.stringify(value)}`);
 	}
 });
 
 test('notes.read.all is never what a personal account is asked for', () => {
-	// It is not offered to personal accounts at all, so requesting it is not a
-	// wider ask that might fail — it is a sign-in that cannot succeed. Anything
-	// that escalates an account to organization has to be sure first.
 	assert.ok(!graphScopes('personal').includes('notes.read.all'));
 	assert.ok(graphScopes('organization').includes('notes.read.all'));
 });
 
 test('an opaque access token is not mistaken for a readable one', () => {
-	// What Microsoft actually returns for a personal account: one segment,
-	// nothing to decode. Splitting on '.' and taking [1] gives undefined here,
-	// but a two-segment string would have handed back a base64 blob to parse.
 	assert.equal(accountTypeFromToken('EwAoA8l6BAAUAOyDv0l6PcCVu89kmzvqZmkWABkAAY'), null);
 	assert.equal(accountTypeFromToken('opaque.token'), null);
 });

--- a/tests/onenote/auth.test.ts
+++ b/tests/onenote/auth.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { accountType, accountTypeFromToken, authorizationUrl, graphScopes, tokenUrl } from '../../src/formats/onenote/auth';
+import { accountTypeFromToken, authorizationUrl, graphScopes, storedAccountType, TOKEN_URL } from '../../src/formats/onenote/auth';
 
 const CLIENT_ID = 'client-id';
 const REDIRECT_URI = 'obsidian://importer-auth/';
@@ -33,7 +33,7 @@ test('both account kinds sign in through the common authority', () => {
 		assert.equal(url.pathname, '/common/oauth2/v2.0/authorize', `for ${type}`);
 	}
 
-	assert.equal(tokenUrl(), 'https://login.microsoftonline.com/common/oauth2/v2.0/token');
+	assert.equal(TOKEN_URL, 'https://login.microsoftonline.com/common/oauth2/v2.0/token');
 });
 
 test('sign-in always asks which remembered account to use', () => {
@@ -44,10 +44,11 @@ test('sign-in always asks which remembered account to use', () => {
 	}
 });
 
-test('an unknown stored account type falls back to personal', () => {
-	assert.equal(accountType(undefined), 'personal');
-	assert.equal(accountType('work'), 'personal');
-	assert.equal(accountType('organization'), 'organization');
+test('only a recognised stored account type is read back', () => {
+	assert.equal(storedAccountType(undefined), null);
+	assert.equal(storedAccountType('work'), null);
+	assert.equal(storedAccountType('personal'), 'personal');
+	assert.equal(storedAccountType('organization'), 'organization');
 });
 
 function token(claims: Record<string, unknown>): string {

--- a/tests/onenote/auth.test.ts
+++ b/tests/onenote/auth.test.ts
@@ -6,22 +6,31 @@ import { accountType, authorizationUrl, graphScopes, tokenUrl } from '../../src/
 const CLIENT_ID = 'client-id';
 const REDIRECT_URI = 'obsidian://importer-auth/';
 
-test('personal accounts use the consumer authority and personal OneNote scope', () => {
+test('personal accounts ask only for their own notebooks', () => {
 	const url = new URL(authorizationUrl('personal', CLIENT_ID, REDIRECT_URI, 'state'));
 
 	assert.equal(url.hostname, 'login.microsoftonline.com');
-	assert.equal(url.pathname, '/consumers/oauth2/v2.0/authorize');
+	assert.deepEqual(graphScopes('personal'), ['user.read', 'notes.read']);
 	assert.equal(url.searchParams.get('scope'), 'offline_access user.read notes.read');
-	assert.equal(tokenUrl('personal'), 'https://login.microsoftonline.com/consumers/oauth2/v2.0/token');
 });
 
 test('work and school accounts request organization notebook access', () => {
 	const url = new URL(authorizationUrl('organization', CLIENT_ID, REDIRECT_URI, 'state'));
 
-	assert.equal(url.pathname, '/organizations/oauth2/v2.0/authorize');
 	assert.deepEqual(graphScopes('organization'), ['user.read', 'notes.read.all']);
 	assert.equal(url.searchParams.get('scope'), 'offline_access user.read notes.read.all');
-	assert.equal(tokenUrl('organization'), 'https://login.microsoftonline.com/organizations/oauth2/v2.0/token');
+});
+
+test('both account kinds sign in through the common authority', () => {
+	// A tenant-specific authority rejects a refresh token issued by common, so
+	// choosing one per account type signs out everyone who upgrades — and then
+	// refuses the work accounts it sent to the consumer endpoint.
+	for (const type of ['personal', 'organization'] as const) {
+		const url = new URL(authorizationUrl(type, CLIENT_ID, REDIRECT_URI, 'state'));
+		assert.equal(url.pathname, '/common/oauth2/v2.0/authorize', `for ${type}`);
+	}
+
+	assert.equal(tokenUrl(), 'https://login.microsoftonline.com/common/oauth2/v2.0/token');
 });
 
 test('sign-in always asks which remembered account to use', () => {

--- a/tests/onenote/auth.test.ts
+++ b/tests/onenote/auth.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { accountType, authorizationUrl, graphScopes, tokenUrl } from '../../src/formats/onenote/auth';
+import { accountType, accountTypeFromToken, authorizationUrl, graphScopes, tokenUrl } from '../../src/formats/onenote/auth';
 
 const CLIENT_ID = 'client-id';
 const REDIRECT_URI = 'obsidian://importer-auth/';
@@ -10,15 +10,23 @@ test('personal accounts ask only for their own notebooks', () => {
 	const url = new URL(authorizationUrl('personal', CLIENT_ID, REDIRECT_URI, 'state'));
 
 	assert.equal(url.hostname, 'login.microsoftonline.com');
-	assert.deepEqual(graphScopes('personal'), ['user.read', 'notes.read']);
-	assert.equal(url.searchParams.get('scope'), 'offline_access user.read notes.read');
+	assert.deepEqual(graphScopes('personal'), ['openid', 'user.read', 'notes.read']);
+	assert.equal(url.searchParams.get('scope'), 'offline_access openid user.read notes.read');
 });
 
 test('work and school accounts request organization notebook access', () => {
 	const url = new URL(authorizationUrl('organization', CLIENT_ID, REDIRECT_URI, 'state'));
 
-	assert.deepEqual(graphScopes('organization'), ['user.read', 'notes.read.all']);
-	assert.equal(url.searchParams.get('scope'), 'offline_access user.read notes.read.all');
+	assert.deepEqual(graphScopes('organization'), ['openid', 'user.read', 'notes.read.all']);
+	assert.equal(url.searchParams.get('scope'), 'offline_access openid user.read notes.read.all');
+});
+
+test('both kinds ask for openid, which is what returns a readable token', () => {
+	// The Graph access token is opaque for a personal account, so the id_token
+	// is the only thing that says which tenant signed in.
+	for (const type of ['personal', 'organization'] as const) {
+		assert.ok(graphScopes(type).includes('openid'), `for ${type}`);
+	}
 });
 
 test('both account kinds sign in through the common authority', () => {
@@ -45,4 +53,40 @@ test('an unknown stored account type falls back to personal', () => {
 	assert.equal(accountType(undefined), 'personal');
 	assert.equal(accountType('work'), 'personal');
 	assert.equal(accountType('organization'), 'organization');
+});
+
+/** A JWT with the given claims, signature omitted the way we never check it. */
+function token(claims: Record<string, unknown>): string {
+	const encode = (value: object) => Buffer.from(JSON.stringify(value))
+		.toString('base64')
+		.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+	return `${encode({ alg: 'RS256', typ: 'JWT' })}.${encode(claims)}.signature`;
+}
+
+test('the tenant in the token says which kind of account signed in', () => {
+	// Every personal Microsoft account signs in under this one tenant.
+	assert.equal(accountTypeFromToken(token({ tid: '9188040d-6c67-4c5b-b112-36a304b66dad' })), 'personal');
+	assert.equal(accountTypeFromToken(token({ tid: '72f988bf-86f1-41af-91ab-2d7cd011db47' })), 'organization');
+});
+
+test('a token that does not say leaves the choice alone', () => {
+	// Nothing promises a readable token, and the answer only decides what to
+	// ask for next time, so not knowing is a valid state.
+	for (const value of [undefined, '', 'not-a-jwt', 'a.b', token({}), `${token({})}`.replace(/\..*/, '.!!!.x')]) {
+		assert.equal(accountTypeFromToken(value), null, `for ${JSON.stringify(value)}`);
+	}
+});
+
+test('an opaque access token is not mistaken for a readable one', () => {
+	// What Microsoft actually returns for a personal account: one segment,
+	// nothing to decode. Splitting on '.' and taking [1] gives undefined here,
+	// but a two-segment string would have handed back a base64 blob to parse.
+	assert.equal(accountTypeFromToken('EwAoA8l6BAAUAOyDv0l6PcCVu89kmzvqZmkWABkAAY'), null);
+	assert.equal(accountTypeFromToken('opaque.token'), null);
+});
+
+test('a tenant claim of the wrong shape is not read as an organization', () => {
+	assert.equal(accountTypeFromToken(token({ tid: 42 })), null);
+	assert.equal(accountTypeFromToken(token({ tid: null })), null);
 });

--- a/tests/onenote/auth.test.ts
+++ b/tests/onenote/auth.test.ts
@@ -1,0 +1,39 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { accountType, authorizationUrl, graphScopes, tokenUrl } from '../../src/formats/onenote/auth';
+
+const CLIENT_ID = 'client-id';
+const REDIRECT_URI = 'obsidian://importer-auth/';
+
+test('personal accounts use the consumer authority and personal OneNote scope', () => {
+	const url = new URL(authorizationUrl('personal', CLIENT_ID, REDIRECT_URI, 'state'));
+
+	assert.equal(url.hostname, 'login.microsoftonline.com');
+	assert.equal(url.pathname, '/consumers/oauth2/v2.0/authorize');
+	assert.equal(url.searchParams.get('scope'), 'offline_access user.read notes.read');
+	assert.equal(tokenUrl('personal'), 'https://login.microsoftonline.com/consumers/oauth2/v2.0/token');
+});
+
+test('work and school accounts request organization notebook access', () => {
+	const url = new URL(authorizationUrl('organization', CLIENT_ID, REDIRECT_URI, 'state'));
+
+	assert.equal(url.pathname, '/organizations/oauth2/v2.0/authorize');
+	assert.deepEqual(graphScopes('organization'), ['user.read', 'notes.read.all']);
+	assert.equal(url.searchParams.get('scope'), 'offline_access user.read notes.read.all');
+	assert.equal(tokenUrl('organization'), 'https://login.microsoftonline.com/organizations/oauth2/v2.0/token');
+});
+
+test('sign-in always asks which remembered account to use', () => {
+	for (const type of ['personal', 'organization'] as const) {
+		const url = new URL(authorizationUrl(type, CLIENT_ID, REDIRECT_URI, 'state'));
+		assert.equal(url.searchParams.get('prompt'), 'select_account');
+		assert.equal(url.searchParams.get('state'), 'state');
+	}
+});
+
+test('an unknown stored account type falls back to personal', () => {
+	assert.equal(accountType(undefined), 'personal');
+	assert.equal(accountType('work'), 'personal');
+	assert.equal(accountType('organization'), 'organization');
+});

--- a/tests/onenote/auth.test.ts
+++ b/tests/onenote/auth.test.ts
@@ -78,6 +78,14 @@ test('a token that does not say leaves the choice alone', () => {
 	}
 });
 
+test('notes.read.all is never what a personal account is asked for', () => {
+	// It is not offered to personal accounts at all, so requesting it is not a
+	// wider ask that might fail — it is a sign-in that cannot succeed. Anything
+	// that escalates an account to organization has to be sure first.
+	assert.ok(!graphScopes('personal').includes('notes.read.all'));
+	assert.ok(graphScopes('organization').includes('notes.read.all'));
+});
+
 test('an opaque access token is not mistaken for a readable one', () => {
 	// What Microsoft actually returns for a personal account: one segment,
 	// nothing to decode. Splitting on '.' and taking [1] gives undefined here,

--- a/tests/onenote/errors.test.ts
+++ b/tests/onenote/errors.test.ts
@@ -11,7 +11,7 @@ test('the scope failure names the account type that causes it', () => {
 		},
 	});
 
-	assert.match(message, /work or school account/);
+	assert.match(message, /choose Work or school/);
 	assert.doesNotMatch(message, /limiting how fast/);
 });
 

--- a/tests/onenote/errors.test.ts
+++ b/tests/onenote/errors.test.ts
@@ -1,0 +1,49 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { describeNotebookFailure } from '../../src/formats/onenote/errors';
+
+test('the scope failure names the account type that causes it', () => {
+	const message = describeNotebookFailure({
+		error: {
+			code: '40004',
+			message: 'The OAuth token provided does not have the necessary scopes',
+		},
+	});
+
+	assert.match(message, /work or school account/);
+	assert.doesNotMatch(message, /limiting how fast/);
+});
+
+test('the scope failure is recognised however it is wrapped', () => {
+	const message = describeNotebookFailure(Object.assign(new Error('Exceeded maximum retry attempts'), {
+		status: 403,
+		error: { code: '40004' },
+	}));
+
+	assert.match(message, /work or school account/);
+});
+
+test('throttling is still reported as throttling', () => {
+	for (const error of [{ status: 429 }, { error: { code: '20166' } }]) {
+		assert.match(describeNotebookFailure(error), /limiting how fast/, `for ${JSON.stringify(error)}`);
+	}
+});
+
+test('a rejected sign-in says to sign in again', () => {
+	const message = describeNotebookFailure({ status: 401 });
+
+	assert.match(message, /Sign out and back in/);
+	assert.doesNotMatch(message, /limiting how fast/);
+});
+
+test('an outage is not blamed on the account', () => {
+	assert.match(describeNotebookFailure({ status: 503 }), /could not return your notebooks right now/);
+	assert.match(describeNotebookFailure({ status: 504 }), /took too long/);
+});
+
+test('an unrecognised failure repeats what OneNote said rather than guessing', () => {
+	const message = describeNotebookFailure(new Error('Failed to fetch'));
+
+	assert.equal(message, 'Could not read your notebooks: Failed to fetch');
+});

--- a/tests/onenote/errors.test.ts
+++ b/tests/onenote/errors.test.ts
@@ -3,7 +3,9 @@ import assert from 'node:assert/strict';
 
 import { describeNotebookFailure } from '../../src/formats/onenote/errors';
 
-test('the scope failure names the account type that causes it', () => {
+test('the scope failure says what to do about it', () => {
+	// Signing in again is the whole remedy: the account type was recognised
+	// from the first token, so the second sign-in asks for the wider access.
 	const message = describeNotebookFailure({
 		error: {
 			code: '40004',
@@ -11,7 +13,8 @@ test('the scope failure names the account type that causes it', () => {
 		},
 	});
 
-	assert.match(message, /choose Work or school/);
+	assert.match(message, /Sign out and sign in again/);
+	assert.match(message, /work or school access/);
 	assert.doesNotMatch(message, /limiting how fast/);
 });
 
@@ -21,7 +24,7 @@ test('the scope failure is recognised however it is wrapped', () => {
 		error: { code: '40004' },
 	}));
 
-	assert.match(message, /work or school account/);
+	assert.match(message, /work or school access/);
 });
 
 test('throttling is still reported as throttling', () => {

--- a/tests/onenote/errors.test.ts
+++ b/tests/onenote/errors.test.ts
@@ -4,8 +4,6 @@ import assert from 'node:assert/strict';
 import { describeNotebookFailure } from '../../src/formats/onenote/errors';
 
 test('the scope failure says what to do about it', () => {
-	// Signing in again is the whole remedy: the account type was recognised
-	// from the first token, so the second sign-in asks for the wider access.
 	const message = describeNotebookFailure({
 		error: {
 			code: '40004',

--- a/tests/onenote/hierarchy.test.ts
+++ b/tests/onenote/hierarchy.test.ts
@@ -1,0 +1,26 @@
+import '../shims/runtime';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Notebook } from '@microsoft/microsoft-graph-types';
+
+import { OneNoteImporter } from '../../src/formats/onenote';
+
+test('a page path starts with its notebook and preserves section groups', () => {
+	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
+	subject.notebooks = [{
+		id: 'notebook',
+		displayName: 'Work',
+		sectionGroups: [{
+			id: 'group',
+			displayName: 'Projects',
+			sections: [{
+				id: 'section',
+				displayName: 'Roadmap',
+				pages: [{ id: 'page', title: 'Next', level: 0, contentUrl: 'page-id=page}' }],
+			}],
+		}],
+	}] as Notebook[];
+
+	assert.equal(subject.getEntityPathNoParent('page', 'OneNote'), 'OneNote/Work/Projects/Roadmap');
+});

--- a/tests/onenote/import.test.ts
+++ b/tests/onenote/import.test.ts
@@ -20,6 +20,9 @@ function importerOverPages(pages: OnenotePage[], overrides: Partial<OneNoteImpor
 	Object.assign(subject, {
 		selectedSections: [{ id: 'section', title: 'Section' }],
 		notebooks: [],
+		// Object.create skips the field initialisers the constructor would run.
+		sectionPages: new Map(),
+		prefetching: Promise.resolve(),
 		graphData: { accessToken: 'token' },
 		duplicateHandling: DuplicateHandling.CreateCopy,
 		host: { plugin: null, abortController: new AbortController() },
@@ -86,6 +89,46 @@ test('the total is the whole import from the first note, not one section at a ti
 
 	assert.deepEqual([...new Set(totals)], [10], 'one total throughout, and it is every page');
 	assert.equal(totals.length, 11, 'reported once up front and once per page');
+});
+
+test('page lists read ahead of the import are not fetched twice', async () => {
+	// The point of reading ahead while the later steps are filled in is that
+	// the import then starts on what it already has.
+	const listed: string[] = [];
+	const pages = [{ id: 'p', title: 'P', contentUrl: 'page-id=p}' }] as OnenotePage[];
+
+	const subject = importerOverPages([], {
+		sectionPages: new Map([['section', pages]]),
+		fetchResource: async (url: string) => {
+			if (url.includes('/pages?')) listed.push(url);
+			return url.includes('/pages?') ? { value: pages } : 'content';
+		},
+		processFile: async () => {},
+	} as unknown as Partial<OneNoteImporter>);
+
+	await subject.import(new ImportContext());
+
+	assert.deepEqual(listed, [], 'the cached list should be used as it stands');
+});
+
+test('a section missed by the read-ahead is still fetched by the import', async () => {
+	const listed: string[] = [];
+	const pages = [{ id: 'p', title: 'P', contentUrl: 'page-id=p}' }] as OnenotePage[];
+
+	const subject = importerOverPages([], {
+		sectionPages: new Map(),
+		fetchResource: async (url: string) => {
+			if (url.includes('/pages?')) listed.push(url);
+			return url.includes('/pages?') ? { value: pages } : 'content';
+		},
+		processFile: async () => {},
+	} as unknown as Partial<OneNoteImporter>);
+
+	await subject.import(new ImportContext());
+
+	assert.equal(listed.length, 1, 'a read-ahead that failed or never ran must not lose the section');
+	// $ arrives percent-encoded, the way every other parameter here already does.
+	assert.match(listed[0], /%24top=100/, 'and asks for more than the default 20 a time');
 });
 
 test('a vault that will not take the write does stop the import', async () => {

--- a/tests/onenote/import.test.ts
+++ b/tests/onenote/import.test.ts
@@ -235,6 +235,57 @@ test('signing out forgets which kind of account it was', () => {
 		'the next account is asked for the scopes it can actually consent to');
 });
 
+test('a rejected stored token also forgets the previous account', async () => {
+	const stored = new Map<string, unknown>([['onenote-importer-account-type', 'organization']]);
+	const secrets = new Map([['onenote-importer', 'expired-token']]);
+	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
+
+	Object.assign(subject, {
+		app: {
+			loadLocalStorage: (key: string) => stored.get(key) ?? null,
+			saveLocalStorage: (key: string, value: unknown) =>
+				void (value === null ? stored.delete(key) : stored.set(key, value)),
+			secretStorage: {
+				getSecret: (key: string) => secrets.get(key) ?? null,
+				deleteSecret: (key: string) => void secrets.delete(key),
+			},
+		},
+		updateAccessToken: async () => { throw { status: 400 }; },
+	});
+
+	const signedIn = await (subject as unknown as { signInWithStoredToken(): Promise<boolean> })
+		.signInWithStoredToken();
+
+	assert.equal(signedIn, false);
+	assert.equal(secrets.has('onenote-importer'), false);
+	assert.equal(stored.has('onenote-importer-account-type'), false);
+});
+
+test('a temporary stored-token failure keeps the account available for retry', async () => {
+	const stored = new Map<string, unknown>([['onenote-importer-account-type', 'organization']]);
+	const secrets = new Map([['onenote-importer', 'refresh-token']]);
+	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
+
+	Object.assign(subject, {
+		app: {
+			loadLocalStorage: (key: string) => stored.get(key) ?? null,
+			saveLocalStorage: (key: string, value: unknown) => void stored.set(key, value),
+			secretStorage: {
+				getSecret: (key: string) => secrets.get(key) ?? null,
+				deleteSecret: (key: string) => void secrets.delete(key),
+			},
+		},
+		updateAccessToken: async () => { throw { status: 503 }; },
+	});
+
+	const signedIn = await (subject as unknown as { signInWithStoredToken(): Promise<boolean> })
+		.signInWithStoredToken();
+
+	assert.equal(signedIn, false);
+	assert.equal(secrets.get('onenote-importer'), 'refresh-token');
+	assert.equal(stored.get('onenote-importer-account-type'), 'organization');
+});
+
 test('counting says which section it is in and how much it has found', () => {
 	assert.equal(findingNotes('Recipes', 0, 1), 'Finding notes in Recipes');
 	assert.equal(findingNotes('Recipes', 0, 7), 'Finding notes in Recipes (section 1 of 7)');

--- a/tests/onenote/import.test.ts
+++ b/tests/onenote/import.test.ts
@@ -20,7 +20,6 @@ function importerOverPages(pages: OnenotePage[], overrides: Partial<OneNoteImpor
 	Object.assign(subject, {
 		selectedSections: [{ id: 'section', title: 'Section' }],
 		notebooks: [],
-		// Object.create skips the field initialisers the constructor would run.
 		sectionPages: new Map(),
 		readingAhead: new Map(),
 		readAheadQueue: Promise.resolve(),
@@ -62,8 +61,6 @@ test('pages that will not convert are reported without ending the import', async
 });
 
 test('the total is the whole import from the first note, not one section at a time', async () => {
-	// Counting as it went meant the bar filled up on the first section and
-	// jumped backwards each time another was opened.
 	const sections = [
 		{ id: 'a', title: 'A', pages: 3 },
 		{ id: 'b', title: 'B', pages: 5 },
@@ -88,21 +85,15 @@ test('the total is the whole import from the first note, not one section at a ti
 
 	await subject.import(progress);
 
-	// Counting reports a total that climbs while nothing has been imported yet,
-	// so the remaining count fills in as the sections come in.
 	const counting = reports.filter(([current]) => current === 0).map(([, total]) => total);
 	assert.deepEqual(counting, [3, 8, 10, 10], 'the total should grow with each section read');
 
-	// Once a note has been imported the total is settled: a total that grew
-	// from there is what made the bar fill up and then jump backwards.
 	const importing = reports.filter(([current]) => current > 0);
 	assert.deepEqual([...new Set(importing.map(([, total]) => total))], [10]);
 	assert.deepEqual(importing.map(([current]) => current), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 });
 
 test('page lists read ahead of the import are not fetched twice', async () => {
-	// The point of reading ahead while the later steps are filled in is that
-	// the import then starts on what it already has.
 	const listed: string[] = [];
 	const pages = [{ id: 'p', title: 'P', contentUrl: 'page-id=p}' }] as OnenotePage[];
 
@@ -136,19 +127,15 @@ test('a section missed by the read-ahead is still fetched by the import', async 
 	await subject.import(new ImportContext());
 
 	assert.equal(listed.length, 1, 'a read-ahead that failed or never ran must not lose the section');
-	// $ arrives percent-encoded, the way every other parameter here already does.
 	assert.match(listed[0], /%24top=100/, 'and asks for more than the default 20 a time');
 });
 
 test('unticking a section drops it from the read-ahead queue', async () => {
-	// Sections are read one at a time, so most of a large selection is still
-	// waiting its turn. Changing your mind has to call that work off.
 	const listed: string[] = [];
 	let releaseFirst: () => void = () => {};
 	const firstInFlight = new Promise<void>(resolve => { releaseFirst = resolve; });
 
 	const subject = importerOverPages([], {
-		// signedIn is a getter with no setter; graphData is what it reads.
 		sectionPages: new Map(),
 		selectedSections: [
 			{ id: 'a', title: 'A' }, { id: 'b', title: 'B' }, { id: 'c', title: 'C' },
@@ -163,7 +150,6 @@ test('unticking a section drops it from the read-ahead queue', async () => {
 
 	(subject as unknown as { prefetchSelectedPages(): void }).prefetchSelectedPages();
 
-	// While A is still in flight, B and C are unticked.
 	subject.selectedSections = [{ id: 'a', title: 'A' }] as OneNoteImporter['selectedSections'];
 	releaseFirst();
 	await (subject as unknown as { readAheadQueue: Promise<void> }).readAheadQueue;
@@ -172,16 +158,12 @@ test('unticking a section drops it from the read-ahead queue', async () => {
 });
 
 test('counting says which section it is in and how much it has found', () => {
-	// One section is not "section 1 of 1"; how many notes have turned up is
-	// the remaining count's job, not this one's.
 	assert.equal(findingNotes('Recipes', 0, 1), 'Finding notes in Recipes');
 	assert.equal(findingNotes('Recipes', 0, 7), 'Finding notes in Recipes (section 1 of 7)');
 	assert.equal(findingNotes('Recipes', 2, 7), 'Finding notes in Recipes (section 3 of 7)');
 });
 
 test('the count carries on climbing through sections read ahead', async () => {
-	// Reporting only the sections still to be read left the phase silent
-	// whenever the read-ahead had already done its job.
 	const said: string[] = [];
 	const progress = new ImportContext();
 	progress.status = (message: string) => void said.push(message);
@@ -192,7 +174,6 @@ test('the count carries on climbing through sections read ahead', async () => {
 
 	const subject = importerOverPages([], {
 		selectedSections: [{ id: 'a', title: 'A' }, { id: 'b', title: 'B' }],
-		// Both already read ahead, so nothing is fetched during the import.
 		sectionPages: new Map([['a', pagesOf('a', 3)], ['b', pagesOf('b', 4)]]),
 		fetchResource: async () => 'content',
 		processFile: async () => {},

--- a/tests/onenote/import.test.ts
+++ b/tests/onenote/import.test.ts
@@ -6,10 +6,51 @@ import type { OnenotePage } from '@microsoft/microsoft-graph-types';
 
 import { OneNoteImporter } from '../../src/formats/onenote';
 import { ImportContext } from '../../src/import-context';
+import { DuplicateHandling } from '../../src/format-importer';
 
 test('a malformed page is not swallowed before the import can report it', async () => {
 	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
 	const page = { id: 'page', title: 'Broken page' } as OnenotePage;
 
 	await assert.rejects(subject.processFile(new ImportContext(), 'not multipart', page), /input string is incorrect/);
+});
+
+/**
+ * The consecutive-failure counter is there to notice the API going out from
+ * under an import — it stops the run and reports every page after it skipped.
+ * Pages that simply will not convert must not reach it: they are one bad page
+ * each, and six of them in a row used to end a working import.
+ */
+test('pages that will not convert are reported without ending the import', async () => {
+	const pages: OnenotePage[] = Array.from({ length: 8 }, (_, i) => ({
+		id: `page-${i}`, title: `Page ${i}`, contentUrl: `page-id=page-${i}}`,
+	}));
+
+	const failed: string[] = [];
+	const skipped: string[] = [];
+	const progress = new ImportContext();
+	progress.reportFailed = (name: string) => void failed.push(name);
+	progress.reportSkipped = (name: string) => void skipped.push(name);
+
+	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
+	Object.assign(subject, {
+		selectedSections: [{ id: 'section', title: 'Section' }],
+		notebooks: [],
+		graphData: { accessToken: 'token' },
+		duplicateHandling: DuplicateHandling.CreateCopy,
+		legacyImportedIds: new Set<string>(),
+		host: { plugin: null, abortController: new AbortController() },
+		readLegacyImportedIds: async () => {},
+		getOutputFolder: async () => ({ name: 'OneNote', path: 'OneNote' }),
+		insertPagesToSection: () => {},
+		fetchResource: async (url: string) => url.includes('/pages?') ? { value: pages } : 'content',
+		// Every page converts badly, the way a whole section exported from one
+		// source would.
+		processFile: async () => { throw new Error('could not convert'); },
+	});
+
+	await subject.import(progress);
+
+	assert.deepEqual(failed, pages.map(page => page.title));
+	assert.deepEqual(skipped, [], 'no page should be abandoned as collateral');
 });

--- a/tests/onenote/import.test.ts
+++ b/tests/onenote/import.test.ts
@@ -15,15 +15,6 @@ test('a malformed page is not swallowed before the import can report it', async 
 	await assert.rejects(subject.processFile(new ImportContext(), 'not multipart', page), /input string is incorrect/);
 });
 
-/**
- * The consecutive-failure counter is there to notice something failing the
- * same way for every page — the API going out from under the import, a vault
- * that will not take a write. It stops the run and reports the rest skipped.
- *
- * A page its own content defeated is not that, and six of those in a row used
- * to end a working import. Telling the two apart is the whole point, so both
- * directions are checked.
- */
 function importerOverPages(pages: OnenotePage[], overrides: Partial<OneNoteImporter>): OneNoteImporter {
 	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
 	Object.assign(subject, {
@@ -56,8 +47,6 @@ const eightPages: OnenotePage[] = Array.from({ length: 8 }, (_, i) => ({
 test('pages that will not convert are reported without ending the import', async () => {
 	const { progress, failed, skipped } = watchedContext();
 
-	// Not a stub for processFile: the real one is left to reject the content,
-	// so what is under test is that it classifies it as the page's own problem.
 	const subject = importerOverPages(eightPages, {
 		fetchResource: async (url: string) => url.includes('/pages?')
 			? { value: eightPages }
@@ -73,8 +62,6 @@ test('pages that will not convert are reported without ending the import', async
 test('a vault that will not take the write does stop the import', async () => {
 	const { progress, failed, skipped } = watchedContext();
 
-	// A full disk, or a folder that cannot be created, fails the same way for
-	// every page after it — which is exactly what the counter is watching for.
 	const subject = importerOverPages(eightPages, {
 		fetchResource: async (url: string) => url.includes('/pages?') ? { value: eightPages } : 'content',
 		processFile: async () => { throw new Error('ENOSPC: no space left on device'); },

--- a/tests/onenote/import.test.ts
+++ b/tests/onenote/import.test.ts
@@ -23,6 +23,7 @@ function importerOverPages(pages: OnenotePage[], overrides: Partial<OneNoteImpor
 		sectionPages: new Map(),
 		readingAhead: new Map(),
 		readAheadQueue: Promise.resolve(),
+		pagesGeneration: 0,
 		graphData: { accessToken: 'token' },
 		duplicateHandling: DuplicateHandling.CreateCopy,
 		host: { plugin: null, abortController: new AbortController() },
@@ -155,6 +156,83 @@ test('unticking a section drops it from the read-ahead queue', async () => {
 	await (subject as unknown as { readAheadQueue: Promise<void> }).readAheadQueue;
 
 	assert.deepEqual(listed, ['a'], 'only the section already being read should have been asked for');
+});
+
+test('reloading the notebooks reads the page lists again', async () => {
+	const listed: string[] = [];
+	const pages = [{ id: 'p', title: 'P', contentUrl: 'page-id=p}' }] as OnenotePage[];
+
+	const subject = importerOverPages([], {
+		sectionPages: new Map([['section', pages]]),
+		fetchResource: async (url: string) => {
+			if (url.includes('/pages?')) listed.push(url);
+			return url.includes('/pages?') ? { value: pages } : 'content';
+		},
+		processFile: async () => {},
+		picker: { load: async (read: () => Promise<unknown>) => void await read() },
+		readNotebooks: async () => [],
+	} as unknown as Partial<OneNoteImporter>);
+
+	await subject.showSectionPickerUI();
+	await subject.import(new ImportContext());
+
+	assert.equal(listed.length, 1, 'a list read before the reload no longer describes the section');
+});
+
+test('a read still in flight when the notebooks reload is not taken as the answer', async () => {
+	let releaseFirst: () => void = () => {};
+	const firstInFlight = new Promise<void>(resolve => { releaseFirst = resolve; });
+	const stale = [{ id: 'stale', title: 'Stale', contentUrl: 'page-id=stale}' }] as OnenotePage[];
+
+	const subject = importerOverPages([], {
+		sectionPages: new Map(),
+		fetchResource: async (url: string) => {
+			if (!url.includes('/pages?')) return 'content';
+			await firstInFlight;
+			return { value: stale };
+		},
+		picker: { load: async (read: () => Promise<unknown>) => void await read() },
+		readNotebooks: async () => [],
+	} as unknown as Partial<OneNoteImporter>);
+
+	const inner = subject as unknown as { prefetchSelectedPages(): void, readAheadQueue: Promise<void> };
+
+	inner.prefetchSelectedPages();
+	await subject.showSectionPickerUI();
+	releaseFirst();
+	await inner.readAheadQueue;
+
+	const cached = (subject as unknown as { sectionPages: Map<string, OnenotePage[]> }).sectionPages;
+	assert.equal(cached.size, 0, 'the reload disowned the read that was already running');
+});
+
+test('signing out forgets which kind of account it was', () => {
+	const stored = new Map<string, unknown>([['onenote-importer-account-type', 'organization']]);
+
+	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
+	Object.assign(subject, {
+		app: {
+			loadLocalStorage: (key: string) => stored.get(key) ?? null,
+			saveLocalStorage: (key: string, value: unknown) =>
+				void (value === null ? stored.delete(key) : stored.set(key, value)),
+			secretStorage: { deleteSecret: () => {} },
+		},
+		graphData: { accessToken: 'token' },
+		sectionPages: new Map(),
+		readingAhead: new Map(),
+		pagesGeneration: 0,
+		picker: { reset: () => {} },
+		accountSetting: { setDesc: () => {} },
+		accountButton: {
+			setButtonText: () => ({ setCta: () => {} }),
+			buttonEl: { removeClass: () => {} },
+		},
+	});
+
+	(subject as unknown as { signOut(): void }).signOut();
+
+	assert.equal(stored.has('onenote-importer-account-type'), false,
+		'the next account is asked for the scopes it can actually consent to');
 });
 
 test('counting says which section it is in and how much it has found', () => {

--- a/tests/onenote/import.test.ts
+++ b/tests/onenote/import.test.ts
@@ -1,0 +1,15 @@
+import '../shims/runtime';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { OnenotePage } from '@microsoft/microsoft-graph-types';
+
+import { OneNoteImporter } from '../../src/formats/onenote';
+import { ImportContext } from '../../src/import-context';
+
+test('a malformed page is not swallowed before the import can report it', async () => {
+	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
+	const page = { id: 'page', title: 'Broken page' } as OnenotePage;
+
+	await assert.rejects(subject.processFile(new ImportContext(), 'not multipart', page), /input string is incorrect/);
+});

--- a/tests/onenote/import.test.ts
+++ b/tests/onenote/import.test.ts
@@ -172,12 +172,11 @@ test('unticking a section drops it from the read-ahead queue', async () => {
 });
 
 test('counting says which section it is in and how much it has found', () => {
-	// Neither number is worth saying before it means anything: one section is
-	// not "1 of 1", and nothing found yet is not "0 notes so far".
-	assert.equal(findingNotes('Recipes', 0, 1, 0), 'Finding notes in Recipes');
-	assert.equal(findingNotes('Recipes', 0, 7, 0), 'Finding notes in Recipes (section 1 of 7)');
-	assert.equal(findingNotes('Recipes', 2, 7, 240), 'Finding notes in Recipes (section 3 of 7, 240 notes so far)');
-	assert.equal(findingNotes('Recipes', 1, 1, 1), 'Finding notes in Recipes (1 note so far)');
+	// One section is not "section 1 of 1"; how many notes have turned up is
+	// the remaining count's job, not this one's.
+	assert.equal(findingNotes('Recipes', 0, 1), 'Finding notes in Recipes');
+	assert.equal(findingNotes('Recipes', 0, 7), 'Finding notes in Recipes (section 1 of 7)');
+	assert.equal(findingNotes('Recipes', 2, 7), 'Finding notes in Recipes (section 3 of 7)');
 });
 
 test('the count carries on climbing through sections read ahead', async () => {
@@ -202,7 +201,7 @@ test('the count carries on climbing through sections read ahead', async () => {
 	await subject.import(progress);
 
 	assert.ok(said.includes('Finding notes in A (section 1 of 2)'), said.join(' | '));
-	assert.ok(said.includes('Finding notes in B (section 2 of 2, 3 notes so far)'), said.join(' | '));
+	assert.ok(said.includes('Finding notes in B (section 2 of 2)'), said.join(' | '));
 });
 
 test('a vault that will not take the write does stop the import', async () => {

--- a/tests/onenote/import.test.ts
+++ b/tests/onenote/import.test.ts
@@ -22,9 +22,7 @@ function importerOverPages(pages: OnenotePage[], overrides: Partial<OneNoteImpor
 		notebooks: [],
 		graphData: { accessToken: 'token' },
 		duplicateHandling: DuplicateHandling.CreateCopy,
-		legacyImportedIds: new Set<string>(),
 		host: { plugin: null, abortController: new AbortController() },
-		readLegacyImportedIds: async () => {},
 		getOutputFolder: async () => ({ name: 'OneNote', path: 'OneNote' }),
 		insertPagesToSection: () => {},
 	}, overrides);

--- a/tests/onenote/import.test.ts
+++ b/tests/onenote/import.test.ts
@@ -22,7 +22,8 @@ function importerOverPages(pages: OnenotePage[], overrides: Partial<OneNoteImpor
 		notebooks: [],
 		// Object.create skips the field initialisers the constructor would run.
 		sectionPages: new Map(),
-		prefetching: Promise.resolve(),
+		readingAhead: new Map(),
+		readAheadQueue: Promise.resolve(),
 		graphData: { accessToken: 'token' },
 		duplicateHandling: DuplicateHandling.CreateCopy,
 		host: { plugin: null, abortController: new AbortController() },
@@ -72,9 +73,9 @@ test('the total is the whole import from the first note, not one section at a ti
 		id: `${id}-${i}`, title: `${id} ${i}`, contentUrl: `page-id=${id}-${i}}`,
 	}));
 
-	const totals: number[] = [];
+	const reports: Array<[number, number]> = [];
 	const progress = new ImportContext();
-	progress.reportProgress = (_current: number, total: number) => void totals.push(total);
+	progress.reportProgress = (current: number, total: number) => void reports.push([current, total]);
 
 	const subject = importerOverPages([], {
 		selectedSections: sections.map(s => ({ id: s.id, title: s.title })),
@@ -87,8 +88,16 @@ test('the total is the whole import from the first note, not one section at a ti
 
 	await subject.import(progress);
 
-	assert.deepEqual([...new Set(totals)], [10], 'one total throughout, and it is every page');
-	assert.equal(totals.length, 11, 'reported once up front and once per page');
+	// Counting reports a total that climbs while nothing has been imported yet,
+	// so the remaining count fills in as the sections come in.
+	const counting = reports.filter(([current]) => current === 0).map(([, total]) => total);
+	assert.deepEqual(counting, [3, 8, 10, 10], 'the total should grow with each section read');
+
+	// Once a note has been imported the total is settled: a total that grew
+	// from there is what made the bar fill up and then jump backwards.
+	const importing = reports.filter(([current]) => current > 0);
+	assert.deepEqual([...new Set(importing.map(([, total]) => total))], [10]);
+	assert.deepEqual(importing.map(([current]) => current), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 });
 
 test('page lists read ahead of the import are not fetched twice', async () => {
@@ -157,7 +166,7 @@ test('unticking a section drops it from the read-ahead queue', async () => {
 	// While A is still in flight, B and C are unticked.
 	subject.selectedSections = [{ id: 'a', title: 'A' }] as OneNoteImporter['selectedSections'];
 	releaseFirst();
-	await (subject as unknown as { prefetching: Promise<void> }).prefetching;
+	await (subject as unknown as { readAheadQueue: Promise<void> }).readAheadQueue;
 
 	assert.deepEqual(listed, ['a'], 'only the section already being read should have been asked for');
 });

--- a/tests/onenote/import.test.ts
+++ b/tests/onenote/import.test.ts
@@ -4,7 +4,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import type { OnenotePage } from '@microsoft/microsoft-graph-types';
 
-import { OneNoteImporter } from '../../src/formats/onenote';
+import { findingNotes, OneNoteImporter } from '../../src/formats/onenote';
 import { ImportContext } from '../../src/import-context';
 import { DuplicateHandling } from '../../src/format-importer';
 
@@ -160,6 +160,40 @@ test('unticking a section drops it from the read-ahead queue', async () => {
 	await (subject as unknown as { prefetching: Promise<void> }).prefetching;
 
 	assert.deepEqual(listed, ['a'], 'only the section already being read should have been asked for');
+});
+
+test('counting says which section it is in and how much it has found', () => {
+	// Neither number is worth saying before it means anything: one section is
+	// not "1 of 1", and nothing found yet is not "0 notes so far".
+	assert.equal(findingNotes('Recipes', 0, 1, 0), 'Finding notes in Recipes');
+	assert.equal(findingNotes('Recipes', 0, 7, 0), 'Finding notes in Recipes (section 1 of 7)');
+	assert.equal(findingNotes('Recipes', 2, 7, 240), 'Finding notes in Recipes (section 3 of 7, 240 notes so far)');
+	assert.equal(findingNotes('Recipes', 1, 1, 1), 'Finding notes in Recipes (1 note so far)');
+});
+
+test('the count carries on climbing through sections read ahead', async () => {
+	// Reporting only the sections still to be read left the phase silent
+	// whenever the read-ahead had already done its job.
+	const said: string[] = [];
+	const progress = new ImportContext();
+	progress.status = (message: string) => void said.push(message);
+
+	const pagesOf = (id: string, n: number): OnenotePage[] => Array.from({ length: n }, (_, i) => ({
+		id: `${id}-${i}`, title: `${id} ${i}`, contentUrl: `page-id=${id}-${i}}`,
+	}));
+
+	const subject = importerOverPages([], {
+		selectedSections: [{ id: 'a', title: 'A' }, { id: 'b', title: 'B' }],
+		// Both already read ahead, so nothing is fetched during the import.
+		sectionPages: new Map([['a', pagesOf('a', 3)], ['b', pagesOf('b', 4)]]),
+		fetchResource: async () => 'content',
+		processFile: async () => {},
+	} as unknown as Partial<OneNoteImporter>);
+
+	await subject.import(progress);
+
+	assert.ok(said.includes('Finding notes in A (section 1 of 2)'), said.join(' | '));
+	assert.ok(said.includes('Finding notes in B (section 2 of 2, 3 notes so far)'), said.join(' | '));
 });
 
 test('a vault that will not take the write does stop the import', async () => {

--- a/tests/onenote/import.test.ts
+++ b/tests/onenote/import.test.ts
@@ -57,6 +57,37 @@ test('pages that will not convert are reported without ending the import', async
 	assert.deepEqual(skipped, [], 'no page should be abandoned as collateral');
 });
 
+test('the total is the whole import from the first note, not one section at a time', async () => {
+	// Counting as it went meant the bar filled up on the first section and
+	// jumped backwards each time another was opened.
+	const sections = [
+		{ id: 'a', title: 'A', pages: 3 },
+		{ id: 'b', title: 'B', pages: 5 },
+		{ id: 'c', title: 'C', pages: 2 },
+	];
+	const pagesOf = (id: string, n: number): OnenotePage[] => Array.from({ length: n }, (_, i) => ({
+		id: `${id}-${i}`, title: `${id} ${i}`, contentUrl: `page-id=${id}-${i}}`,
+	}));
+
+	const totals: number[] = [];
+	const progress = new ImportContext();
+	progress.reportProgress = (_current: number, total: number) => void totals.push(total);
+
+	const subject = importerOverPages([], {
+		selectedSections: sections.map(s => ({ id: s.id, title: s.title })),
+		fetchResource: async (url: string) => {
+			const section = sections.find(s => url.includes(`/sections/${s.id}/pages`));
+			return section ? { value: pagesOf(section.id, section.pages) } : 'content';
+		},
+		processFile: async () => {},
+	} as unknown as Partial<OneNoteImporter>);
+
+	await subject.import(progress);
+
+	assert.deepEqual([...new Set(totals)], [10], 'one total throughout, and it is every page');
+	assert.equal(totals.length, 11, 'reported once up front and once per page');
+});
+
 test('a vault that will not take the write does stop the import', async () => {
 	const { progress, failed, skipped } = watchedContext();
 

--- a/tests/onenote/import.test.ts
+++ b/tests/onenote/import.test.ts
@@ -16,22 +16,15 @@ test('a malformed page is not swallowed before the import can report it', async 
 });
 
 /**
- * The consecutive-failure counter is there to notice the API going out from
- * under an import — it stops the run and reports every page after it skipped.
- * Pages that simply will not convert must not reach it: they are one bad page
- * each, and six of them in a row used to end a working import.
+ * The consecutive-failure counter is there to notice something failing the
+ * same way for every page — the API going out from under the import, a vault
+ * that will not take a write. It stops the run and reports the rest skipped.
+ *
+ * A page its own content defeated is not that, and six of those in a row used
+ * to end a working import. Telling the two apart is the whole point, so both
+ * directions are checked.
  */
-test('pages that will not convert are reported without ending the import', async () => {
-	const pages: OnenotePage[] = Array.from({ length: 8 }, (_, i) => ({
-		id: `page-${i}`, title: `Page ${i}`, contentUrl: `page-id=page-${i}}`,
-	}));
-
-	const failed: string[] = [];
-	const skipped: string[] = [];
-	const progress = new ImportContext();
-	progress.reportFailed = (name: string) => void failed.push(name);
-	progress.reportSkipped = (name: string) => void skipped.push(name);
-
+function importerOverPages(pages: OnenotePage[], overrides: Partial<OneNoteImporter>): OneNoteImporter {
 	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
 	Object.assign(subject, {
 		selectedSections: [{ id: 'section', title: 'Section' }],
@@ -43,14 +36,52 @@ test('pages that will not convert are reported without ending the import', async
 		readLegacyImportedIds: async () => {},
 		getOutputFolder: async () => ({ name: 'OneNote', path: 'OneNote' }),
 		insertPagesToSection: () => {},
-		fetchResource: async (url: string) => url.includes('/pages?') ? { value: pages } : 'content',
-		// Every page converts badly, the way a whole section exported from one
-		// source would.
-		processFile: async () => { throw new Error('could not convert'); },
-	});
+	}, overrides);
+	return subject;
+}
+
+function watchedContext(): { progress: ImportContext, failed: string[], skipped: string[] } {
+	const failed: string[] = [];
+	const skipped: string[] = [];
+	const progress = new ImportContext();
+	progress.reportFailed = (name: string) => void failed.push(name);
+	progress.reportSkipped = (name: string) => void skipped.push(name);
+	return { progress, failed, skipped };
+}
+
+const eightPages: OnenotePage[] = Array.from({ length: 8 }, (_, i) => ({
+	id: `page-${i}`, title: `Page ${i}`, contentUrl: `page-id=page-${i}}`,
+}));
+
+test('pages that will not convert are reported without ending the import', async () => {
+	const { progress, failed, skipped } = watchedContext();
+
+	// Not a stub for processFile: the real one is left to reject the content,
+	// so what is under test is that it classifies it as the page's own problem.
+	const subject = importerOverPages(eightPages, {
+		fetchResource: async (url: string) => url.includes('/pages?')
+			? { value: eightPages }
+			: 'not a multipart document',
+	} as Partial<OneNoteImporter>);
 
 	await subject.import(progress);
 
-	assert.deepEqual(failed, pages.map(page => page.title));
+	assert.deepEqual(failed, eightPages.map(page => page.title));
 	assert.deepEqual(skipped, [], 'no page should be abandoned as collateral');
+});
+
+test('a vault that will not take the write does stop the import', async () => {
+	const { progress, failed, skipped } = watchedContext();
+
+	// A full disk, or a folder that cannot be created, fails the same way for
+	// every page after it — which is exactly what the counter is watching for.
+	const subject = importerOverPages(eightPages, {
+		fetchResource: async (url: string) => url.includes('/pages?') ? { value: eightPages } : 'content',
+		processFile: async () => { throw new Error('ENOSPC: no space left on device'); },
+	} as Partial<OneNoteImporter>);
+
+	await subject.import(progress);
+
+	assert.equal(failed.length, 6, 'stops once six in a row have failed the same way');
+	assert.equal(skipped.length, 2, 'and says what it gave up on');
 });

--- a/tests/onenote/import.test.ts
+++ b/tests/onenote/import.test.ts
@@ -53,7 +53,7 @@ test('pages that will not convert are reported without ending the import', async
 		fetchResource: async (url: string) => url.includes('/pages?')
 			? { value: eightPages }
 			: 'not a multipart document',
-	} as Partial<OneNoteImporter>);
+	} as unknown as Partial<OneNoteImporter>);
 
 	await subject.import(progress);
 
@@ -269,7 +269,7 @@ test('a vault that will not take the write does stop the import', async () => {
 	const subject = importerOverPages(eightPages, {
 		fetchResource: async (url: string) => url.includes('/pages?') ? { value: eightPages } : 'content',
 		processFile: async () => { throw new Error('ENOSPC: no space left on device'); },
-	} as Partial<OneNoteImporter>);
+	} as unknown as Partial<OneNoteImporter>);
 
 	await subject.import(progress);
 

--- a/tests/onenote/import.test.ts
+++ b/tests/onenote/import.test.ts
@@ -131,6 +131,37 @@ test('a section missed by the read-ahead is still fetched by the import', async 
 	assert.match(listed[0], /%24top=100/, 'and asks for more than the default 20 a time');
 });
 
+test('unticking a section drops it from the read-ahead queue', async () => {
+	// Sections are read one at a time, so most of a large selection is still
+	// waiting its turn. Changing your mind has to call that work off.
+	const listed: string[] = [];
+	let releaseFirst: () => void = () => {};
+	const firstInFlight = new Promise<void>(resolve => { releaseFirst = resolve; });
+
+	const subject = importerOverPages([], {
+		// signedIn is a getter with no setter; graphData is what it reads.
+		sectionPages: new Map(),
+		selectedSections: [
+			{ id: 'a', title: 'A' }, { id: 'b', title: 'B' }, { id: 'c', title: 'C' },
+		],
+		fetchResource: async (url: string) => {
+			const id = /sections\/([^/]+)\//.exec(url)?.[1] ?? '';
+			listed.push(id);
+			if (id === 'a') await firstInFlight;
+			return { value: [] };
+		},
+	} as unknown as Partial<OneNoteImporter>);
+
+	(subject as unknown as { prefetchSelectedPages(): void }).prefetchSelectedPages();
+
+	// While A is still in flight, B and C are unticked.
+	subject.selectedSections = [{ id: 'a', title: 'A' }] as OneNoteImporter['selectedSections'];
+	releaseFirst();
+	await (subject as unknown as { prefetching: Promise<void> }).prefetching;
+
+	assert.deepEqual(listed, ['a'], 'only the section already being read should have been asked for');
+});
+
 test('a vault that will not take the write does stop the import', async () => {
 	const { progress, failed, skipped } = watchedContext();
 

--- a/tests/onenote/retry.test.ts
+++ b/tests/onenote/retry.test.ts
@@ -1,0 +1,159 @@
+/**
+ * How fetchResource decides between asking again and giving up.
+ *
+ * All of this was verified by hand against a stubbed Graph, which is how the
+ * bugs in it were found and also why they were found late. What each case
+ * asserts is the request count as much as the message: the point of failing
+ * fast on a refusal is that it does not spend five round trips first, and the
+ * point of keeping the retry for a bare 400 is that it does.
+ */
+import '../shims/runtime';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { OneNoteImporter } from '../../src/formats/onenote';
+import { ImportContext } from '../../src/import-context';
+
+const URL = 'https://graph.microsoft.com/v1.0/me/onenote/notebooks';
+
+interface Answer {
+	status: number;
+	body?: unknown;
+	raw?: string;
+}
+
+/**
+ * Drives fetchResource against a stubbed Graph. Returns how many requests were
+ * made and what came back out, so a test can assert on both.
+ */
+async function fetching(
+	answers: Answer | Answer[],
+	progress?: ImportContext,
+	allowBackOff = false,
+): Promise<{ backOffs: number, calls: number, error: unknown, refreshes: number }> {
+	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
+	const sequence = Array.isArray(answers) ? answers : [answers];
+	let backOffs = 0;
+	let calls = 0;
+	let refreshes = 0;
+
+	Object.assign(subject, {
+		graphData: { accessToken: 'token' },
+		host: { abortController: new AbortController() },
+		lastSuccessfulFetchTime: performance.now(),
+		updateAccessToken: async () => { refreshes++; },
+		backOff: async () => {
+			backOffs++;
+			if (!allowBackOff) throw new Error('backed off during a test');
+		},
+	});
+
+	const realFetch = globalThis.fetch;
+	globalThis.fetch = (async () => {
+		const answer = sequence[Math.min(calls, sequence.length - 1)];
+		calls++;
+		const body = answer.raw ?? JSON.stringify(answer.body ?? {});
+		return new Response(body, {
+			status: answer.status,
+			headers: { 'Content-Type': answer.raw === undefined ? 'application/json' : 'text/html' },
+		});
+	}) as typeof fetch;
+
+	let error: unknown = null;
+	try {
+		await subject.fetchResource(URL, 'json', progress);
+	}
+	catch (e) {
+		error = e;
+	}
+	finally {
+		globalThis.fetch = realFetch;
+	}
+
+	return { backOffs, calls, error, refreshes };
+}
+
+const graph = (code: string, message = '') => ({ error: { code, message } });
+
+test('a refusal is not asked again', async () => {
+	// 403 and 404 are decisions. Retrying them spends the time and then
+	// replaces what Graph said with 'Exceeded maximum retry attempts'.
+	for (const status of [403, 404]) {
+		const { calls } = await fetching({ status, body: graph('40004') });
+		assert.equal(calls, 1, `for ${status}`);
+	}
+});
+
+test('40004 refuses whatever status carries it', async () => {
+	// The scope failure behind #440 has been reported with more than one.
+	const { calls, error } = await fetching({ status: 400, body: graph('40004', 'no scopes') });
+
+	assert.equal(calls, 1);
+	assert.equal((error as { code?: string }).code, '40004');
+});
+
+test('a bare 400 is still retried', async () => {
+	// OneNote answers page requests with these, and they usually clear.
+	// Narrowing retries to 408/429/5xx had quietly dropped this.
+	const { calls } = await fetching({ status: 400, body: graph('19999') });
+
+	assert.equal(calls, 5);
+});
+
+test('an outage is retried, and reports the outage rather than the retrying', async () => {
+	const { calls, error } = await fetching({ status: 503, body: graph('UnknownError') });
+
+	assert.equal(calls, 5);
+	assert.equal((error as { status?: number }).status, 503);
+});
+
+test('a 401 refreshes once and then refuses', async () => {
+	// Refreshing is the whole remedy, so a 401 that survives it is the account
+	// not being allowed to read this — worth saying instead of retrying into
+	// 'Exceeded maximum retry attempts'.
+	const { calls, error, refreshes } = await fetching({ status: 401, body: graph('InvalidAuthenticationToken') });
+
+	assert.equal(refreshes, 1);
+	assert.equal(calls, 2);
+	assert.equal((error as { status?: number }).status, 401);
+});
+
+test('throttling refuses at once when there is no import to pace', async () => {
+	// The picker has nothing on screen that waiting helps, so it would sit
+	// silently for a minute an attempt — issue #390. backOff throws in this
+	// harness, so reaching it at all would fail the test.
+	for (const answer of [{ status: 429, body: graph('20166') }, { status: 503, body: graph('20166') }]) {
+		const { calls, error } = await fetching(answer);
+		assert.equal(calls, 1, `for ${answer.status}`);
+		assert.equal((error as { status?: number }).status, 429, `for ${answer.status}`);
+	}
+});
+
+test('throttling waits and retries during an import', async () => {
+	const progress = new ImportContext();
+	const { backOffs, calls, error } = await fetching([
+		{ status: 429, body: graph('20166') },
+		{ status: 200, body: { value: [] } },
+	], progress, true);
+
+	assert.equal(backOffs, 1);
+	assert.equal(calls, 2);
+	assert.equal(error, null);
+});
+
+test('a non-JSON error body still reaches the branch that describes it', async () => {
+	// An empty body, or an HTML page from a proxy, used to reject out of
+	// response.json() and be retried as though the network had failed.
+	const { calls, error } = await fetching({ status: 429, raw: '<html>Too Many Requests</html>' });
+
+	assert.equal(calls, 1);
+	assert.equal((error as { status?: number }).status, 429);
+});
+
+test('an empty body on an outage is retried, not mistaken for something else', async () => {
+	const { calls, error } = await fetching({ status: 503, raw: '' });
+
+	assert.equal(calls, 5);
+	assert.equal((error as { status?: number }).status, 503);
+});

--- a/tests/onenote/retry.test.ts
+++ b/tests/onenote/retry.test.ts
@@ -118,6 +118,45 @@ test('throttling waits and retries during an import', async () => {
 	assert.equal(error, null);
 });
 
+test('attachments run at full speed until OneNote actually throttles', async () => {
+	// A fixed pause every few attachments spent the same minutes whether or not
+	// anything was rate limiting; on a notebook of hundreds that was most of
+	// the import.
+	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
+	const spacing = () => (subject as unknown as { throttleSpacingMs: number }).throttleSpacingMs;
+
+	Object.assign(subject, {
+		throttleSpacingMs: 0,
+		graphData: { accessToken: 'token' },
+		host: { abortController: new AbortController() },
+		lastSuccessfulFetchTime: performance.now(),
+		backOff: async () => {},
+	});
+
+	assert.equal(spacing(), 0, 'nothing to pay before anything has gone wrong');
+
+	// Throttled once, then let through. Answering 429 forever would never
+	// return: during an import the wait is deliberately unbounded.
+	const realFetch = globalThis.fetch;
+	let calls = 0;
+	globalThis.fetch = (async () => {
+		calls++;
+		return calls === 1
+			? new Response(JSON.stringify(graph('20166')), { status: 429, headers: { 'Content-Type': 'application/json' } })
+			: new Response(JSON.stringify({ value: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+	}) as typeof fetch;
+
+	try {
+		await subject.fetchResource(URL, 'json', new ImportContext());
+	}
+	finally {
+		globalThis.fetch = realFetch;
+	}
+
+	assert.ok(spacing() > 0, 'being throttled should slow the downloads down');
+	assert.ok(spacing() <= 3_000, 'but only so far');
+});
+
 test('a non-JSON error body still reaches the branch that describes it', async () => {
 	const { calls, error } = await fetching({ status: 429, raw: '<html>Too Many Requests</html>' });
 

--- a/tests/onenote/retry.test.ts
+++ b/tests/onenote/retry.test.ts
@@ -1,12 +1,3 @@
-/**
- * How fetchResource decides between asking again and giving up.
- *
- * All of this was verified by hand against a stubbed Graph, which is how the
- * bugs in it were found and also why they were found late. What each case
- * asserts is the request count as much as the message: the point of failing
- * fast on a refusal is that it does not spend five round trips first, and the
- * point of keeping the retry for a bare 400 is that it does.
- */
 import '../shims/runtime';
 
 import { test } from 'node:test';
@@ -23,10 +14,6 @@ interface Answer {
 	raw?: string;
 }
 
-/**
- * Drives fetchResource against a stubbed Graph. Returns how many requests were
- * made and what came back out, so a test can assert on both.
- */
 async function fetching(
 	answers: Answer | Answer[],
 	progress?: ImportContext,
@@ -77,8 +64,6 @@ async function fetching(
 const graph = (code: string, message = '') => ({ error: { code, message } });
 
 test('a refusal is not asked again', async () => {
-	// 403 and 404 are decisions. Retrying them spends the time and then
-	// replaces what Graph said with 'Exceeded maximum retry attempts'.
 	for (const status of [403, 404]) {
 		const { calls } = await fetching({ status, body: graph('40004') });
 		assert.equal(calls, 1, `for ${status}`);
@@ -86,7 +71,6 @@ test('a refusal is not asked again', async () => {
 });
 
 test('40004 refuses whatever status carries it', async () => {
-	// The scope failure behind #440 has been reported with more than one.
 	const { calls, error } = await fetching({ status: 400, body: graph('40004', 'no scopes') });
 
 	assert.equal(calls, 1);
@@ -94,8 +78,6 @@ test('40004 refuses whatever status carries it', async () => {
 });
 
 test('a bare 400 is still retried', async () => {
-	// OneNote answers page requests with these, and they usually clear.
-	// Narrowing retries to 408/429/5xx had quietly dropped this.
 	const { calls } = await fetching({ status: 400, body: graph('19999') });
 
 	assert.equal(calls, 5);
@@ -109,9 +91,6 @@ test('an outage is retried, and reports the outage rather than the retrying', as
 });
 
 test('a 401 refreshes once and then refuses', async () => {
-	// Refreshing is the whole remedy, so a 401 that survives it is the account
-	// not being allowed to read this — worth saying instead of retrying into
-	// 'Exceeded maximum retry attempts'.
 	const { calls, error, refreshes } = await fetching({ status: 401, body: graph('InvalidAuthenticationToken') });
 
 	assert.equal(refreshes, 1);
@@ -120,9 +99,6 @@ test('a 401 refreshes once and then refuses', async () => {
 });
 
 test('throttling refuses at once when there is no import to pace', async () => {
-	// The picker has nothing on screen that waiting helps, so it would sit
-	// silently for a minute an attempt — issue #390. backOff throws in this
-	// harness, so reaching it at all would fail the test.
 	for (const answer of [{ status: 429, body: graph('20166') }, { status: 503, body: graph('20166') }]) {
 		const { calls, error } = await fetching(answer);
 		assert.equal(calls, 1, `for ${answer.status}`);
@@ -143,8 +119,6 @@ test('throttling waits and retries during an import', async () => {
 });
 
 test('a non-JSON error body still reaches the branch that describes it', async () => {
-	// An empty body, or an HTML page from a proxy, used to reject out of
-	// response.json() and be retried as though the network had failed.
 	const { calls, error } = await fetching({ status: 429, raw: '<html>Too Many Requests</html>' });
 
 	assert.equal(calls, 1);

--- a/tests/onenote/retry.test.ts
+++ b/tests/onenote/retry.test.ts
@@ -119,9 +119,6 @@ test('throttling waits and retries during an import', async () => {
 });
 
 test('attachments run at full speed until OneNote actually throttles', async () => {
-	// A fixed pause every few attachments spent the same minutes whether or not
-	// anything was rate limiting; on a notebook of hundreds that was most of
-	// the import.
 	const subject = Object.create(OneNoteImporter.prototype) as OneNoteImporter;
 	const spacing = () => (subject as unknown as { throttleSpacingMs: number }).throttleSpacingMs;
 
@@ -135,8 +132,6 @@ test('attachments run at full speed until OneNote actually throttles', async () 
 
 	assert.equal(spacing(), 0, 'nothing to pay before anything has gone wrong');
 
-	// Throttled once, then let through. Answering 429 forever would never
-	// return: during an import the wait is deliberately unbounded.
 	const realFetch = globalThis.fetch;
 	let calls = 0;
 	globalThis.fetch = (async () => {

--- a/tests/shims/vault.ts
+++ b/tests/shims/vault.ts
@@ -125,11 +125,27 @@ export class MemoryVault {
 		return String(this.contents.get(file.path) ?? '');
 	}
 
+	async readBinary(file: { path: string }): Promise<ArrayBuffer> {
+		const content = this.contents.get(file.path);
+		if (!(content instanceof ArrayBuffer)) throw new Error(`${file.path} is not binary`);
+		return content;
+	}
+
 	async modify(file: { path: string }, data: string, options?: DataWriteOptions): Promise<void> {
 		this.contents.set(file.path, data);
 
 		const entry = this.entries.get(normalizePath(file.path).toLowerCase());
 		if (entry instanceof TFile && options) Object.assign(entry.stat, options);
+	}
+
+	async modifyBinary(file: { path: string }, data: ArrayBuffer, options?: DataWriteOptions): Promise<void> {
+		this.contents.set(file.path, data);
+
+		const entry = this.entries.get(normalizePath(file.path).toLowerCase());
+		if (entry instanceof TFile) {
+			entry.stat.size = data.byteLength;
+			if (options) Object.assign(entry.stat, options);
+		}
 	}
 
 	/** The vault refuses a name that is taken rather than picking another. */

--- a/tests/util/request-failure.test.ts
+++ b/tests/util/request-failure.test.ts
@@ -1,0 +1,94 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { describeRequestFailure, requestFailure } from '../../src/request-failure';
+
+const ONENOTE = {
+	name: 'OneNote',
+	subject: 'your notebooks',
+	credential: 'Try signing out and back in.',
+};
+
+test('a status, code and message are taken from the error itself', () => {
+	const failure = requestFailure(Object.assign(new Error('Rate limited'), { status: 429, code: '20166' }));
+
+	assert.deepEqual(failure, { status: 429, code: '20166', message: 'Rate limited' });
+});
+
+test('a Graph error body is read through its error property', () => {
+	const failure = requestFailure({
+		error: {
+			code: '40004',
+			message: 'The OAuth token provided does not have the necessary scopes',
+		},
+	});
+
+	assert.equal(failure.code, '40004');
+	assert.equal(failure.message, 'The OAuth token provided does not have the necessary scopes');
+});
+
+test('a nested message is preferred over the wrapper it arrived in', () => {
+	const failure = requestFailure(Object.assign(new Error('Exceeded maximum retry attempts'), {
+		status: 403,
+		error: { code: '40004', message: 'The OAuth token provided does not have the necessary scopes' },
+	}));
+
+	assert.equal(failure.status, 403);
+	assert.equal(failure.message, 'The OAuth token provided does not have the necessary scopes');
+});
+
+test('an error with nothing on it yields nothing rather than inventing a status', () => {
+	assert.deepEqual(requestFailure(new Error('')), { status: undefined, code: undefined, message: undefined });
+	assert.deepEqual(requestFailure(null), {});
+	assert.deepEqual(requestFailure(undefined), {});
+	assert.deepEqual(requestFailure('Failed to fetch'), { message: 'Failed to fetch' });
+});
+
+test('a status sent as a string is still a status', () => {
+	assert.equal(requestFailure({ status: '503' }).status, 503);
+	assert.equal(requestFailure({ status: '5' }).status, undefined);
+});
+
+test('a rejected credential is described as one, and says what to do', () => {
+	const message = describeRequestFailure({ status: 401 }, ONENOTE);
+
+	assert.equal(message, 'OneNote did not accept the request for your notebooks. Try signing out and back in.');
+});
+
+test('an account without access is not reported as throttling', () => {
+	const message = describeRequestFailure({ status: 403, error: { code: '40004' } }, ONENOTE);
+
+	assert.match(message, /would not give access/);
+	assert.doesNotMatch(message, /limiting how fast/);
+});
+
+test('throttling is described as throttling', () => {
+	const message = describeRequestFailure({ status: 429 }, ONENOTE);
+
+	assert.equal(message, 'OneNote is limiting how fast your notebooks can be read. Wait a few minutes and try again.');
+});
+
+test('a timeout and an outage read differently', () => {
+	assert.match(describeRequestFailure({ status: 504 }, ONENOTE), /took too long/);
+	assert.match(describeRequestFailure({ status: 500 }, ONENOTE), /could not return your notebooks right now/);
+});
+
+test('an unrecognised failure shows what the service said', () => {
+	const message = describeRequestFailure(new Error('Failed to fetch'), ONENOTE);
+
+	assert.equal(message, 'Could not read your notebooks: Failed to fetch');
+});
+
+test('a code travels with the message it explains', () => {
+	const message = describeRequestFailure({ code: 'restricted_resource', message: 'Insufficient permissions' }, {
+		name: 'Notion',
+		subject: 'your pages',
+		credential: 'Check your token.',
+	});
+
+	assert.equal(message, 'Could not read your pages: Insufficient permissions (restricted_resource)');
+});
+
+test('an error carrying nothing at all still names what failed', () => {
+	assert.equal(describeRequestFailure({}, ONENOTE), 'Could not read your notebooks.');
+});

--- a/tests/write/place-attachment.test.ts
+++ b/tests/write/place-attachment.test.ts
@@ -123,3 +123,13 @@ test('two attachments of one name in a single run get a path each', async () => 
 	assert.equal(first.path, 'Photo.png');
 	assert.equal(second.path, 'Photo 1.png');
 });
+
+test('a folder with the requested attachment name is passed over', async () => {
+	const { vault, subject } = importer();
+	await vault.createFolder('Photo.png');
+
+	const { path, reuse } = await subject.place('Photo.png', sized(1));
+
+	assert.equal(path, 'Photo 1.png');
+	assert.equal(reuse, null);
+});

--- a/tests/write/place-attachment.test.ts
+++ b/tests/write/place-attachment.test.ts
@@ -1,0 +1,125 @@
+import '../shims/runtime';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { TFile } from 'obsidian';
+
+import { AttachmentVerdict, DuplicateHandling, FormatImporter } from '../../src/format-importer';
+import { ImportContext } from '../../src/import-context';
+import { MemoryVault, memoryApp } from '../shims/vault';
+
+/** An importer that keeps its attachments in one folder, as the vault default does. */
+class PlacingImporter extends FormatImporter {
+	init(): void {}
+	async import(_ctx: ImportContext): Promise<void> {}
+
+	place(filename: string, recognise: (existing: TFile) => AttachmentVerdict | Promise<AttachmentVerdict>) {
+		return this.placeAttachment(filename, undefined, recognise);
+	}
+}
+
+function importer(duplicateHandling = DuplicateHandling.Update) {
+	const vault = new MemoryVault();
+	const subject = new PlacingImporter(memoryApp(vault), { sourceEl: null, optionsEl: null } as never);
+	subject.duplicateHandling = duplicateHandling;
+	subject.indexImportedNotes();
+
+	return { vault, subject };
+}
+
+/** What OneNote does: a size it asked the service for, against the file on disk. */
+const sized = (size: number) => (existing: TFile): AttachmentVerdict =>
+	existing.stat.size === size ? 'same' : 'another';
+
+test('an attachment another source left behind is not handed to this one', async () => {
+	const { vault, subject } = importer();
+	await vault.createBinary('Document.pdf', new ArrayBuffer(11));
+
+	const { path, reuse } = await subject.place('Document.pdf', sized(22));
+
+	assert.equal(reuse, null, 'a name is not an identity');
+	assert.equal(path, 'Document 1.pdf', 'the other source keeps the file it wrote');
+	assert.equal((vault.contents.get('Document.pdf') as ArrayBuffer).byteLength, 11);
+});
+
+test('the attachment this source wrote before is the one taken back up', async () => {
+	const { vault, subject } = importer();
+	await vault.createBinary('Document.pdf', new ArrayBuffer(22));
+
+	const { path, reuse } = await subject.place('Document.pdf', sized(22));
+
+	assert.equal(path, 'Document.pdf');
+	assert.equal(reuse?.path, 'Document.pdf', 'nothing to download');
+});
+
+test('a name is passed over until the copy behind it is this attachment', async () => {
+	const { vault, subject } = importer();
+	await vault.createBinary('Drawing.png', new ArrayBuffer(1));
+	await vault.createBinary('Drawing 1.png', new ArrayBuffer(2));
+	await vault.createBinary('Drawing 2.png', new ArrayBuffer(3));
+
+	const { path, reuse } = await subject.place('Drawing.png', sized(3));
+
+	assert.equal(path, 'Drawing 2.png');
+	assert.equal(reuse?.path, 'Drawing 2.png');
+});
+
+test('re-importing a note of same-named attachments does not grow the vault', async () => {
+	const { vault, subject } = importer();
+	const sizes = [10, 20, 30];
+
+	for (const round of [1, 2, 3]) {
+		subject.indexImportedNotes();
+
+		for (const size of sizes) {
+			const { path, reuse } = await subject.place('Drawing.png', sized(size));
+			if (!reuse) await vault.createBinary(path, new ArrayBuffer(size));
+		}
+
+		assert.equal(vault.paths().length, sizes.length, `round ${round} wrote another set`);
+	}
+
+	assert.deepEqual(vault.paths().sort(), ['Drawing 1.png', 'Drawing 2.png', 'Drawing.png']);
+});
+
+test('an attachment the source has changed is written over where it stands', async () => {
+	const { vault, subject } = importer();
+	await vault.createBinary('Photo.png', new ArrayBuffer(5));
+
+	const { path, reuse } = await subject.place('Photo.png', () => 'stale');
+
+	assert.equal(path, 'Photo.png', 'in place rather than beside it');
+	assert.equal(reuse, null, 'and the new bytes are fetched');
+});
+
+test('"Skip" leaves an attachment the source has changed alone', async () => {
+	const { vault, subject } = importer(DuplicateHandling.Skip);
+	await vault.createBinary('Photo.png', new ArrayBuffer(5));
+
+	const { reuse } = await subject.place('Photo.png', () => 'stale');
+
+	assert.equal(reuse?.path, 'Photo.png');
+});
+
+test('"Create a copy" never asks, and never reuses', async () => {
+	const { vault, subject } = importer(DuplicateHandling.CreateCopy);
+	await vault.createBinary('Photo.png', new ArrayBuffer(5));
+
+	let asked = 0;
+	const { path, reuse } = await subject.place('Photo.png', () => (asked++, 'same'));
+
+	assert.equal(asked, 0);
+	assert.equal(reuse, null);
+	assert.equal(path, 'Photo 1.png');
+});
+
+test('two attachments of one name in a single run get a path each', async () => {
+	const { vault, subject } = importer();
+
+	const first = await subject.place('Photo.png', sized(1));
+	await vault.createBinary(first.path, new ArrayBuffer(1));
+	const second = await subject.place('Photo.png', sized(2));
+
+	assert.equal(first.path, 'Photo.png');
+	assert.equal(second.path, 'Photo 1.png');
+});

--- a/tests/write/write-note.test.ts
+++ b/tests/write/write-note.test.ts
@@ -103,6 +103,7 @@ test('with no time to go on, "Update" compares the text instead', async () => {
 test('the source id is recorded only when the importer has one and it was asked for', async () => {
 	const { vault, subject, ctx } = importer(DuplicateHandling.CreateCopy);
 	subject.idProperty = 'notion-id';
+	subject.saveSourceId = false;
 
 	const bare = await subject.writeNote(ctx, vault.root, 'A', 'body\n', { sourceId: 'abc-123' });
 	assert.equal(vault.contents.get(bare.file.path), 'body\n');


### PR DESCRIPTION
- Fix [#145](https://github.com/obsidianmd/obsidian-importer/issues/145) — preserve notebook, section group, and section hierarchy.
- Fix [#256](https://github.com/obsidianmd/obsidian-importer/issues/256) — preserve content following embedded objects.
- Fix [#278](https://github.com/obsidianmd/obsidian-importer/issues/278) — show the account chooser, detect account type, and support switching accounts.
- Fix [#334](https://github.com/obsidianmd/obsidian-importer/issues/334) — report the actual authentication, permission, throttling, or service failure.
- Fix [#390](https://github.com/obsidianmd/obsidian-importer/issues/390) — report picker throttling immediately while retaining import backoff.
- Fix [#398](https://github.com/obsidianmd/obsidian-importer/issues/398) — recover pages incorrectly marked as previously imported.
- Fix [#440](https://github.com/obsidianmd/obsidian-importer/issues/440) and [#462](https://github.com/obsidianmd/obsidian-importer/issues/462) — request organization notebook access and explain missing-scope failures.

## Changes

- Preserve refresh tokens through Microsoft’s common authority.
- Detect personal and organization accounts and request the appropriate scopes.
- Reset account state safely while preserving organization-scope retries.
- Retry transient failures, refresh expired tokens once, and fail fast on permission errors.
- Preserve the complete OneNote hierarchy.
- Count selected pages before importing and prefetch page lists while settings are completed.
- Invalidate prefetched pages when notebooks are refreshed.
- Keep progress reporting active throughout counting and importing.
- Default existing-note handling to Update.
- Isolate malformed pages without hiding systemic failures such as vault write errors.
- Preserve attachment fallback content and report malformed attachments.
- Identify attachments by stable OneNote resource IDs instead of filenames or sizes.
- Reuse unchanged attachments, update changed content in place, and prevent cross-page or same-name collisions.
- Give inline images stable names and pace downloads only after actual throttling.
- Handle Apple Notes attachment collisions and SQLite error shapes consistently.

## Supersedes

- Supersedes [#528](https://github.com/obsidianmd/obsidian-importer/pull/528).
- Together with related fixes already on `master`, supersedes [#550](https://github.com/obsidianmd/obsidian-importer/pull/550).