### PR TITLE
Add "Update" to Notion API and Airtable API importers

### DIFF
--- a/locale/en.txt
+++ b/locale/en.txt
@@ -854,10 +854,6 @@ translation=
 original=Empty record
 translation=
 
-[importer.airtable-api.reason-already-imported]
-original=Already imported
-translation=
-
 [importer.apple-notes.name]
 original=Apple Notes
 translation=

--- a/locale/en.txt
+++ b/locale/en.txt
@@ -854,6 +854,10 @@ translation=
 original=Empty record
 translation=
 
+[importer.airtable-api.desc-no-modified-time]
+original=Airtable does not say when a record last changed, so "{{update}}" compares the note with the record instead. A note you have edited yourself reads as changed, and will be written over.
+translation=
+
 [importer.apple-notes.name]
 original=Apple Notes
 translation=

--- a/locale/fr.txt
+++ b/locale/fr.txt
@@ -854,10 +854,6 @@ translation=Impossible de lire les noms des enregistrements
 original=Empty record
 translation=Enregistrement vide
 
-[importer.airtable-api.reason-already-imported]
-original=Already imported
-translation=Déjà importé
-
 [importer.apple-notes.name]
 original=Apple Notes
 translation=

--- a/locale/fr.txt
+++ b/locale/fr.txt
@@ -854,6 +854,10 @@ translation=Impossible de lire les noms des enregistrements
 original=Empty record
 translation=Enregistrement vide
 
+[importer.airtable-api.desc-no-modified-time]
+original=Airtable does not say when a record last changed, so "{{update}}" compares the note with the record instead. A note you have edited yourself reads as changed, and will be written over.
+translation=
+
 [importer.apple-notes.name]
 original=Apple Notes
 translation=

--- a/src/format-importer.ts
+++ b/src/format-importer.ts
@@ -209,6 +209,9 @@ export abstract class FormatImporter {
 		DuplicateHandling.Update,
 	];
 
+	/** What this importer's source cannot tell it, shown under the setting. */
+	duplicateCaveat: string | null = null;
+
 	/** Frontmatter property used to identify imported notes. */
 	idProperty: string | null = null;
 	/** Set in init() when an importer names its ID something more specific. */
@@ -651,6 +654,14 @@ export abstract class FormatImporter {
 			frag.appendText(i18n.output.descDuplicates({
 				update: duplicateHandlingLabel(DuplicateHandling.Update),
 			}));
+
+			// What the shared description promises rests on the source saying
+			// when it last changed something. An importer whose source does not
+			// says so here rather than letting the promise stand.
+			if (this.duplicateCaveat) {
+				frag.createEl('br');
+				frag.appendText(this.duplicateCaveat);
+			}
 		});
 	}
 

--- a/src/format-importer.ts
+++ b/src/format-importer.ts
@@ -82,8 +82,24 @@ export function vaultAttachmentLocation(vault: Vault): AttachmentLocation {
 	return { mode: 'folder', path: normalizePath(value) };
 }
 
+/**
+ * What the source calls this note.
+ *
+ * A list is for an importer whose id has changed shape: the first is written
+ * onto the note, and every one of them is recognised, so notes an earlier
+ * version wrote still match rather than being imported a second time.
+ */
+export type SourceId = string | string[];
+
+/** A note whose source has no id for it is matched by its path alone. */
+function idsOf(sourceId: SourceId | undefined): string[] {
+	if (!sourceId) return [];
+
+	return (typeof sourceId === 'string' ? [sourceId] : sourceId).filter(Boolean);
+}
+
 export interface NoteImport extends DataWriteOptions {
-	sourceId?: string;
+	sourceId?: SourceId;
 }
 
 /**
@@ -120,7 +136,7 @@ export interface PlannedNote {
 	targetPath: string;
 	/** The note an earlier import wrote, when this one matches it. */
 	file: TFile | null;
-	sourceId?: string;
+	sourceId?: SourceId;
 }
 
 /**
@@ -924,14 +940,16 @@ export abstract class FormatImporter {
 		if (path.toLowerCase().endsWith('.md')) this.markdownFiles.add(path);
 	}
 
-	protected withSourceId(content: string, sourceId: string | undefined): string {
+	protected withSourceId(content: string, sourceId: SourceId | undefined): string {
 		const { idProperty } = this;
-		if (!idProperty || !sourceId || !this.saveSourceId) return content;
+		// The first is the one to write; the rest are only for recognising.
+		const [id] = idsOf(sourceId);
+		if (!idProperty || !id || !this.saveSourceId) return content;
 
 		const parsed = parseFrontMatterBlock(content);
-		if (!parsed) return serializeFrontMatter({ [idProperty]: sourceId }) + content;
+		if (!parsed) return serializeFrontMatter({ [idProperty]: id }) + content;
 
-		return serializeFrontMatter({ [idProperty]: sourceId, ...parsed.frontMatter }) + parsed.body;
+		return serializeFrontMatter({ [idProperty]: id, ...parsed.frontMatter }) + parsed.body;
 	}
 
 	/**
@@ -948,7 +966,7 @@ export abstract class FormatImporter {
 	 * claim is what stops a second source note of the same name adopting it, and
 	 * a match that ends up writing nothing never took the name to begin with.
 	 */
-	planNote(folder: TFolder | string, title: string, sourceId?: string): PlannedNote {
+	planNote(folder: TFolder | string, title: string, sourceId?: SourceId): PlannedNote {
 		const name = `${sanitizeFileName(title).replace(/\.md$/i, '')}.md`;
 		const folderPath = typeof folder === 'string' ? normalizePath(folder) : folder.path;
 		const parent = folderPath === '/' ? '' : folderPath;
@@ -1073,12 +1091,15 @@ export abstract class FormatImporter {
 	}
 
 	/** Find a previous import by source ID, falling back to its expected path. */
-	protected previouslyImported(fullPath: string, sourceId?: string): TFile | null {
+	protected previouslyImported(fullPath: string, sourceId?: SourceId): TFile | null {
 		const { idProperty } = this;
+		const ids = idsOf(sourceId);
 
-		if (idProperty && sourceId) {
-			const known = this.importedById?.get(sourceId);
-			if (known && this.vault.getAbstractFileByPath(known.path) === known) return known;
+		if (idProperty && ids.length) {
+			for (const id of ids) {
+				const known = this.importedById?.get(id);
+				if (known && this.vault.getAbstractFileByPath(known.path) === known) return known;
+			}
 		}
 
 		// A second source note with this path needs its own file.
@@ -1088,10 +1109,10 @@ export abstract class FormatImporter {
 			?? this.vault.getAbstractFileByPathInsensitive(fullPath);
 		if (!(file instanceof TFile)) return null;
 
-		if (idProperty && sourceId) {
+		if (idProperty && ids.length) {
 			const recorded = this.recordedId(file, idProperty);
 			// Notes imported before IDs were recorded still match by path.
-			if (recorded && recorded !== sourceId) return null;
+			if (recorded && !ids.includes(recorded)) return null;
 		}
 
 		return file;

--- a/src/format-importer.ts
+++ b/src/format-importer.ts
@@ -131,6 +131,16 @@ export interface PlannedNote {
 export type NoteDisposition =
 	| 'create' | 'copy' | 'skip' | 'unchanged' | 'preserve' | 'update' | 'compare-content';
 
+/**
+ * Whether this answer means the note in the vault stays as it is.
+ *
+ * Three of the seven do. Which of the three matters separately: only
+ * `preserve` is a note the import may not write to at all.
+ */
+export function leavesTheNoteAlone(disposition: NoteDisposition): boolean {
+	return disposition === 'skip' || disposition === 'unchanged' || disposition === 'preserve';
+}
+
 const OUTCOME_OF: Record<'skip' | 'unchanged' | 'preserve', NoteOutcome> = {
 	skip: 'skipped',
 	unchanged: 'unchanged',
@@ -209,6 +219,17 @@ export abstract class FormatImporter {
 
 	protected claimPath(path: string): void {
 		this.claimed.add(normalizePath(path).toLowerCase());
+	}
+
+	/**
+	 * Give a name back, for a file that was never written after all.
+	 *
+	 * A download that does not arrive would otherwise leave its name reserved
+	 * for the rest of the import, and the next file of that name numbered
+	 * around a gap.
+	 */
+	protected releasePath(path: string): void {
+		this.claimed.delete(normalizePath(path).toLowerCase());
 	}
 
 	protected hasClaimed(path: string): boolean {
@@ -810,14 +831,21 @@ export abstract class FormatImporter {
 			: this.vault.createBinary(path, data, options);
 	}
 
+	/**
+	 * A name for an attachment that nothing else in this run is going to want.
+	 *
+	 * Notes are planned before they are written, so a name being free in the
+	 * vault is not the same as being free: an attachment called "notes.md" would
+	 * otherwise be handed a path a note is holding, and the note's own write
+	 * would then fail on a file the import had put in its way.
+	 */
 	async getAvailablePathForAttachment(filename: string, claimedPaths: string[], sourcePath?: string): Promise<string> {
 		const at = await this.attachmentNaming(filename, sourcePath);
 
 		for (let nth = 0; ; nth++) {
 			const candidate = at(nth);
-			if (!claimedPaths.includes(candidate) && !this.vault.getAbstractFileByPath(candidate)) {
-				return candidate;
-			}
+			if (claimedPaths.includes(candidate) || this.hasClaimed(candidate)) continue;
+			if (!this.vault.getAbstractFileByPath(candidate)) return candidate;
 		}
 	}
 

--- a/src/format-importer.ts
+++ b/src/format-importer.ts
@@ -87,13 +87,10 @@ export interface NoteImport extends DataWriteOptions {
 }
 
 /**
- * What became of an imported note, for an importer that has more to do after
- * writing it. `written` says whether the file changed; `outcome` says why.
- *
- * The difference between the three that did not write matters to anything that
- * rewrites notes after the import. A note left alone because the source has not
- * moved on can still have its unresolved links repaired; a note left alone
- * because the user edited it must not be touched at all.
+ * What became of an imported note. The three that wrote nothing are kept
+ * apart because a note left alone by a source that has not moved on can still
+ * have its unresolved links repaired, while one the user has edited must not
+ * be touched at all.
  */
 export type NoteOutcome = 'created' | 'updated' | 'skipped' | 'unchanged' | 'preserved';
 
@@ -103,15 +100,7 @@ export interface NoteWritten {
 	outcome: NoteOutcome;
 }
 
-/**
- * Where a note is going and what is already there, decided before its markdown
- * exists.
- *
- * An importer that resolves attachment paths or links against the note's own
- * location needs to know that location before it converts anything, and one
- * that can tell from the source whether a note is stale wants to skip the
- * conversion entirely.
- */
+/** Where a note is going and what is already there, decided before its markdown exists. */
 export interface PlannedNote {
 	title: string;
 	/** Where this import would place the note, before anything already there. */
@@ -131,12 +120,7 @@ export interface PlannedNote {
 export type NoteDisposition =
 	| 'create' | 'copy' | 'skip' | 'unchanged' | 'preserve' | 'update' | 'compare-content';
 
-/**
- * Whether this answer means the note in the vault stays as it is.
- *
- * Three of the seven do. Which of the three matters separately: only
- * `preserve` is a note the import may not write to at all.
- */
+/** Whether the note in the vault stays as it is. Which of the three it is still matters: only `preserve` may not be written to at all. */
 export function leavesTheNoteAlone(disposition: NoteDisposition): boolean {
 	return disposition === 'skip' || disposition === 'unchanged' || disposition === 'preserve';
 }
@@ -148,8 +132,6 @@ const OUTCOME_OF: Record<'skip' | 'unchanged' | 'preserve', NoteOutcome> = {
 };
 
 /**
- * What the note in the vault is, next to the source's modification time.
- *
  * An import writes the source's time onto the file, so an equal time is a note
  * nothing has touched since, and a later one is a note the user has edited.
  */
@@ -222,11 +204,9 @@ export abstract class FormatImporter {
 	}
 
 	/**
-	 * Give a name back, for a file that was never written after all.
-	 *
-	 * A download that does not arrive would otherwise leave its name reserved
-	 * for the rest of the import, and the next file of that name numbered
-	 * around a gap.
+	 * Give a name back, for a file that was never written after all: a download
+	 * that does not arrive would otherwise leave the next file of that name
+	 * numbered around a gap.
 	 */
 	protected releasePath(path: string): void {
 		this.claimed.delete(normalizePath(path).toLowerCase());
@@ -650,9 +630,6 @@ export abstract class FormatImporter {
 				update: duplicateHandlingLabel(DuplicateHandling.Update),
 			}));
 
-			// What the shared description promises rests on the source saying
-			// when it last changed something. An importer whose source does not
-			// says so here rather than letting the promise stand.
 			if (this.duplicateCaveat) {
 				frag.createEl('br');
 				frag.appendText(this.duplicateCaveat);
@@ -832,12 +809,9 @@ export abstract class FormatImporter {
 	}
 
 	/**
-	 * A name for an attachment that nothing else in this run is going to want.
-	 *
-	 * Notes are planned before they are written, so a name being free in the
-	 * vault is not the same as being free: an attachment called "notes.md" would
-	 * otherwise be handed a path a note is holding, and the note's own write
-	 * would then fail on a file the import had put in its way.
+	 * A name nothing else in this run is going to want. Notes are planned before
+	 * they are written, so a name free in the vault may still be one a note is
+	 * holding, and that note's own write would then fail.
 	 */
 	async getAvailablePathForAttachment(filename: string, claimedPaths: string[], sourcePath?: string): Promise<string> {
 		const at = await this.attachmentNaming(filename, sourcePath);
@@ -976,16 +950,12 @@ export abstract class FormatImporter {
 	/**
 	 * Where this note is going, and the earlier import it matches.
 	 *
-	 * Answering before the markdown exists is what lets an importer resolve
-	 * attachment paths and links against the note's real location, and lets one
-	 * that knows the source's modification time skip converting a note it is
-	 * only going to leave alone.
+	 * Answering before the markdown exists lets an importer resolve attachment
+	 * paths and links against the note's real location, and lets one that knows
+	 * the source's modification time skip converting a note it will leave alone.
 	 *
-	 * The path is claimed here, whether the note is new or one an earlier import
-	 * wrote. An importer that plans every note before writing any - which is the
-	 * point of planning at all - would otherwise hand the same name to two of
-	 * them: a free name to two new notes, or one untitled legacy note to every
-	 * source item that shares its title.
+	 * The path is claimed here, new note or matched one alike, so that planning
+	 * every note before writing any does not hand the same name to two of them.
 	 */
 	planNote(folder: TFolder | string, title: string, sourceId?: string): PlannedNote {
 		const name = `${sanitizeFileName(title).replace(/\.md$/i, '')}.md`;
@@ -1004,11 +974,9 @@ export abstract class FormatImporter {
 	}
 
 	/**
-	 * A name no note holds and this run has not taken.
-	 *
-	 * getUniqueFilePath only knows what the vault holds, which was enough while
-	 * every note was written the moment its name was chosen. Resolving ahead of
-	 * the conversion means two notes can be waiting on their markdown at once.
+	 * A name no note holds and this run has not taken. getUniqueFilePath knows
+	 * only what the vault holds, which was enough while every note was written
+	 * the moment its name was chosen.
 	 */
 	private freeNotePath(parent: string, name: string): string {
 		const unique = getUniqueFilePath(this.vault, parent, name);
@@ -1022,11 +990,9 @@ export abstract class FormatImporter {
 	}
 
 	/**
-	 * What to do with a resolved note, before its markdown is generated.
-	 *
-	 * Reports the reason for every answer that settles the matter here, so an
-	 * importer can act on it and move on. Without a `sourceMtime` nothing can be
-	 * settled yet and the answer is `compare-content`.
+	 * What to do with a resolved note, before its markdown is generated. Reports
+	 * the reason for every answer that settles the matter here, so an importer
+	 * can act on it and move on.
 	 */
 	protected preflightNote(ctx: ImportContext, resolved: PlannedNote, sourceMtime?: number): NoteDisposition {
 		const { file, title, targetPath, desiredPath } = resolved;
@@ -1051,10 +1017,9 @@ export abstract class FormatImporter {
 	}
 
 	/**
-	 * Create, update or leave a planned note, and say which.
-	 *
-	 * Pass the `disposition` an earlier `preflightNote` returned to act on the
-	 * answer it already reported; without one the decision is made here.
+	 * Create, update or leave a planned note, and say which. Pass the
+	 * `disposition` an earlier `preflightNote` returned to act on the answer it
+	 * already reported; without one the decision is made here.
 	 */
 	async writePlannedNote(
 		ctx: ImportContext,
@@ -1143,8 +1108,6 @@ export abstract class FormatImporter {
 	}
 
 	/**
-	 * Whether writing this content would leave the note as it already is.
-	 *
 	 * What a source with no modification time is left with. It cannot tell an
 	 * edit the user made from a change in the source: both read as different.
 	 */

--- a/src/format-importer.ts
+++ b/src/format-importer.ts
@@ -7,7 +7,7 @@ import { ImportContext } from './import-context';
 import { formatImportReport, importReportName } from './import-report';
 import { createMarkdown, formatMarkdown, markdownOutputFor, modifyMarkdown, standardizedMarkdown, standardizeMarkdownFile } from './markdown-output';
 import { i18n } from './i18n';
-import { getUniqueFilePath, parseFrontMatterBlock, sanitizeFileName, sanitizeFilePath, serializeFrontMatter } from './util';
+import { availableFileName, getUniqueFilePath, parseFrontMatterBlock, sanitizeFileName, sanitizeFilePath, serializeFrontMatter } from './util';
 
 const MAX_PATH_DESCRIPTION_LENGTH = 300;
 
@@ -86,9 +86,68 @@ export interface NoteImport extends DataWriteOptions {
 	sourceId?: string;
 }
 
+/**
+ * What became of an imported note, for an importer that has more to do after
+ * writing it. `written` says whether the file changed; `outcome` says why.
+ *
+ * The difference between the three that did not write matters to anything that
+ * rewrites notes after the import. A note left alone because the source has not
+ * moved on can still have its unresolved links repaired; a note left alone
+ * because the user edited it must not be touched at all.
+ */
+export type NoteOutcome = 'created' | 'updated' | 'skipped' | 'unchanged' | 'preserved';
+
 export interface NoteWritten {
 	file: TFile;
 	written: boolean;
+	outcome: NoteOutcome;
+}
+
+/**
+ * Where a note is going and what is already there, decided before its markdown
+ * exists.
+ *
+ * An importer that resolves attachment paths or links against the note's own
+ * location needs to know that location before it converts anything, and one
+ * that can tell from the source whether a note is stale wants to skip the
+ * conversion entirely.
+ */
+export interface PlannedNote {
+	title: string;
+	/** Where this import would place the note, before anything already there. */
+	desiredPath: string;
+	/** Where it will be written: an earlier import's note, or a free name. */
+	targetPath: string;
+	/** The note an earlier import wrote, when this one matches it. */
+	file: TFile | null;
+	sourceId?: string;
+}
+
+/**
+ * What to do with a resolved note. `compare-content` is the answer when the
+ * source offers no modification time: the caller has to produce the markdown
+ * before anything can be decided.
+ */
+export type NoteDisposition =
+	| 'create' | 'copy' | 'skip' | 'unchanged' | 'preserve' | 'update' | 'compare-content';
+
+const OUTCOME_OF: Record<'skip' | 'unchanged' | 'preserve', NoteOutcome> = {
+	skip: 'skipped',
+	unchanged: 'unchanged',
+	preserve: 'preserved',
+};
+
+/**
+ * What the note in the vault is, next to the source's modification time.
+ *
+ * An import writes the source's time onto the file, so an equal time is a note
+ * nothing has touched since, and a later one is a note the user has edited.
+ */
+function comparedToSource(file: TFile, sourceMtime: number): 'unchanged' | 'preserve' | 'update' {
+	if (file.stat.mtime === sourceMtime) return 'unchanged';
+	if (file.stat.mtime > sourceMtime) return 'preserve';
+
+	return 'update';
 }
 
 export type ImporterStep = 'source' | 'output' | 'options';
@@ -875,36 +934,141 @@ export abstract class FormatImporter {
 		return serializeFrontMatter({ [idProperty]: sourceId, ...parsed.frontMatter }) + parsed.body;
 	}
 
-	/** Write, update, or match an imported note according to the duplicate mode. */
-	async writeNote(ctx: ImportContext, folder: TFolder, title: string, content: string, options: NoteImport = {}): Promise<NoteWritten> {
-		const { sourceId, ...writeOptions } = options;
-		content = this.withSourceId(content, sourceId);
+	/**
+	 * Where this note is going, and the earlier import it matches.
+	 *
+	 * Answering before the markdown exists is what lets an importer resolve
+	 * attachment paths and links against the note's real location, and lets one
+	 * that knows the source's modification time skip converting a note it is
+	 * only going to leave alone.
+	 *
+	 * A name chosen for a new note is claimed here rather than at the write, or
+	 * two notes waiting on their markdown are handed the same free one. A note
+	 * that matched an earlier import claims at the write, as it always has: the
+	 * claim is what stops a second source note of the same name adopting it, and
+	 * a match that ends up writing nothing never took the name to begin with.
+	 */
+	planNote(folder: TFolder, title: string, sourceId?: string): PlannedNote {
 		const name = `${sanitizeFileName(title).replace(/\.md$/i, '')}.md`;
 		const parent = folder.path === '/' ? '' : folder.path;
-		const fullPath = normalizePath(parent ? `${parent}/${name}` : name);
+		const desiredPath = normalizePath(parent ? `${parent}/${name}` : name);
 
-		const existing = this.duplicateHandling === DuplicateHandling.CreateCopy
+		const file = this.duplicateHandling === DuplicateHandling.CreateCopy
 			? null
-			: this.previouslyImported(fullPath, sourceId);
+			: this.previouslyImported(desiredPath, sourceId);
 
-		if (!existing) {
-			const file = await this.createFile(folder, name, content, writeOptions);
-			this.claimPath(file.path);
-			return { file, written: true };
+		if (file) return { title, desiredPath, targetPath: file.path, file, sourceId };
+
+		const targetPath = this.freeNotePath(parent, name);
+		this.claimPath(targetPath);
+
+		return { title, desiredPath, targetPath, file, sourceId };
+	}
+
+	/**
+	 * A name no note holds and this run has not taken.
+	 *
+	 * getUniqueFilePath only knows what the vault holds, which was enough while
+	 * every note was written the moment its name was chosen. Resolving ahead of
+	 * the conversion means two notes can be waiting on their markdown at once.
+	 */
+	private freeNotePath(parent: string, name: string): string {
+		const unique = getUniqueFilePath(this.vault, parent, name);
+		if (!this.hasClaimed(unique)) return unique;
+
+		const at = (candidate: string) => normalizePath(parent ? `${parent}/${candidate}` : candidate);
+		const free = availableFileName(name, candidate =>
+			this.hasClaimed(at(candidate)) || this.vault.getAbstractFileByPathInsensitive(at(candidate)) !== null);
+
+		return at(free);
+	}
+
+	/**
+	 * What to do with a resolved note, before its markdown is generated.
+	 *
+	 * Reports the reason for every answer that settles the matter here, so an
+	 * importer can act on it and move on. Without a `sourceMtime` nothing can be
+	 * settled yet and the answer is `compare-content`.
+	 */
+	protected preflightNote(ctx: ImportContext, resolved: PlannedNote, sourceMtime?: number): NoteDisposition {
+		const { file, title, targetPath, desiredPath } = resolved;
+
+		if (!file) {
+			return this.duplicateHandling === DuplicateHandling.CreateCopy && targetPath !== desiredPath
+				? 'copy'
+				: 'create';
 		}
 
 		if (this.duplicateHandling === DuplicateHandling.Skip) {
 			ctx.reportSkipped(title, i18n.reason.alreadyInVault());
-			return { file: existing, written: false };
+			return 'skip';
 		}
 
-		if (await this.unchangedSinceImport(ctx, existing, title, content, writeOptions.mtime)) {
-			return { file: existing, written: false };
+		if (sourceMtime === undefined) return 'compare-content';
+
+		const disposition = comparedToSource(file, sourceMtime);
+		if (disposition !== 'update') this.reportUnwritten(ctx, title, disposition);
+
+		return disposition;
+	}
+
+	/**
+	 * Create, update or leave a planned note, and say which.
+	 *
+	 * Pass the `disposition` an earlier `preflightNote` returned to act on the
+	 * answer it already reported; without one the decision is made here.
+	 */
+	async writePlannedNote(
+		ctx: ImportContext,
+		planned: PlannedNote,
+		content: string,
+		options: NoteImport & { disposition?: NoteDisposition } = {},
+	): Promise<NoteWritten> {
+		const { sourceId = planned.sourceId, disposition, ...writeOptions } = options;
+		const { file, title, targetPath } = planned;
+		content = this.withSourceId(content, sourceId);
+
+		let decided = disposition ?? this.preflightNote(ctx, planned, writeOptions.mtime);
+
+		if (decided === 'compare-content') {
+			decided = !file ? 'create'
+				: await this.unchangedContent(ctx, file, title, content) ? 'unchanged'
+					: 'update';
 		}
 
-		await this.modifyMarkdown(existing, content, writeOptions);
-		this.claimPath(existing.path);
-		return { file: existing, written: true };
+		switch (decided) {
+			case 'skip':
+			case 'unchanged':
+			case 'preserve':
+				// All three answers matched a note, so there is a file here.
+				return { file: file!, written: false, outcome: OUTCOME_OF[decided] };
+
+			case 'update':
+				await this.modifyMarkdown(file!, content, writeOptions);
+				this.claimPath(file!.path);
+				return { file: file!, written: true, outcome: 'updated' };
+
+			default:
+				return {
+					file: await this.createMarkdown(targetPath, content, writeOptions),
+					written: true,
+					outcome: 'created',
+				};
+		}
+	}
+
+	/** Write, update, or match an imported note according to the duplicate mode. */
+	async writeNote(ctx: ImportContext, folder: TFolder, title: string, content: string, options: NoteImport = {}): Promise<NoteWritten> {
+		const { sourceId, ...writeOptions } = options;
+		const resolved = this.planNote(folder, title, sourceId);
+
+		return await this.writePlannedNote(ctx, resolved, content, { ...writeOptions, sourceId });
+	}
+
+	private reportUnwritten(ctx: ImportContext, title: string, disposition: 'unchanged' | 'preserve'): void {
+		ctx.reportSkipped(title, disposition === 'unchanged'
+			? i18n.reason.unchangedSinceImport()
+			: i18n.reason.editedSinceImport());
 	}
 
 	/** Find a previous import by source ID, falling back to its expected path. */
@@ -937,22 +1101,13 @@ export abstract class FormatImporter {
 		return typeof id === 'string' && id ? id : null;
 	}
 
-	/** Leave notes unchanged or edited since the source update alone. */
-	private async unchangedSinceImport(ctx: ImportContext, file: TFile, title: string, content: string, sourceMtime?: number): Promise<boolean> {
-		if (sourceMtime !== undefined) {
-			if (file.stat.mtime === sourceMtime) {
-				ctx.reportSkipped(title, i18n.reason.unchangedSinceImport());
-				return true;
-			}
-
-			if (file.stat.mtime > sourceMtime) {
-				ctx.reportSkipped(title, i18n.reason.editedSinceImport());
-				return true;
-			}
-
-			return false;
-		}
-
+	/**
+	 * Whether writing this content would leave the note as it already is.
+	 *
+	 * What a source with no modification time is left with. It cannot tell an
+	 * edit the user made from a change in the source: both read as different.
+	 */
+	private async unchangedContent(ctx: ImportContext, file: TFile, title: string, content: string): Promise<boolean> {
 		try {
 			const current = await this.vault.read(file);
 			if (current !== await standardizedMarkdown(this.app, file.path, content)) return false;
@@ -962,7 +1117,7 @@ export abstract class FormatImporter {
 			return false;
 		}
 
-		ctx.reportSkipped(title, i18n.reason.unchangedSinceImport());
+		this.reportUnwritten(ctx, title, 'unchanged');
 		return true;
 	}
 

--- a/src/format-importer.ts
+++ b/src/format-importer.ts
@@ -82,34 +82,8 @@ export function vaultAttachmentLocation(vault: Vault): AttachmentLocation {
 	return { mode: 'folder', path: normalizePath(value) };
 }
 
-/**
- * What the source calls this note, for an importer whose id has changed shape.
- *
- * `id` is written onto the note and recognised wherever the note has moved to.
- * A `formerly` id is recognised only where the version that wrote it would have
- * put the note, because an id that has been made more specific is by definition
- * one that could not tell every note apart - two sources may each claim a note
- * carrying it. At the expected path there is nothing to be wrong about; away
- * from it there is no way to tell which source it belonged to, so it is left
- * alone rather than guessed at.
- */
-export interface SourceIdentity {
-	id: string;
-	formerly?: string[];
-}
-
-export type SourceId = string | SourceIdentity;
-
-/** A note whose source has no id for it is matched by its path alone. */
-function identityOf(sourceId: SourceId | undefined): { id: string | null, formerly: string[] } {
-	if (!sourceId) return { id: null, formerly: [] };
-	if (typeof sourceId === 'string') return { id: sourceId, formerly: [] };
-
-	return { id: sourceId.id || null, formerly: (sourceId.formerly ?? []).filter(Boolean) };
-}
-
 export interface NoteImport extends DataWriteOptions {
-	sourceId?: SourceId;
+	sourceId?: string;
 }
 
 /**
@@ -146,7 +120,7 @@ export interface PlannedNote {
 	targetPath: string;
 	/** The note an earlier import wrote, when this one matches it. */
 	file: TFile | null;
-	sourceId?: SourceId;
+	sourceId?: string;
 }
 
 /**
@@ -961,17 +935,14 @@ export abstract class FormatImporter {
 		if (path.toLowerCase().endsWith('.md')) this.markdownFiles.add(path);
 	}
 
-	protected withSourceId(content: string, sourceId: SourceId | undefined): string {
+	protected withSourceId(content: string, sourceId: string | undefined): string {
 		const { idProperty } = this;
-		// A former id is only ever recognised, never written, so a note being
-		// rewritten is a note whose id stops being the ambiguous one.
-		const { id } = identityOf(sourceId);
-		if (!idProperty || !id || !this.saveSourceId) return content;
+		if (!idProperty || !sourceId || !this.saveSourceId) return content;
 
 		const parsed = parseFrontMatterBlock(content);
-		if (!parsed) return serializeFrontMatter({ [idProperty]: id }) + content;
+		if (!parsed) return serializeFrontMatter({ [idProperty]: sourceId }) + content;
 
-		return serializeFrontMatter({ [idProperty]: id, ...parsed.frontMatter }) + parsed.body;
+		return serializeFrontMatter({ [idProperty]: sourceId, ...parsed.frontMatter }) + parsed.body;
 	}
 
 	/**
@@ -988,7 +959,7 @@ export abstract class FormatImporter {
 	 * them: a free name to two new notes, or one untitled legacy note to every
 	 * source item that shares its title.
 	 */
-	planNote(folder: TFolder | string, title: string, sourceId?: SourceId): PlannedNote {
+	planNote(folder: TFolder | string, title: string, sourceId?: string): PlannedNote {
 		const name = `${sanitizeFileName(title).replace(/\.md$/i, '')}.md`;
 		const folderPath = typeof folder === 'string' ? normalizePath(folder) : folder.path;
 		const parent = folderPath === '/' ? '' : folderPath;
@@ -1111,12 +1082,11 @@ export abstract class FormatImporter {
 	}
 
 	/** Find a previous import by source ID, falling back to its expected path. */
-	protected previouslyImported(fullPath: string, sourceId?: SourceId): TFile | null {
+	protected previouslyImported(fullPath: string, sourceId?: string): TFile | null {
 		const { idProperty } = this;
-		const { id, formerly } = identityOf(sourceId);
 
-		if (idProperty && id) {
-			const known = this.importedById?.get(id);
+		if (idProperty && sourceId) {
+			const known = this.importedById?.get(sourceId);
 			// A note this run has already taken belongs to whatever took it.
 			if (known && !this.hasClaimed(known.path) && this.vault.getAbstractFileByPath(known.path) === known) {
 				return known;
@@ -1130,12 +1100,10 @@ export abstract class FormatImporter {
 			?? this.vault.getAbstractFileByPathInsensitive(fullPath);
 		if (!(file instanceof TFile)) return null;
 
-		if (idProperty && id) {
+		if (idProperty && sourceId) {
 			const recorded = this.recordedId(file, idProperty);
-			// Notes imported before IDs were recorded still match by path, and
-			// so do notes carrying an id this source used to be known by - here,
-			// where the version that wrote it would have put the note.
-			if (recorded && recorded !== id && !formerly.includes(recorded)) return null;
+			// Notes imported before IDs were recorded still match by path.
+			if (recorded && recorded !== sourceId) return null;
 		}
 
 		return file;

--- a/src/format-importer.ts
+++ b/src/format-importer.ts
@@ -83,19 +83,29 @@ export function vaultAttachmentLocation(vault: Vault): AttachmentLocation {
 }
 
 /**
- * What the source calls this note.
+ * What the source calls this note, for an importer whose id has changed shape.
  *
- * A list is for an importer whose id has changed shape: the first is written
- * onto the note, and every one of them is recognised, so notes an earlier
- * version wrote still match rather than being imported a second time.
+ * `id` is written onto the note and recognised wherever the note has moved to.
+ * A `formerly` id is recognised only where the version that wrote it would have
+ * put the note, because an id that has been made more specific is by definition
+ * one that could not tell every note apart - two sources may each claim a note
+ * carrying it. At the expected path there is nothing to be wrong about; away
+ * from it there is no way to tell which source it belonged to, so it is left
+ * alone rather than guessed at.
  */
-export type SourceId = string | string[];
+export interface SourceIdentity {
+	id: string;
+	formerly?: string[];
+}
+
+export type SourceId = string | SourceIdentity;
 
 /** A note whose source has no id for it is matched by its path alone. */
-function idsOf(sourceId: SourceId | undefined): string[] {
-	if (!sourceId) return [];
+function identityOf(sourceId: SourceId | undefined): { id: string | null, formerly: string[] } {
+	if (!sourceId) return { id: null, formerly: [] };
+	if (typeof sourceId === 'string') return { id: sourceId, formerly: [] };
 
-	return (typeof sourceId === 'string' ? [sourceId] : sourceId).filter(Boolean);
+	return { id: sourceId.id || null, formerly: (sourceId.formerly ?? []).filter(Boolean) };
 }
 
 export interface NoteImport extends DataWriteOptions {
@@ -942,8 +952,9 @@ export abstract class FormatImporter {
 
 	protected withSourceId(content: string, sourceId: SourceId | undefined): string {
 		const { idProperty } = this;
-		// The first is the one to write; the rest are only for recognising.
-		const [id] = idsOf(sourceId);
+		// A former id is only ever recognised, never written, so a note being
+		// rewritten is a note whose id stops being the ambiguous one.
+		const { id } = identityOf(sourceId);
 		if (!idProperty || !id || !this.saveSourceId) return content;
 
 		const parsed = parseFrontMatterBlock(content);
@@ -960,11 +971,11 @@ export abstract class FormatImporter {
 	 * that knows the source's modification time skip converting a note it is
 	 * only going to leave alone.
 	 *
-	 * A name chosen for a new note is claimed here rather than at the write, or
-	 * two notes waiting on their markdown are handed the same free one. A note
-	 * that matched an earlier import claims at the write, as it always has: the
-	 * claim is what stops a second source note of the same name adopting it, and
-	 * a match that ends up writing nothing never took the name to begin with.
+	 * The path is claimed here, whether the note is new or one an earlier import
+	 * wrote. An importer that plans every note before writing any - which is the
+	 * point of planning at all - would otherwise hand the same name to two of
+	 * them: a free name to two new notes, or one untitled legacy note to every
+	 * source item that shares its title.
 	 */
 	planNote(folder: TFolder | string, title: string, sourceId?: SourceId): PlannedNote {
 		const name = `${sanitizeFileName(title).replace(/\.md$/i, '')}.md`;
@@ -976,9 +987,7 @@ export abstract class FormatImporter {
 			? null
 			: this.previouslyImported(desiredPath, sourceId);
 
-		if (file) return { title, desiredPath, targetPath: file.path, file, sourceId };
-
-		const targetPath = this.freeNotePath(parent, name);
+		const targetPath = file ? file.path : this.freeNotePath(parent, name);
 		this.claimPath(targetPath);
 
 		return { title, desiredPath, targetPath, file, sourceId };
@@ -1093,12 +1102,13 @@ export abstract class FormatImporter {
 	/** Find a previous import by source ID, falling back to its expected path. */
 	protected previouslyImported(fullPath: string, sourceId?: SourceId): TFile | null {
 		const { idProperty } = this;
-		const ids = idsOf(sourceId);
+		const { id, formerly } = identityOf(sourceId);
 
-		if (idProperty && ids.length) {
-			for (const id of ids) {
-				const known = this.importedById?.get(id);
-				if (known && this.vault.getAbstractFileByPath(known.path) === known) return known;
+		if (idProperty && id) {
+			const known = this.importedById?.get(id);
+			// A note this run has already taken belongs to whatever took it.
+			if (known && !this.hasClaimed(known.path) && this.vault.getAbstractFileByPath(known.path) === known) {
+				return known;
 			}
 		}
 
@@ -1109,10 +1119,12 @@ export abstract class FormatImporter {
 			?? this.vault.getAbstractFileByPathInsensitive(fullPath);
 		if (!(file instanceof TFile)) return null;
 
-		if (idProperty && ids.length) {
+		if (idProperty && id) {
 			const recorded = this.recordedId(file, idProperty);
-			// Notes imported before IDs were recorded still match by path.
-			if (recorded && !ids.includes(recorded)) return null;
+			// Notes imported before IDs were recorded still match by path, and
+			// so do notes carrying an id this source used to be known by - here,
+			// where the version that wrote it would have put the note.
+			if (recorded && recorded !== id && !formerly.includes(recorded)) return null;
 		}
 
 		return file;

--- a/src/format-importer.ts
+++ b/src/format-importer.ts
@@ -948,9 +948,10 @@ export abstract class FormatImporter {
 	 * claim is what stops a second source note of the same name adopting it, and
 	 * a match that ends up writing nothing never took the name to begin with.
 	 */
-	planNote(folder: TFolder, title: string, sourceId?: string): PlannedNote {
+	planNote(folder: TFolder | string, title: string, sourceId?: string): PlannedNote {
 		const name = `${sanitizeFileName(title).replace(/\.md$/i, '')}.md`;
-		const parent = folder.path === '/' ? '' : folder.path;
+		const folderPath = typeof folder === 'string' ? normalizePath(folder) : folder.path;
+		const parent = folderPath === '/' ? '' : folderPath;
 		const desiredPath = normalizePath(parent ? `${parent}/${name}` : name);
 
 		const file = this.duplicateHandling === DuplicateHandling.CreateCopy

--- a/src/formats/airtable-api.ts
+++ b/src/formats/airtable-api.ts
@@ -847,10 +847,8 @@ export class AirtableAPIImporter extends FormatImporter {
 					continue;
 				}
 
-				// Where the note goes is settled here, before any of them is
-				// written, so a record linking to another can name the file it
-				// will end up in - including one an earlier import already wrote,
-				// wherever the user has since moved it to.
+				// Including the note an earlier import wrote, wherever the user
+				// has since moved it to.
 				const note = this.planNote(tablePath, recordTitle(record, primaryFieldName), record.id);
 				const { basename } = parseFilePath(note.targetPath);
 
@@ -1194,10 +1192,9 @@ export class AirtableAPIImporter extends FormatImporter {
 			return;
 		}
 
-		// Nothing here can be told from the record: Airtable gives no
-		// modification time, so a decision needs the markdown to compare.
-		// Skip is the exception - it needs no comparison, and settling it now
-		// is what keeps an untouched record from downloading its attachments.
+		// Airtable gives no modification time, so every other answer needs the
+		// markdown to compare. Skip needs no comparison, and settling it now is
+		// what keeps an untouched record from downloading its attachments.
 		const disposition = this.preflightNote(ctx, note);
 		if (disposition === 'skip') {
 			this.processedRecordsCount++;
@@ -1247,14 +1244,10 @@ export class AirtableAPIImporter extends FormatImporter {
 	 *
 	 * A name and a size together are as much identity as Airtable leaves in the
 	 * vault: the attachment id it hands out is not written anywhere a later
-	 * import could read it back from. So the same name holding the same number
-	 * of bytes is taken to be this attachment again and left alone, and any
-	 * other file of that name is somebody else's and passed over for the next
-	 * name along.
-	 *
-	 * Without this, every import found its own file already there, wrote
-	 * "cover 1.png" beside it, and changed the note to say so - which under
-	 * "Update" is a record that has changed every time it is looked at.
+	 * import could read it back from. Without them, every import found its own
+	 * file already there, wrote "cover 1.png" beside it, and changed the note to
+	 * say so - which under "Update" is a record that changes every time it is
+	 * looked at.
 	 */
 	protected attachmentPlacer(notePath: string): (filename: string, size: number | undefined) => Promise<AttachmentPlacement> {
 		return async (filename, size) => {
@@ -1298,8 +1291,6 @@ export class AirtableAPIImporter extends FormatImporter {
 			const existingFile = this.vault.getAbstractFileByPathInsensitive(baseFilePath);
 
 			if (existingFile && existingFile instanceof TFile) {
-				// Regenerated from the schema, but a view the user added beside
-				// the imported ones is theirs and is kept.
 				const existingContent = await this.vault.read(existingFile);
 
 				try {

--- a/src/formats/airtable-api.ts
+++ b/src/formats/airtable-api.ts
@@ -32,6 +32,7 @@ import {
 	frontMatterFieldsForTable,
 	isEmptyRecord,
 	RECORD_ID_PROPERTY,
+	recordTimestamps,
 	recordTitle,
 } from './airtable-api/record-note';
 import type {
@@ -1232,7 +1233,11 @@ export class AirtableAPIImporter extends FormatImporter {
 			formatAttachmentsForYAML,
 		});
 
-		const { written } = await this.writePlannedNote(ctx, note, content, { disposition, sourceId: record.id });
+		const { written } = await this.writePlannedNote(ctx, note, content, {
+			disposition,
+			sourceId: record.id,
+			...recordTimestamps(record),
+		});
 		if (written) ctx.reportNoteSuccess(title);
 
 		this.processedRecordsCount++;

--- a/src/formats/airtable-api.ts
+++ b/src/formats/airtable-api.ts
@@ -39,6 +39,7 @@ import {
 import type {
 	AirtableTreeNode,
 	AirtableViewInfo,
+	AttachmentPlacement,
 	AirtableFieldSchema,
 	AirtableRecord,
 	PreparedTableData,
@@ -1222,9 +1223,7 @@ export class AirtableAPIImporter extends FormatImporter {
 				ctx,
 				vault: this.vault,
 				downloadAttachments: this.downloadAttachments,
-				getAvailableAttachmentPath: async (filename: string) => {
-					return await this.getAvailablePathForAttachment(filename, [], filePath);
-				},
+				placeAttachment: this.attachmentPlacer(filePath),
 			}),
 			formatAttachmentsForBody: results => formatAttachmentsForBody(results, {
 				currentFilePath: filePath,
@@ -1243,6 +1242,29 @@ export class AirtableAPIImporter extends FormatImporter {
 
 		this.processedRecordsCount++;
 		this.reportOverallProgress(ctx);
+	}
+
+	/**
+	 * Where a record's attachments go, and which of them are already there.
+	 *
+	 * A name and a size together are as much identity as Airtable leaves in the
+	 * vault: the attachment id it hands out is not written anywhere a later
+	 * import could read it back from. So the same name holding the same number
+	 * of bytes is taken to be this attachment again and left alone, and any
+	 * other file of that name is somebody else's and passed over for the next
+	 * name along.
+	 *
+	 * Without this, every import found its own file already there, wrote
+	 * "cover 1.png" beside it, and changed the note to say so - which under
+	 * "Update" is a record that has changed every time it is looked at.
+	 */
+	protected attachmentPlacer(notePath: string): (filename: string, size: number | undefined) => Promise<AttachmentPlacement> {
+		return async (filename, size) => {
+			const { path, reuse } = await this.placeAttachment(filename, notePath, existing =>
+				size !== undefined && existing.stat.size === size ? 'same' : 'another');
+
+			return { path, reuse: reuse !== null };
+		};
 	}
 
 	private computeTableFormulas(fields: AirtableFieldSchema[], primaryFieldId: string): Map<string, string> {

--- a/src/formats/airtable-api.ts
+++ b/src/formats/airtable-api.ts
@@ -4,7 +4,7 @@
  */
 
 import { Notice, normalizePath, TFile, setIcon, stringifyYaml, parseYaml } from 'obsidian';
-import { DuplicateHandling, FormatImporter } from '../format-importer';
+import { FormatImporter } from '../format-importer';
 import { ImportContext } from '../import-context';
 import { i18n } from '../i18n';
 import { parseFilePath } from '../filesystem';
@@ -23,7 +23,7 @@ import {
 import Airtable from 'airtable';
 import { fetchBases, fetchTableSchema, selectRecords } from './airtable-api/api-helpers';
 import { downloadAttachmentList, formatAttachmentsForBody, formatAttachmentsForYAML } from './airtable-api/attachment-helpers';
-import { buildBaseFile, sanitizePropertyName } from './airtable-api/base-file';
+import { buildBaseFile, mergedBaseViews, sanitizePropertyName } from './airtable-api/base-file';
 import { mapAirtableTypeToObsidian } from './airtable-api/field-converter';
 import { computeTableFormulas } from './airtable-api/table-formulas';
 import {
@@ -100,10 +100,6 @@ export class AirtableAPIImporter extends FormatImporter {
 	formulaStrategy: FormulaImportStrategy = 'hybrid';
 	downloadAttachments: boolean = true;
 	viewPropertyName: string = 'Views';
-	get incrementalImport(): boolean {
-		return this.duplicateHandling !== DuplicateHandling.CreateCopy;
-	}
-
 	private picker: TreePicker<AirtableTreeNode>;
 
 	// Tracking data
@@ -1302,32 +1298,18 @@ export class AirtableAPIImporter extends FormatImporter {
 			const existingFile = this.vault.getAbstractFileByPathInsensitive(baseFilePath);
 
 			if (existingFile && existingFile instanceof TFile) {
-				// File exists - update it by merging views
+				// Regenerated from the schema, but a view the user added beside
+				// the imported ones is theirs and is kept.
 				const existingContent = await this.vault.read(existingFile);
 
-				// Parse existing YAML to extract existing views (Obsidian Bases internal format)
 				try {
 					const existingConfig = parseYaml(existingContent);
-					const existingViews = existingConfig.views || [];
+					baseConfig.views = mergedBaseViews(existingConfig?.views ?? [], baseConfig.views ?? []);
 
-					// Merge new views with existing ones (avoid duplicates by view name)
-					const viewMap = new Map();
-					for (const view of existingViews) {
-						viewMap.set(view.name, view);
-					}
-					for (const view of baseConfig.views ?? []) {
-						viewMap.set(view.name, view); // Override if exists
-					}
-
-					// Update config with merged views
-					baseConfig.views = Array.from(viewMap.values());
-
-					// Write updated content
-					const updatedContent = stringifyYaml(baseConfig);
-					await this.vault.modify(existingFile, updatedContent);
+					await this.vault.modify(existingFile, stringifyYaml(baseConfig));
 				}
 				catch {
-					// If parsing fails, just overwrite
+					// Nothing readable to keep, so what the schema says stands.
 					await this.vault.modify(existingFile, content);
 				}
 			}

--- a/src/formats/airtable-api.ts
+++ b/src/formats/airtable-api.ts
@@ -1281,7 +1281,7 @@ export class AirtableAPIImporter extends FormatImporter {
 	/**
 	 * Create a single .base file for the table with multiple views
 	 */
-	private async createBaseFile(ctx: BaseFileContext): Promise<Map<string, string>> {
+	protected async createBaseFile(ctx: BaseFileContext): Promise<Map<string, string>> {
 		const { tableName } = ctx;
 
 		const { path: baseFilePath, config: baseConfig, membershipTokens } = buildBaseFile({

--- a/src/formats/airtable-api.ts
+++ b/src/formats/airtable-api.ts
@@ -8,7 +8,7 @@ import { DuplicateHandling, FormatImporter } from '../format-importer';
 import { ImportContext } from '../import-context';
 import { i18n } from '../i18n';
 import { parseFilePath } from '../filesystem';
-import { extractErrorMessage, sanitizeFileName, getUniqueFilePath, updatePropertyTypes } from '../util';
+import { extractErrorMessage, sanitizeFileName, updatePropertyTypes } from '../util';
 import { areAnySelected, selectedNodes } from '../tree';
 import { describeRequestFailure } from '../request-failure';
 import { TreePicker } from '../tree-view';
@@ -128,7 +128,7 @@ export class AirtableAPIImporter extends FormatImporter {
 	private globalRecordIdToTitle: Map<string, string> = new Map();
 
 	// Prepared data cache for two-phase import
-	private preparedData: PreparedTableData[] = [];
+	protected preparedData: PreparedTableData[] = [];
 
 	// Airtable SDK handles, reused for the duration of an import. A table with
 	// many views would otherwise construct a client per view.
@@ -812,12 +812,9 @@ export class AirtableAPIImporter extends FormatImporter {
 		}
 	}
 
-	private async planRecordPaths(ctx: ImportContext, rootPath: string): Promise<TablePlan[]> {
+	protected async planRecordPaths(ctx: ImportContext, rootPath: string): Promise<TablePlan[]> {
 		// Resolve every path first so record links use final, deduplicated names.
 		const plans: TablePlan[] = [];
-
-		// The vault cannot see files that this import has not written yet.
-		const claimed = new Set<string>();
 
 		for (const tableData of this.preparedData) {
 			if (await ctx.shouldStop()) return plans;
@@ -842,6 +839,7 @@ export class AirtableAPIImporter extends FormatImporter {
 				if (isEmptyRecord(record)) {
 					planned.push({
 						record,
+						note: null,
 						filePath: '',
 						title: 'Untitled Record',
 						skipped: i18n.importer.airtableApi.reasonEmptyRecord(),
@@ -849,29 +847,17 @@ export class AirtableAPIImporter extends FormatImporter {
 					continue;
 				}
 
-				const title = sanitizeFileName(recordTitle(record, primaryFieldName));
-				const desiredPath = normalizePath(`${tablePath}/${title}.md`);
+				// Where the note goes is settled here, before any of them is
+				// written, so a record linking to another can name the file it
+				// will end up in - including one an earlier import already wrote,
+				// wherever the user has since moved it to.
+				const note = this.planNote(tablePath, recordTitle(record, primaryFieldName), record.id);
+				const { basename } = parseFilePath(note.targetPath);
 
-				const existing = this.existingRecordNote(desiredPath, record.id);
-				if (existing) {
-					claimed.add(existing.path.toLowerCase());
-					this.recordIdToPath.set(`${baseId}:${record.id}`, existing.path.replace(/\.md$/, ''));
-					planned.push({
-						record,
-						filePath: existing.path,
-						title,
-						skipped: i18n.importer.airtableApi.reasonAlreadyImported(),
-					});
-					continue;
-				}
-
-				const filePath = this.claimRecordPath(tablePath, title, claimed);
-				const { basename } = parseFilePath(filePath);
-
-				this.recordIdToPath.set(`${baseId}:${record.id}`, filePath.replace(/\.md$/, ''));
+				this.recordIdToPath.set(`${baseId}:${record.id}`, note.targetPath.replace(/\.md$/, ''));
 				this.globalRecordIdToTitle.set(record.id, basename);
 
-				planned.push({ record, filePath, title: basename });
+				planned.push({ record, note, filePath: note.targetPath, title: basename });
 			}
 
 			plans.push({ tableData, tablePath, records: planned });
@@ -880,17 +866,6 @@ export class AirtableAPIImporter extends FormatImporter {
 		this.chooseLinkForms();
 
 		return plans;
-	}
-
-	private claimRecordPath(tablePath: string, title: string, claimed: Set<string>): string {
-		let path = getUniqueFilePath(this.vault, tablePath, `${title}.md`);
-
-		for (let suffix = 1; claimed.has(path.toLowerCase()); suffix++) {
-			path = getUniqueFilePath(this.vault, tablePath, `${title} ${suffix}.md`);
-		}
-
-		claimed.add(path.toLowerCase());
-		return path;
 	}
 
 	private chooseLinkForms(): void {
@@ -1210,10 +1185,21 @@ export class AirtableAPIImporter extends FormatImporter {
 		fileContext: RecordFileContext
 	): Promise<void> {
 		const { primaryFieldName, fields, viewReferences, formulaFieldNames, frontMatterFields } = fileContext;
-		const { record, filePath, title } = planned;
+		const { record, note, filePath, title } = planned;
 
-		if (planned.skipped) {
+		if (planned.skipped || !note) {
 			ctx.reportSkipped(title, planned.skipped);
+			this.processedRecordsCount++;
+			this.reportOverallProgress(ctx);
+			return;
+		}
+
+		// Nothing here can be told from the record: Airtable gives no
+		// modification time, so a decision needs the markdown to compare.
+		// Skip is the exception - it needs no comparison, and settling it now
+		// is what keeps an untouched record from downloading its attachments.
+		const disposition = this.preflightNote(ctx, note);
+		if (disposition === 'skip') {
 			this.processedRecordsCount++;
 			this.reportOverallProgress(ctx);
 			return;
@@ -1246,34 +1232,13 @@ export class AirtableAPIImporter extends FormatImporter {
 			formatAttachmentsForYAML,
 		});
 
-		await this.createMarkdown(filePath, this.withSourceId(content, record.id));
-
-		ctx.reportNoteSuccess(title);
+		const { written } = await this.writePlannedNote(ctx, note, content, { disposition, sourceId: record.id });
+		if (written) ctx.reportNoteSuccess(title);
 
 		this.processedRecordsCount++;
 		this.reportOverallProgress(ctx);
 	}
 
-	/**
-	 * Handle incremental import check for a record
-	 * If file exists with same airtable-id, executes the callback and returns true
-	 * Otherwise returns false to continue with normal import
-	 *
-	 * @param filePath - Path to check
-	 * @param recordId - Airtable record ID to compare
-	 * @returns true if same record already exists (should skip), false otherwise
-	 */
-	private existingRecordNote(filePath: string, recordId: string): TFile | null {
-		if (!this.incrementalImport) {
-			return null;
-		}
-
-		return this.previouslyImported(normalizePath(filePath), recordId);
-	}
-
-	/**
-	 * Create a single .base file for the table with multiple views
-	 */
 	private computeTableFormulas(fields: AirtableFieldSchema[], primaryFieldId: string): Map<string, string> {
 		if (this.formulaStrategy === 'static') {
 			return new Map();

--- a/src/formats/airtable-api.ts
+++ b/src/formats/airtable-api.ts
@@ -217,7 +217,9 @@ export class AirtableAPIImporter extends FormatImporter {
 					this.viewPropertyName = value.trim().replace(/["\\]/g, '') || 'Views';
 				}));
 
-		this.duplicateModes = [DuplicateHandling.CreateCopy, DuplicateHandling.Skip];
+		this.duplicateCaveat = i18n.importer.airtableApi.descNoModifiedTime({
+			update: i18n.output.optionUpdate(),
+		});
 	}
 
 	private createTokenDescription(): DocumentFragment {

--- a/src/formats/airtable-api.ts
+++ b/src/formats/airtable-api.ts
@@ -1221,6 +1221,7 @@ export class AirtableAPIImporter extends FormatImporter {
 				vault: this.vault,
 				downloadAttachments: this.downloadAttachments,
 				placeAttachment: this.attachmentPlacer(filePath),
+				releasePath: path => this.releasePath(path),
 			}),
 			formatAttachmentsForBody: results => formatAttachmentsForBody(results, {
 				currentFilePath: filePath,

--- a/src/formats/airtable-api.ts
+++ b/src/formats/airtable-api.ts
@@ -1303,8 +1303,7 @@ export class AirtableAPIImporter extends FormatImporter {
 				const existingContent = await this.vault.read(existingFile);
 
 				try {
-					const existingConfig = parseYaml(existingContent);
-					baseConfig.views = mergedBaseViews(existingConfig?.views ?? [], baseConfig.views ?? []);
+					baseConfig.views = mergedBaseViews(parseYaml(existingContent), baseConfig.views ?? []);
 
 					await this.vault.modify(existingFile, stringifyYaml(baseConfig));
 				}

--- a/src/formats/airtable-api.ts
+++ b/src/formats/airtable-api.ts
@@ -32,6 +32,7 @@ import {
 	frontMatterFieldsForTable,
 	isEmptyRecord,
 	RECORD_ID_PROPERTY,
+	recordSourceIds,
 	recordTimestamps,
 	recordTitle,
 } from './airtable-api/record-note';
@@ -852,7 +853,7 @@ export class AirtableAPIImporter extends FormatImporter {
 				// written, so a record linking to another can name the file it
 				// will end up in - including one an earlier import already wrote,
 				// wherever the user has since moved it to.
-				const note = this.planNote(tablePath, recordTitle(record, primaryFieldName), record.id);
+				const note = this.planNote(tablePath, recordTitle(record, primaryFieldName), recordSourceIds(baseId, record.id));
 				const { basename } = parseFilePath(note.targetPath);
 
 				this.recordIdToPath.set(`${baseId}:${record.id}`, note.targetPath.replace(/\.md$/, ''));
@@ -1233,9 +1234,9 @@ export class AirtableAPIImporter extends FormatImporter {
 			formatAttachmentsForYAML,
 		});
 
+		// The ids come from the plan, which knows the base this record is in.
 		const { written } = await this.writePlannedNote(ctx, note, content, {
 			disposition,
-			sourceId: record.id,
 			...recordTimestamps(record),
 		});
 		if (written) ctx.reportNoteSuccess(title);

--- a/src/formats/airtable-api.ts
+++ b/src/formats/airtable-api.ts
@@ -32,7 +32,6 @@ import {
 	frontMatterFieldsForTable,
 	isEmptyRecord,
 	RECORD_ID_PROPERTY,
-	recordSourceIds,
 	recordTimestamps,
 	recordTitle,
 } from './airtable-api/record-note';
@@ -852,7 +851,7 @@ export class AirtableAPIImporter extends FormatImporter {
 				// written, so a record linking to another can name the file it
 				// will end up in - including one an earlier import already wrote,
 				// wherever the user has since moved it to.
-				const note = this.planNote(tablePath, recordTitle(record, primaryFieldName), recordSourceIds(baseId, record.id));
+				const note = this.planNote(tablePath, recordTitle(record, primaryFieldName), record.id);
 				const { basename } = parseFilePath(note.targetPath);
 
 				this.recordIdToPath.set(`${baseId}:${record.id}`, note.targetPath.replace(/\.md$/, ''));

--- a/src/formats/airtable-api/attachment-helpers.ts
+++ b/src/formats/airtable-api/attachment-helpers.ts
@@ -41,7 +41,7 @@ async function downloadAttachment(
 	try {
 		const sanitized = sanitizeFileName(attachment.filename);
 
-		// Where it goes is settled first, because the answer may be a file the
+		// Settled before the download, because the answer may be a file the
 		// vault already holds - and then there is nothing to download.
 		const { path, reuse } = await placeAttachment(sanitized, attachment.size);
 		const local: AttachmentResult = { path: normalizePath(path), isLocal: true, filename: sanitized };
@@ -154,8 +154,8 @@ export async function downloadAttachmentList(
 			releasePath,
 		});
 
-		// A file the vault already held was reported as passed over; counting it
-		// as an import as well would count it twice.
+		// A reused file was reported as passed over; counting it as an import
+		// as well would count it twice.
 		if (result.isLocal && !result.reused) {
 			ctx.reportAttachmentSuccess(result.filename ?? attachment.filename);
 		}

--- a/src/formats/airtable-api/attachment-helpers.ts
+++ b/src/formats/airtable-api/attachment-helpers.ts
@@ -19,9 +19,11 @@ async function downloadAttachment(
 		vault: Vault;
 		downloadAttachments: boolean;
 		placeAttachment: (filename: string, size: number | undefined) => Promise<AttachmentPlacement>;
+		/** Give a name back when the download it was chosen for does not arrive. */
+		releasePath: (path: string) => void;
 	}
 ): Promise<AttachmentResult> {
-	const { ctx, vault, downloadAttachments, placeAttachment } = context;
+	const { ctx, vault, downloadAttachments, placeAttachment, releasePath } = context;
 
 	// Every failure path leaves the note pointing at Airtable's own URL, so the
 	// attachment is still reachable even though it is not in the vault
@@ -46,7 +48,7 @@ async function downloadAttachment(
 
 		if (reuse) {
 			ctx.reportSkipped(sanitized, i18n.reason.alreadyInVault());
-			return local;
+			return { ...local, reused: true };
 		}
 
 		ctx.status(i18n.importer.airtableApi.statusDownloadingAttachment({ name: attachment.filename }));
@@ -59,6 +61,7 @@ async function downloadAttachment(
 
 		if (response.status !== 200) {
 			console.warn(`Failed to download attachment: ${attachment.filename}`);
+			releasePath(local.path);
 			return remote;
 		}
 
@@ -136,9 +139,10 @@ export async function downloadAttachmentList(
 		vault: Vault;
 		downloadAttachments: boolean;
 		placeAttachment: (filename: string, size: number | undefined) => Promise<AttachmentPlacement>;
+		releasePath: (path: string) => void;
 	}
 ): Promise<AttachmentResult[]> {
-	const { ctx, vault, downloadAttachments, placeAttachment } = context;
+	const { ctx, vault, downloadAttachments, placeAttachment, releasePath } = context;
 	const results: AttachmentResult[] = [];
 
 	for (const attachment of attachments) {
@@ -147,9 +151,12 @@ export async function downloadAttachmentList(
 			vault,
 			downloadAttachments,
 			placeAttachment,
+			releasePath,
 		});
 
-		if (result.isLocal) {
+		// A file the vault already held was reported as passed over; counting it
+		// as an import as well would count it twice.
+		if (result.isLocal && !result.reused) {
 			ctx.reportAttachmentSuccess(result.filename ?? attachment.filename);
 		}
 

--- a/src/formats/airtable-api/attachment-helpers.ts
+++ b/src/formats/airtable-api/attachment-helpers.ts
@@ -6,7 +6,7 @@ import { requestUrl, normalizePath, TFile } from 'obsidian';
 import type { Vault, App } from 'obsidian';
 import { ImportContext } from '../../import-context';
 import { i18n } from '../../i18n';
-import type { AirtableAttachment, AttachmentResult } from './types';
+import type { AirtableAttachment, AttachmentPlacement, AttachmentResult } from './types';
 import { sanitizeFileName } from '../../util';
 
 /**
@@ -18,10 +18,10 @@ async function downloadAttachment(
 		ctx: ImportContext;
 		vault: Vault;
 		downloadAttachments: boolean;
-		getAvailableAttachmentPath: (filename: string) => Promise<string>;
+		placeAttachment: (filename: string, size: number | undefined) => Promise<AttachmentPlacement>;
 	}
 ): Promise<AttachmentResult> {
-	const { ctx, vault, downloadAttachments, getAvailableAttachmentPath } = context;
+	const { ctx, vault, downloadAttachments, placeAttachment } = context;
 
 	// Every failure path leaves the note pointing at Airtable's own URL, so the
 	// attachment is still reachable even though it is not in the vault
@@ -37,6 +37,18 @@ async function downloadAttachment(
 	}
 
 	try {
+		const sanitized = sanitizeFileName(attachment.filename);
+
+		// Where it goes is settled first, because the answer may be a file the
+		// vault already holds - and then there is nothing to download.
+		const { path, reuse } = await placeAttachment(sanitized, attachment.size);
+		const local: AttachmentResult = { path: normalizePath(path), isLocal: true, filename: sanitized };
+
+		if (reuse) {
+			ctx.reportSkipped(sanitized, i18n.reason.alreadyInVault());
+			return local;
+		}
+
 		ctx.status(i18n.importer.airtableApi.statusDownloadingAttachment({ name: attachment.filename }));
 
 		const response = await requestUrl({
@@ -50,17 +62,9 @@ async function downloadAttachment(
 			return remote;
 		}
 
-		const sanitized = sanitizeFileName(attachment.filename);
+		await vault.createBinary(local.path, response.arrayBuffer);
 
-		// Respects the user's attachment folder settings
-		const normalizedPath = normalizePath(await getAvailableAttachmentPath(sanitized));
-		await vault.createBinary(normalizedPath, response.arrayBuffer);
-
-		return {
-			path: normalizedPath,
-			isLocal: true,
-			filename: sanitized,
-		};
+		return local;
 	}
 	catch (error) {
 		console.error(`Failed to download attachment ${attachment.filename}:`, error);
@@ -131,10 +135,10 @@ export async function downloadAttachmentList(
 		ctx: ImportContext;
 		vault: Vault;
 		downloadAttachments: boolean;
-		getAvailableAttachmentPath: (filename: string) => Promise<string>;
+		placeAttachment: (filename: string, size: number | undefined) => Promise<AttachmentPlacement>;
 	}
 ): Promise<AttachmentResult[]> {
-	const { ctx, vault, downloadAttachments, getAvailableAttachmentPath } = context;
+	const { ctx, vault, downloadAttachments, placeAttachment } = context;
 	const results: AttachmentResult[] = [];
 
 	for (const attachment of attachments) {
@@ -142,7 +146,7 @@ export async function downloadAttachmentList(
 			ctx,
 			vault,
 			downloadAttachments,
-			getAvailableAttachmentPath,
+			placeAttachment,
 		});
 
 		if (result.isLocal) {

--- a/src/formats/airtable-api/base-file.ts
+++ b/src/formats/airtable-api/base-file.ts
@@ -133,13 +133,9 @@ export function buildBaseFile(options: BuildBaseFileOptions): BuiltBaseFile {
 /**
  * The views a rewritten .base should hold.
  *
- * A .base is generated from the table's schema, so an import replaces what it
- * generated. Its views are the exception: the user may have added their own
- * beside the imported ones, and those are theirs to keep. A view the import
- * brings replaces the one of that name; anything else in the file stays.
- *
- * Nothing here reads the duplicate mode. That setting is about notes, and a
- * .base holding a view of a table whose schema has moved on is no use.
+ * An import replaces what it generated, except the views: the user may have
+ * added their own beside the imported ones, and those are theirs to keep. A
+ * view the import brings replaces the one of that name.
  */
 export function mergedBaseViews(existing: unknown, importedViews: BasesConfigFileView[]): BasesConfigFileView[] {
 	const byName = new Map<string, BasesConfigFileView>();
@@ -151,11 +147,9 @@ export function mergedBaseViews(existing: unknown, importedViews: BasesConfigFil
 }
 
 /**
- * The views in a .base as it stands, which is a file the user can edit.
- *
- * Anything in it that is not a view with a name is not something to carry
- * over: there would be no name to keep it under, and no way to tell whether
- * the import means to replace it.
+ * The views in a .base as it stands, which is a file the user can edit. What
+ * is not a named view cannot be carried over: there is no name to keep it
+ * under, and no way to tell whether the import means to replace it.
  */
 function viewsIn(config: unknown): BasesConfigFileView[] {
 	if (typeof config !== 'object' || config === null) return [];

--- a/src/formats/airtable-api/base-file.ts
+++ b/src/formats/airtable-api/base-file.ts
@@ -141,14 +141,28 @@ export function buildBaseFile(options: BuildBaseFileOptions): BuiltBaseFile {
  * Nothing here reads the duplicate mode. That setting is about notes, and a
  * .base holding a view of a table whose schema has moved on is no use.
  */
-export function mergedBaseViews(
-	existingViews: BasesConfigFileView[],
-	importedViews: BasesConfigFileView[],
-): BasesConfigFileView[] {
+export function mergedBaseViews(existing: unknown, importedViews: BasesConfigFileView[]): BasesConfigFileView[] {
 	const byName = new Map<string, BasesConfigFileView>();
 
-	for (const view of existingViews) byName.set(view.name, view);
+	for (const view of viewsIn(existing)) byName.set(view.name, view);
 	for (const view of importedViews) byName.set(view.name, view);
 
 	return [...byName.values()];
+}
+
+/**
+ * The views in a .base as it stands, which is a file the user can edit.
+ *
+ * Anything in it that is not a view with a name is not something to carry
+ * over: there would be no name to keep it under, and no way to tell whether
+ * the import means to replace it.
+ */
+function viewsIn(config: unknown): BasesConfigFileView[] {
+	if (typeof config !== 'object' || config === null) return [];
+
+	const views = (config as { views?: unknown }).views;
+	if (!Array.isArray(views)) return [];
+
+	return views.filter((view): view is BasesConfigFileView =>
+		typeof view === 'object' && view !== null && typeof (view as { name?: unknown }).name === 'string');
 }

--- a/src/formats/airtable-api/base-file.ts
+++ b/src/formats/airtable-api/base-file.ts
@@ -129,3 +129,26 @@ export function buildBaseFile(options: BuildBaseFileOptions): BuiltBaseFile {
 
 	return { path: baseFilePath, membershipTokens, config };
 }
+
+/**
+ * The views a rewritten .base should hold.
+ *
+ * A .base is generated from the table's schema, so an import replaces what it
+ * generated. Its views are the exception: the user may have added their own
+ * beside the imported ones, and those are theirs to keep. A view the import
+ * brings replaces the one of that name; anything else in the file stays.
+ *
+ * Nothing here reads the duplicate mode. That setting is about notes, and a
+ * .base holding a view of a table whose schema has moved on is no use.
+ */
+export function mergedBaseViews(
+	existingViews: BasesConfigFileView[],
+	importedViews: BasesConfigFileView[],
+): BasesConfigFileView[] {
+	const byName = new Map<string, BasesConfigFileView>();
+
+	for (const view of existingViews) byName.set(view.name, view);
+	for (const view of importedViews) byName.set(view.name, view);
+
+	return [...byName.values()];
+}

--- a/src/formats/airtable-api/base-file.ts
+++ b/src/formats/airtable-api/base-file.ts
@@ -163,6 +163,10 @@ function viewsIn(config: unknown): BasesConfigFileView[] {
 	const views = (config as { views?: unknown }).views;
 	if (!Array.isArray(views)) return [];
 
-	return views.filter((view): view is BasesConfigFileView =>
-		typeof view === 'object' && view !== null && typeof (view as { name?: unknown }).name === 'string');
+	return views.filter((view): view is BasesConfigFileView => {
+		if (typeof view !== 'object' || view === null) return false;
+		const { name, type } = view as { name?: unknown, type?: unknown };
+
+		return typeof name === 'string' && typeof type === 'string';
+	});
 }

--- a/src/formats/airtable-api/record-note.ts
+++ b/src/formats/airtable-api/record-note.ts
@@ -1,4 +1,5 @@
 import { FrontMatterCache } from 'obsidian';
+import type { SourceIdentity } from '../../format-importer';
 import { sanitizeFileName, serializeFrontMatter } from '../../util';
 import { applyTemplate } from '../../template';
 import { convertFieldValue } from './field-converter';
@@ -8,17 +9,19 @@ import type { AirtableAttachment, AirtableFieldSchema, AirtableRecord, Attachmen
 export const RECORD_ID_PROPERTY = 'airtable-id';
 
 /**
- * What a record's note is known by, newest first.
+ * What a record's note is known by.
  *
  * A record id is only unique within its base, which is why the importer's own
  * map is keyed by both. The note is keyed by both now too, so two bases that
  * happen to share a record id do not import onto one another's notes.
  *
- * The bare id follows it because that is what earlier versions wrote, and a
- * note carrying one still belongs to its record.
+ * The bare id is what earlier versions wrote, and is recognised only where such
+ * a version would have put the note. Recognising it anywhere would undo the
+ * point of the change: every base's record rec1 would match the one note
+ * carrying "rec1", which is the collision the base id is here to prevent.
  */
-export function recordSourceIds(baseId: string, recordId: string): string[] {
-	return [`${baseId}:${recordId}`, recordId];
+export function recordSourceIds(baseId: string, recordId: string): SourceIdentity {
+	return { id: `${baseId}:${recordId}`, formerly: [recordId] };
 }
 
 /**

--- a/src/formats/airtable-api/record-note.ts
+++ b/src/formats/airtable-api/record-note.ts
@@ -8,6 +8,20 @@ import type { AirtableAttachment, AirtableFieldSchema, AirtableRecord, Attachmen
 export const RECORD_ID_PROPERTY = 'airtable-id';
 
 /**
+ * What a record's note is known by, newest first.
+ *
+ * A record id is only unique within its base, which is why the importer's own
+ * map is keyed by both. The note is keyed by both now too, so two bases that
+ * happen to share a record id do not import onto one another's notes.
+ *
+ * The bare id follows it because that is what earlier versions wrote, and a
+ * note carrying one still belongs to its record.
+ */
+export function recordSourceIds(baseId: string, recordId: string): string[] {
+	return [`${baseId}:${recordId}`, recordId];
+}
+
+/**
  * The times to write onto a record's note.
  *
  * Only ctime. Airtable reports when a record was created and nothing about

--- a/src/formats/airtable-api/record-note.ts
+++ b/src/formats/airtable-api/record-note.ts
@@ -1,5 +1,4 @@
 import { FrontMatterCache } from 'obsidian';
-import type { SourceIdentity } from '../../format-importer';
 import { sanitizeFileName, serializeFrontMatter } from '../../util';
 import { applyTemplate } from '../../template';
 import { convertFieldValue } from './field-converter';
@@ -7,22 +6,6 @@ import { sanitizePropertyName } from './base-file';
 import type { AirtableAttachment, AirtableFieldSchema, AirtableRecord, AttachmentResult } from './types';
 
 export const RECORD_ID_PROPERTY = 'airtable-id';
-
-/**
- * What a record's note is known by.
- *
- * A record id is only unique within its base, which is why the importer's own
- * map is keyed by both. The note is keyed by both now too, so two bases that
- * happen to share a record id do not import onto one another's notes.
- *
- * The bare id is what earlier versions wrote, and is recognised only where such
- * a version would have put the note. Recognising it anywhere would undo the
- * point of the change: every base's record rec1 would match the one note
- * carrying "rec1", which is the collision the base id is here to prevent.
- */
-export function recordSourceIds(baseId: string, recordId: string): SourceIdentity {
-	return { id: `${baseId}:${recordId}`, formerly: [recordId] };
-}
 
 /**
  * The times to write onto a record's note.

--- a/src/formats/airtable-api/record-note.ts
+++ b/src/formats/airtable-api/record-note.ts
@@ -8,14 +8,14 @@ import type { AirtableAttachment, AirtableFieldSchema, AirtableRecord, Attachmen
 export const RECORD_ID_PROPERTY = 'airtable-id';
 
 /**
- * The times to write onto a record's note.
+ * The times to write onto a record's note: ctime only.
  *
- * Only ctime. Airtable reports when a record was created and nothing about
- * when it last changed - a "Last modified time" field exists only if the base
- * was built with one, is named whatever its author called it, and can be
- * scoped to watch a few fields rather than all of them. A modification time
- * that is wrong about a record having changed is worse than none, so an import
- * writes none and compares the note's text instead.
+ * Airtable reports when a record was created and nothing about when it last
+ * changed - a "Last modified time" field exists only if the base was built
+ * with one, is named whatever its author called it, and can be scoped to a few
+ * fields rather than all of them. A modification time that is wrong about a
+ * record having changed is worse than none, so an import writes none and
+ * compares the note's text instead.
  */
 export function recordTimestamps(record: AirtableRecord): { ctime?: number } {
 	const created = Date.parse(record.createdTime ?? '');

--- a/src/formats/airtable-api/record-note.ts
+++ b/src/formats/airtable-api/record-note.ts
@@ -7,6 +7,22 @@ import type { AirtableAttachment, AirtableFieldSchema, AirtableRecord, Attachmen
 
 export const RECORD_ID_PROPERTY = 'airtable-id';
 
+/**
+ * The times to write onto a record's note.
+ *
+ * Only ctime. Airtable reports when a record was created and nothing about
+ * when it last changed - a "Last modified time" field exists only if the base
+ * was built with one, is named whatever its author called it, and can be
+ * scoped to watch a few fields rather than all of them. A modification time
+ * that is wrong about a record having changed is worse than none, so an import
+ * writes none and compares the note's text instead.
+ */
+export function recordTimestamps(record: AirtableRecord): { ctime?: number } {
+	const created = Date.parse(record.createdTime ?? '');
+
+	return Number.isNaN(created) ? {} : { ctime: created };
+}
+
 export function extractStringValue(value: any): string {
 	if (value === null || value === undefined) return '';
 	if (typeof value === 'object' && !Array.isArray(value) && value.text !== undefined) {

--- a/src/formats/airtable-api/types.ts
+++ b/src/formats/airtable-api/types.ts
@@ -163,6 +163,8 @@ export interface AttachmentPlacement {
 export interface AttachmentResult {
 	path: string;
 	isLocal: boolean;
+	/** The vault already held it, so it is not one this import brought in. */
+	reused?: boolean;
 	filename?: string;
 	/** MIME type from Airtable, used to decide whether the link should be an embed */
 	mimeType?: string;

--- a/src/formats/airtable-api/types.ts
+++ b/src/formats/airtable-api/types.ts
@@ -2,6 +2,8 @@
  * Type definitions for Airtable API importer
  */
 
+import type { PlannedNote } from '../../format-importer';
+
 /**
  * Minimal interface for status reporting
  * Used by API helpers that only need to report status messages
@@ -176,9 +178,12 @@ export interface PreparedTableData {
 
 export interface PlannedRecord {
 	record: AirtableRecord;
+	/** Where the note goes, and the earlier import it matches. Empty records have none. */
+	note: PlannedNote | null;
+	/** note.targetPath, or '' for a record with no note to write. */
 	filePath: string;
 	title: string;
-	/** Why this record was passed over, ready to show. */
+	/** Why this record was passed over before it was ever planned, ready to show. */
 	skipped?: string;
 }
 

--- a/src/formats/airtable-api/types.ts
+++ b/src/formats/airtable-api/types.ts
@@ -140,7 +140,21 @@ export interface AirtableAttachment {
 	id: string;
 	url: string;
 	filename: string;
+	/** Bytes, as the records endpoint reports them. Absent on an older response. */
+	size?: number;
 	type: string;
+}
+
+/**
+ * Where an attachment belongs, and whether it is already there.
+ *
+ * Answered before anything is downloaded, so a second import of a file it
+ * already holds costs neither the bytes nor a second copy of them.
+ */
+export interface AttachmentPlacement {
+	path: string;
+	/** The file already at that path, when it is this same attachment. */
+	reuse: boolean;
 }
 
 /**

--- a/src/formats/airtable-api/types.ts
+++ b/src/formats/airtable-api/types.ts
@@ -146,14 +146,13 @@ export interface AirtableAttachment {
 }
 
 /**
- * Where an attachment belongs, and whether it is already there.
- *
- * Answered before anything is downloaded, so a second import of a file it
- * already holds costs neither the bytes nor a second copy of them.
+ * Where an attachment belongs, answered before anything is downloaded, so a
+ * second import of a file the vault already holds costs neither the bytes nor
+ * a second copy of them.
  */
 export interface AttachmentPlacement {
 	path: string;
-	/** The file already at that path, when it is this same attachment. */
+	/** The file already at that path is this same attachment. */
 	reuse: boolean;
 }
 

--- a/src/formats/notion-api.ts
+++ b/src/formats/notion-api.ts
@@ -1,5 +1,5 @@
 import { FrontMatterCache, Notice, normalizePath, requestUrl, TFile, TFolder, DataWriteOptions } from 'obsidian';
-import { DuplicateHandling, FormatImporter } from '../format-importer';
+import { DuplicateHandling, FormatImporter, leavesTheNoteAlone } from '../format-importer';
 import { ImportContext } from '../import-context';
 import { i18n } from '../i18n';
 import { Client, PageObjectResponse } from '@notionhq/client';
@@ -133,7 +133,8 @@ export class NotionAPIImporter extends FormatImporter {
 	 * is not rewritten to point at them. Keeping the two apart is what lets a
 	 * preserved note keep its children without the note being touched.
 	 */
-	private syncedChildrenToReach: Set<string> = new Set();
+	private syncedChildPagesToReach: Set<string> = new Set();
+	private syncedChildDatabasesToReach: Set<string> = new Set();
 
 	init() {
 		// No file chooser needed since we're importing via API
@@ -394,7 +395,8 @@ export class NotionAPIImporter extends FormatImporter {
 	async import(ctx: ImportContext): Promise<void> {
 		this.writtenPaths.clear();
 		this.recoveredPaths.clear();
-		this.syncedChildrenToReach.clear();
+		this.syncedChildPagesToReach.clear();
+		this.syncedChildDatabasesToReach.clear();
 
 		// Validate inputs
 		if (!this.notionToken) {
@@ -487,6 +489,10 @@ export class NotionAPIImporter extends FormatImporter {
 				}
 			}
 
+			// Before the passes that turn placeholders into links, so what they
+			// are asked to link to is in the vault by the time they look.
+			await this.reachSyncedChildren(ctx);
+
 			// After all pages are imported, replace relation placeholders
 			ctx.status(i18n.importer.notionApi.statusRelationLinks());
 			await this.replaceRelationPlaceholders(ctx);
@@ -521,7 +527,7 @@ export class NotionAPIImporter extends FormatImporter {
 	 * The fake block only needs the 'id' and 'type' fields, as the rest of the information is fetched
 	 * from the Notion API inside convertChildDatabase().
 	 */
-	private async importTopLevelDatabase(
+	protected async importTopLevelDatabase(
 		ctx: ImportContext,
 		databaseId: string,
 		parentPath: string,
@@ -651,9 +657,7 @@ export class NotionAPIImporter extends FormatImporter {
 			// since, can still have links an interrupted run left unresolved
 			// repaired. A note edited in Obsidian since the import is the
 			// user's, and nothing here may write to it at all.
-			const leavingItAlone = disposition === 'skip'
-				|| disposition === 'unchanged'
-				|| disposition === 'preserve';
+			const leavingItAlone = leavesTheNoteAlone(disposition);
 
 			if (planned?.file && leavingItAlone) {
 				await this.adoptSkippedNote(planned.file, pageId, disposition !== 'preserve');
@@ -1204,8 +1208,6 @@ export class NotionAPIImporter extends FormatImporter {
  * Performance: Only processes files that contain synced child placeholders (O(n) where n = files with placeholders)
  */
 	protected async replaceSyncedChildPlaceholders(ctx: ImportContext): Promise<void> {
-		await this.reachSyncedChildren(ctx);
-
 		if (this.syncedChildPagePlaceholders.size === 0 && this.syncedChildDatabasePlaceholders.size === 0) {
 			return;
 		}
@@ -1429,15 +1431,21 @@ export class NotionAPIImporter extends FormatImporter {
 		const recovered = this.duplicateHandling === DuplicateHandling.CreateCopy
 			? await this.recoverSyncedBlockNote(ctx, folderPath, fileName, blockId)
 			: null;
-		if (recovered) return recovered;
 
-		const planned = this.planNote(folderPath, fileName.replace(/\.md$/i, ''), blockId);
+		// A note this run already wrote is not written again, but the block is
+		// still walked: Notion may have gained a page under it between the run
+		// that stopped and this one. The note's own placeholders were read out
+		// of the file when it was recognised.
+		if (recovered) {
+			this.noteChildrenOf(await convert(recovered, { forChildrenOnly: true, keepPlaceholders: false }));
+			return recovered;
+		}
+
+		const planned = this.planNote(folderPath, this.syncedBlockTitle(folderPath, fileName), blockId);
 		const sourceMtime = lastEditedTime ? new Date(lastEditedTime).getTime() : undefined;
 		const disposition = this.preflightNote(ctx, planned, sourceMtime);
 
-		const leavingItAlone = disposition === 'skip'
-			|| disposition === 'unchanged'
-			|| disposition === 'preserve';
+		const leavingItAlone = leavesTheNoteAlone(disposition);
 
 		// The placeholders of a note being left alone are the ones in the note,
 		// not the ones in what was just converted: an earlier run may have been
@@ -1455,9 +1463,7 @@ export class NotionAPIImporter extends FormatImporter {
 
 			// Whatever is under it is still fetched, whether or not its note is
 			// ever touched again.
-			for (const type of [PlaceholderType.SYNCED_CHILD_PAGE, PlaceholderType.SYNCED_CHILD_DATABASE]) {
-				for (const id of extractPlaceholderIds(markdown, type)) this.syncedChildrenToReach.add(id);
-			}
+			this.noteChildrenOf(markdown);
 
 			return planned.file?.path ?? planned.targetPath;
 		}
@@ -1476,6 +1482,16 @@ export class NotionAPIImporter extends FormatImporter {
 		return file.path;
 	}
 
+	/** Remember the pages and databases a synced block's markdown points into. */
+	private noteChildrenOf(markdown: string): void {
+		for (const id of extractPlaceholderIds(markdown, PlaceholderType.SYNCED_CHILD_PAGE)) {
+			this.syncedChildPagesToReach.add(id);
+		}
+		for (const id of extractPlaceholderIds(markdown, PlaceholderType.SYNCED_CHILD_DATABASE)) {
+			this.syncedChildDatabasesToReach.add(id);
+		}
+	}
+
 	/**
 	 * Import what sits under a synced block whose note is not being rewritten.
 	 *
@@ -1483,25 +1499,51 @@ export class NotionAPIImporter extends FormatImporter {
 	 * only looks inside files it is going to rewrite. A note left alone is not
 	 * one of those, and a note the user has edited must never be - so what is
 	 * under it is fetched here instead, where no file is touched.
+	 *
+	 * A page and a database are asked for as what they are. Guessing at one and
+	 * falling back to the other cannot work: fetchAndImportPage reports its own
+	 * failures rather than raising them, so the fallback would never run and
+	 * every database would be reported as a page that could not be read.
 	 */
-	private async reachSyncedChildren(ctx: ImportContext): Promise<void> {
-		for (const id of this.syncedChildrenToReach) {
+	protected async reachSyncedChildren(ctx: ImportContext): Promise<void> {
+		for (const pageId of this.syncedChildPagesToReach) {
 			if (await ctx.shouldStop()) return;
-			if (this.notionIdToPath.has(id) || this.processedDatabases.has(id)) continue;
+			if (this.notionIdToPath.has(pageId)) continue;
+
+			await this.fetchAndImportPage({ ctx, pageId, parentPath: this.outputRootPath });
+		}
+
+		for (const databaseId of this.syncedChildDatabasesToReach) {
+			if (await ctx.shouldStop()) return;
+			if (this.processedDatabases.has(databaseId)) continue;
 
 			try {
-				await this.fetchAndImportPage({ ctx, pageId: id, parentPath: this.outputRootPath });
+				await this.importTopLevelDatabase(ctx, databaseId, this.outputRootPath);
 			}
-			catch {
-				// Not a page, or not one this token can read. A database of that
-				// id is the other thing it can be, and the last thing to try.
-				try {
-					await this.importTopLevelDatabase(ctx, id, this.outputRootPath);
-				}
-				catch (error) {
-					console.warn(`Could not import what a synced block holds: ${id}`, error);
-				}
+			catch (error) {
+				console.warn(`Could not import a database a synced block holds: ${databaseId}`, error);
 			}
+		}
+	}
+
+	/**
+	 * What to call a synced block's note, when the id may not be there to ask.
+	 *
+	 * Two synced blocks on one page are named alike, so the second is "… 1.md".
+	 * With ids kept, which is which is never in doubt - the id finds the note
+	 * wherever it is. With "Save source ID" off there are no ids by the time the
+	 * next import runs, and the name is all that is left: so the second block
+	 * takes the second name, rather than the first name nothing is using, which
+	 * would have been "… 2.md" and then "… 3.md" on the import after that.
+	 */
+	private syncedBlockTitle(folderPath: string, fileName: string): string {
+		const { basename } = parseFilePath(fileName);
+
+		for (let nth = 0; ; nth++) {
+			const title = nth === 0 ? basename : `${basename} ${nth}`;
+			const path = normalizePath(folderPath ? `${folderPath}/${title}.md` : `${title}.md`);
+
+			if (!this.hasClaimed(path)) return title;
 		}
 	}
 
@@ -1519,6 +1561,9 @@ export class NotionAPIImporter extends FormatImporter {
 		fileName: string,
 		blockId: string,
 	): Promise<string | null> {
+		// The ids are only left behind for a run that meant to clear them.
+		if (this.saveSourceId) return null;
+
 		const { basename, extension } = parseFilePath(fileName);
 
 		for (let nth = 0; ; nth++) {

--- a/src/formats/notion-api.ts
+++ b/src/formats/notion-api.ts
@@ -43,11 +43,10 @@ function childPageIds(blocksCache: Map<string, { id: string, type: string }[]>):
 /**
  * The folder holding what belongs to a page: the one named after its note.
  *
- * A page importing for the first time is written inside that folder, so the
- * folder is the one already holding it. A note the user has moved, or one
- * written when the page had no children to keep, is not - and its children go
- * into a folder of the note's name beside it rather than into whatever folder
- * the note happens to be sharing.
+ * A page importing for the first time is written inside that folder already.
+ * A note the user has moved, or one written when the page had no children, is
+ * not, so its children go into a folder of the note's name beside it rather
+ * than into whatever folder the note happens to be sharing.
  */
 export function childFolderOf(notePath: string): string {
 	const { parent, basename } = parseFilePath(notePath);
@@ -76,11 +75,8 @@ export class NotionAPIImporter extends FormatImporter {
 	coverPropertyName: string = 'cover'; // Custom property name for page cover
 	databasePropertyName: string = 'base'; // Property name for linking pages to their database
 	/**
-	 * Whether a file already in the vault may stand in for one being imported.
-	 *
 	 * Every mode but "Create a copy": the point of making a copy is to leave
-	 * what is there alone and write your own, and that goes for the attachments
-	 * as much as the notes.
+	 * what is there alone and write your own, attachments as much as notes.
 	 */
 	get reuseExistingAttachments(): boolean {
 		return this.duplicateHandling !== DuplicateHandling.CreateCopy;
@@ -113,8 +109,6 @@ export class NotionAPIImporter extends FormatImporter {
 	// Track mention placeholders for efficient replacement (similar to relationPlaceholders)
 	// Maps source file path to the set of mentioned page/database IDs
 	// Using file path as key allows O(1) file lookup instead of O(n) search
-	// Protected because it is the record of which files the passes after the
-	// import will rewrite, and what belongs in it is worth a test.
 	protected mentionPlaceholders: Map<string, Set<string>> = new Map();
 	// Track synced blocks mapping (original block ID -> file path)
 	// Used to reference synced block content across the vault
@@ -127,11 +121,8 @@ export class NotionAPIImporter extends FormatImporter {
 	/**
 	 * Pages and databases under a synced block whose note is not being written.
 	 *
-	 * What is under a synced block and what is written into its note are two
-	 * questions. A note left alone still has its children fetched - they may
-	 * have changed, or be gone from the vault - but a note the user has edited
-	 * is not rewritten to point at them. Keeping the two apart is what lets a
-	 * preserved note keep its children without the note being touched.
+	 * A note left alone still has its children fetched - they may have changed,
+	 * or be gone from the vault - but is not rewritten to point at them.
 	 */
 	private syncedChildPagesToReach: Set<string> = new Set();
 	private syncedChildDatabasesToReach: Set<string> = new Set();
@@ -490,7 +481,7 @@ export class NotionAPIImporter extends FormatImporter {
 			}
 
 			// Before the passes that turn placeholders into links, so what they
-			// are asked to link to is in the vault by the time they look.
+			// link to is in the vault by the time they look.
 			await this.reachSyncedChildren(ctx);
 
 			// After all pages are imported, replace relation placeholders
@@ -628,10 +619,8 @@ export class NotionAPIImporter extends FormatImporter {
 			// Discover all children first so remaining decreases monotonically.
 			this.pagesDiscovered(ctx, childPageIds(blocksCache));
 
-			// A page with children keeps them in a folder of its own name; one
-			// without is a file where it stands. The folder is chosen before the
-			// note so a page importing for the first time lands inside it, as
-			// it always has.
+			// The folder is chosen before the note so a page importing for the
+			// first time lands inside it, as it always has.
 			const homeFolder = hasChildren ? this.pageFolder(parentPath, sanitizedTitle) : parentPath;
 
 			// "Create a copy" is not looking for a note to write over, but one
@@ -640,10 +629,6 @@ export class NotionAPIImporter extends FormatImporter {
 			const recovered = this.duplicateHandling === DuplicateHandling.CreateCopy
 				&& await this.alreadyWrittenByAnUnfinishedImport(desiredPath, pageId, ctx);
 
-			// Where the note goes, settled before a block is converted: its
-			// attachments, its links and its child pages are all placed
-			// relative to it, and a page the user moved keeps the note it has.
-			//
 			// Notion says when it last changed the page, and an import writes
 			// that onto the note, so a page nobody has touched at either end is
 			// known to be unchanged without reading a word of it.
@@ -652,11 +637,6 @@ export class NotionAPIImporter extends FormatImporter {
 			const disposition = planned ? this.preflightNote(ctx, planned, sourceMtime) : 'skip';
 			const mdFilePath = planned ? planned.targetPath : desiredPath;
 
-			// Three ways of leaving a note alone, and they are not the same. A
-			// note the user asked to skip, and one the source has not changed
-			// since, can still have links an interrupted run left unresolved
-			// repaired. A note edited in Obsidian since the import is the
-			// user's, and nothing here may write to it at all.
 			const leavingItAlone = leavesTheNoteAlone(disposition);
 
 			if (planned?.file && leavingItAlone) {
@@ -671,11 +651,7 @@ export class NotionAPIImporter extends FormatImporter {
 				return;
 			}
 
-			// Where everything belonging to this page goes. Children go in the
-			// folder named after the note: the one holding it when the note is
-			// where this import would have put it, and a folder beside it when
-			// the user has moved the note or a leaf has grown children. A page
-			// without children keeps its synced blocks wherever the note is.
+			// A page without children keeps its synced blocks wherever the note is.
 			const pageFolderPath = hasChildren
 				? childFolderOf(mdFilePath)
 				: parseFilePath(mdFilePath).parent;
@@ -698,9 +674,6 @@ export class NotionAPIImporter extends FormatImporter {
 				downloadExternalAttachments: this.downloadExternalAttachments,
 				singleLineBreaks: this.singleLineBreaks, // Single line breaks mode
 				reuseExistingAttachments: this.reuseExistingAttachments,
-				// A page being left as it is still has to be walked, because a
-				// child of it may have changed. Nothing the walk turns up is
-				// worth downloading: the markdown around it is thrown away.
 				forChildrenOnly: shouldSkipParentFile,
 				indentLevel: 0,
 				blocksCache, // reuse cached blocks
@@ -765,9 +738,8 @@ export class NotionAPIImporter extends FormatImporter {
 				frontMatter[this.databasePropertyName] = `[[${databaseTag}]]`;
 			}
 
-			// Extract all other properties from the page. Only the note being
-			// written has any use for them, and reading them downloads whatever
-			// its file properties point at.
+			// Only a note being written has any use for them, and reading them
+			// downloads whatever its file properties point at.
 			const extractedProps = shouldSkipParentFile ? {} : await extractFrontMatter({
 				page,
 				formulaStrategy: this.formulaStrategy,
@@ -873,10 +845,6 @@ export class NotionAPIImporter extends FormatImporter {
 			if (!shouldSkipParentFile && planned) {
 				const fullContent = serializeFrontMatter(frontMatter) + markdownContent;
 
-				// The path was settled before the conversion, and everything the
-				// conversion resolved - attachments, links, the folder the child
-				// pages went into - was resolved against it. Choosing another one
-				// here would leave all of that pointing at a note that is not here.
 				const options: DataWriteOptions = {};
 				if (page.created_time) options.ctime = new Date(page.created_time).getTime();
 				if (page.last_edited_time) options.mtime = new Date(page.last_edited_time).getTime();
@@ -1387,17 +1355,14 @@ export class NotionAPIImporter extends FormatImporter {
 	/**
 	 * Take on a note this import is leaving as it stands.
 	 *
-	 * Being left alone is not being left out. Pages link to one another, and an
-	 * earlier run may have been interrupted before it could turn its
+	 * An earlier run may have been interrupted before it could turn its
 	 * placeholders into links, so what is still waiting in the file is read back
 	 * out of it here and resolved with everything else once the import is done.
-	 *
-	 * Unless the note has been edited in Obsidian since it was imported. Then it
-	 * is the user's, and the most this import may do is remember where it is.
+	 * Not when the user has edited the note since: then it is theirs, and the
+	 * most this import may do is remember where it is.
 	 */
 	protected async adoptSkippedNote(file: TFile, notionId: string, mayRewrite = true): Promise<void> {
-		// Other pages link to it whatever this import does with it, so where it
-		// is has to be known even when nothing may be written to it.
+		// Other pages link to it whatever this import does with it.
 		this.notionIdToPath.set(notionId, file.path.replace(/\.md$/, ''));
 		if (!mayRewrite) return;
 
@@ -1416,26 +1381,20 @@ export class NotionAPIImporter extends FormatImporter {
 	 * It used to ask for a name nothing was using, so every import wrote
 	 * another one: "Page synced block 1.md", then "Page synced block 2.md". The
 	 * note carries the block's id now, which is what lets a later import find
-	 * the one it wrote before and leave it, or bring it up to date.
-	 *
-	 * Converted whatever is decided, because a synced block can hold child
-	 * pages of its own and they are reached by converting it.
+	 * the one it wrote before. Converted whatever is decided, because a synced
+	 * block can hold child pages and they are reached by converting it.
 	 */
 	protected async importSyncedBlockFile(ctx: ImportContext, request: SyncedBlockRequest): Promise<string> {
 		const { blockId, folderPath, fileName, createdTime, lastEditedTime, convert } = request;
 
 		// "Create a copy" is not looking for a note to reuse, but one this run
-		// wrote before it was interrupted is still its own - and with the ids
-		// index turned off in that mode, the file itself is the only place left
-		// to recognise it from.
+		// wrote before it was interrupted is still its own.
 		const recovered = this.duplicateHandling === DuplicateHandling.CreateCopy
 			? await this.recoverSyncedBlockNote(ctx, folderPath, fileName, blockId)
 			: null;
 
-		// A note this run already wrote is not written again, but the block is
-		// still walked: Notion may have gained a page under it between the run
-		// that stopped and this one. The note's own placeholders were read out
-		// of the file when it was recognised.
+		// Still walked, because Notion may have gained a page under it between
+		// the run that stopped and this one.
 		if (recovered) {
 			this.noteChildrenOf(await convert(recovered, { forChildrenOnly: true, keepPlaceholders: false }));
 			return recovered;
@@ -1447,12 +1406,9 @@ export class NotionAPIImporter extends FormatImporter {
 
 		const leavingItAlone = leavesTheNoteAlone(disposition);
 
-		// The placeholders of a note being left alone are the ones in the note,
-		// not the ones in what was just converted: an earlier run may have been
-		// interrupted before it could resolve them, and what it left behind is
-		// what needs repairing. Reading them out of the file is adoptSkippedNote,
-		// the same as a page's - unless the user has edited it, when the note is
-		// theirs and nothing may rewrite it.
+		// The placeholders worth repairing in a note being left alone are the
+		// ones already in the file, not the ones just converted, so
+		// adoptSkippedNote reads them back out instead.
 		const markdown = await convert(planned.targetPath, {
 			forChildrenOnly: leavingItAlone,
 			keepPlaceholders: !leavingItAlone,
@@ -1461,16 +1417,14 @@ export class NotionAPIImporter extends FormatImporter {
 		if (leavingItAlone) {
 			if (planned.file) await this.adoptSkippedNote(planned.file, blockId, disposition !== 'preserve');
 
-			// Whatever is under it is still fetched, whether or not its note is
-			// ever touched again.
 			this.noteChildrenOf(markdown);
 
 			return planned.file?.path ?? planned.targetPath;
 		}
 
 		// The id goes in whether or not the user asked to keep it, as a page's
-		// does: an import that is interrupted leaves notes it can recognise as
-		// its own, and cleanupNotionIds takes the ids back out at the end.
+		// does, so an interrupted import leaves notes it can recognise as its
+		// own; cleanupNotionIds takes the ids back out at the end.
 		const content = serializeFrontMatter({ [NOTION_ID_PROPERTY]: blockId }) + markdown;
 		const options: DataWriteOptions = {};
 		if (createdTime) options.ctime = new Date(createdTime).getTime();
@@ -1500,10 +1454,9 @@ export class NotionAPIImporter extends FormatImporter {
 	 * one of those, and a note the user has edited must never be - so what is
 	 * under it is fetched here instead, where no file is touched.
 	 *
-	 * A page and a database are asked for as what they are. Guessing at one and
-	 * falling back to the other cannot work: fetchAndImportPage reports its own
-	 * failures rather than raising them, so the fallback would never run and
-	 * every database would be reported as a page that could not be read.
+	 * A page and a database are asked for as what they are: fetchAndImportPage
+	 * reports its own failures rather than raising them, so guessing at one and
+	 * falling back to the other would never reach the fallback.
 	 */
 	protected async reachSyncedChildren(ctx: ImportContext): Promise<void> {
 		for (const pageId of this.syncedChildPagesToReach) {
@@ -1530,11 +1483,10 @@ export class NotionAPIImporter extends FormatImporter {
 	 * What to call a synced block's note, when the id may not be there to ask.
 	 *
 	 * Two synced blocks on one page are named alike, so the second is "… 1.md".
-	 * With ids kept, which is which is never in doubt - the id finds the note
-	 * wherever it is. With "Save source ID" off there are no ids by the time the
-	 * next import runs, and the name is all that is left: so the second block
-	 * takes the second name, rather than the first name nothing is using, which
-	 * would have been "… 2.md" and then "… 3.md" on the import after that.
+	 * With "Save source ID" off there are no ids by the time the next import
+	 * runs and the name is all that is left, so the second block takes the
+	 * second name rather than the first name nothing is using - which would
+	 * have been "… 2.md", and "… 3.md" on the import after that.
 	 */
 	private syncedBlockTitle(folderPath: string, fileName: string): string {
 		const { basename } = parseFilePath(fileName);
@@ -1548,12 +1500,10 @@ export class NotionAPIImporter extends FormatImporter {
 	}
 
 	/**
-	 * A synced block's note left behind by a run that did not finish.
-	 *
-	 * Two synced blocks on one page are named alike, so which numbered name a
-	 * given block ended up under is not something a path can be guessed from -
-	 * the names have to be tried in turn until one of them holds this block's
-	 * id. Stopping at the first name nothing holds is what bounds the search.
+	 * A synced block's note left behind by a run that did not finish. Two
+	 * synced blocks on one page are named alike, so the names have to be tried
+	 * in turn until one of them holds this block's id; stopping at the first
+	 * name nothing holds is what bounds the search.
 	 */
 	private async recoverSyncedBlockNote(
 		ctx: ImportContext,
@@ -1576,10 +1526,8 @@ export class NotionAPIImporter extends FormatImporter {
 	}
 
 	/**
-	 * The folder a page with children keeps them in.
-	 *
-	 * Reused when it is already there, so a second import adds to the folder it
-	 * made rather than making another one beside it.
+	 * The folder a page with children keeps them in, reused when it is already
+	 * there so a second import does not make another one beside it.
 	 */
 	private pageFolder(parentPath: string, title: string): string {
 		const base = normalizePath(parentPath ? `${parentPath}/${title}` : title);

--- a/src/formats/notion-api.ts
+++ b/src/formats/notion-api.ts
@@ -22,7 +22,7 @@ import {
 } from './notion-api/api-helpers';
 import { convertBlocksToMarkdown } from './notion-api/block-converter';
 import { processDatabasePlaceholders, importDatabaseCore, replaceRelationValue } from './notion-api/database-helpers';
-import { DatabaseInfo, RelationPlaceholder, DatabaseProcessingContext, FetchAndImportPageParams, NOTION_VERSION } from './notion-api/types';
+import { DatabaseInfo, RelationPlaceholder, DatabaseProcessingContext, FetchAndImportPageParams, NOTION_VERSION, SyncedBlockRequest } from './notion-api/types';
 import { downloadAttachment } from './notion-api/attachment-helpers';
 import { buildTree, collectItems, type NotionTreeNode } from './notion-api/discovery';
 
@@ -702,8 +702,7 @@ export class NotionAPIImporter extends FormatImporter {
 				writeMarkdownFile: async (path: string, content: string) => {
 					return await this.createMarkdown(path, content);
 				},
-				syncedBlockFile: (blockId, folderPath, fileName, convert) =>
-					this.importSyncedBlockFile(ctx, blockId, folderPath, fileName, convert),
+				syncedBlockFile: request => this.importSyncedBlockFile(ctx, request),
 			});
 
 			// Process database placeholders
@@ -1406,18 +1405,38 @@ export class NotionAPIImporter extends FormatImporter {
 	 * Converted whatever is decided, because a synced block can hold child
 	 * pages of its own and they are reached by converting it.
 	 */
-	protected async importSyncedBlockFile(
-		ctx: ImportContext,
-		blockId: string,
-		folderPath: string,
-		fileName: string,
-		convert: (filePath: string) => Promise<string>,
-	): Promise<string> {
-		const planned = this.planNote(folderPath, fileName.replace(/\.md$/i, ''), blockId);
-		const markdown = await convert(planned.targetPath);
+	protected async importSyncedBlockFile(ctx: ImportContext, request: SyncedBlockRequest): Promise<string> {
+		const { blockId, folderPath, fileName, createdTime, lastEditedTime, convert } = request;
 
-		const { file, written } = await this.writePlannedNote(ctx, planned, markdown, { sourceId: blockId });
-		if (written) this.writtenPaths.add(file.path.replace(/\.md$/, ''));
+		const planned = this.planNote(folderPath, fileName.replace(/\.md$/i, ''), blockId);
+		const sourceMtime = lastEditedTime ? new Date(lastEditedTime).getTime() : undefined;
+		const disposition = this.preflightNote(ctx, planned, sourceMtime);
+
+		// A note the user has edited since the import is theirs: its placeholders
+		// stay unrecorded, because recording them is what would have it rewritten
+		// once the import is done. Which means a page nested inside a synced
+		// block they have edited stops arriving - the note wins over the nesting.
+		const leavingItAlone = disposition === 'skip'
+			|| disposition === 'unchanged'
+			|| disposition === 'preserve';
+
+		const markdown = await convert(planned.targetPath, {
+			forChildrenOnly: leavingItAlone,
+			keepPlaceholders: disposition !== 'preserve',
+		});
+
+		if (leavingItAlone) return planned.file?.path ?? planned.targetPath;
+
+		// The id goes in whether or not the user asked to keep it, as a page's
+		// does: an import that is interrupted leaves notes it can recognise as
+		// its own, and cleanupNotionIds takes the ids back out at the end.
+		const content = serializeFrontMatter({ [NOTION_ID_PROPERTY]: blockId }) + markdown;
+		const options: DataWriteOptions = {};
+		if (createdTime) options.ctime = new Date(createdTime).getTime();
+		if (sourceMtime !== undefined) options.mtime = sourceMtime;
+
+		const { file } = await this.writePlannedNote(ctx, planned, content, { ...options, disposition, sourceId: blockId });
+		this.writtenPaths.add(file.path.replace(/\.md$/, ''));
 
 		return file.path;
 	}

--- a/src/formats/notion-api.ts
+++ b/src/formats/notion-api.ts
@@ -106,7 +106,9 @@ export class NotionAPIImporter extends FormatImporter {
 	// Track mention placeholders for efficient replacement (similar to relationPlaceholders)
 	// Maps source file path to the set of mentioned page/database IDs
 	// Using file path as key allows O(1) file lookup instead of O(n) search
-	private mentionPlaceholders: Map<string, Set<string>> = new Map();
+	// Protected because it is the record of which files the passes after the
+	// import will rewrite, and what belongs in it is worth a test.
+	protected mentionPlaceholders: Map<string, Set<string>> = new Map();
 	// Track synced blocks mapping (original block ID -> file path)
 	// Used to reference synced block content across the vault
 	private syncedBlocksMap: Map<string, string> = new Map();
@@ -147,8 +149,6 @@ export class NotionAPIImporter extends FormatImporter {
 		});
 
 		this.picker.onLoad(() => void this.loadPageTree());
-
-		this.duplicateModes = [DuplicateHandling.CreateCopy, DuplicateHandling.Skip];
 
 		// Formula import strategy
 		this.addSetting()
@@ -619,17 +619,31 @@ export class NotionAPIImporter extends FormatImporter {
 			// Where the note goes, settled before a block is converted: its
 			// attachments, its links and its child pages are all placed
 			// relative to it, and a page the user moved keeps the note it has.
+			//
+			// Notion says when it last changed the page, and an import writes
+			// that onto the note, so a page nobody has touched at either end is
+			// known to be unchanged without reading a word of it.
+			const sourceMtime = page.last_edited_time ? new Date(page.last_edited_time).getTime() : undefined;
 			const planned = recovered ? null : this.planNote(homeFolder, sanitizedTitle, pageId);
-			const disposition = planned ? this.preflightNote(ctx, planned) : 'skip';
+			const disposition = planned ? this.preflightNote(ctx, planned, sourceMtime) : 'skip';
 			const mdFilePath = planned ? planned.targetPath : desiredPath;
 
-			if (planned?.file && disposition === 'skip') {
-				await this.adoptSkippedNote(planned.file, pageId);
+			// Three ways of leaving a note alone, and they are not the same. A
+			// note the user asked to skip, and one the source has not changed
+			// since, can still have links an interrupted run left unresolved
+			// repaired. A note edited in Obsidian since the import is the
+			// user's, and nothing here may write to it at all.
+			const leavingItAlone = disposition === 'skip'
+				|| disposition === 'unchanged'
+				|| disposition === 'preserve';
+
+			if (planned?.file && leavingItAlone) {
+				await this.adoptSkippedNote(planned.file, pageId, disposition !== 'preserve');
 			}
 
-			// A skipped page still has its children to reach, and they are
+			// A page left alone still has its children to reach, and they are
 			// reached by converting it. One with none has nothing left to do.
-			const shouldSkipParentFile = disposition === 'skip';
+			const shouldSkipParentFile = leavingItAlone;
 			if (shouldSkipParentFile && !hasChildren) {
 				this.pageFinished(ctx);
 				return;
@@ -1360,9 +1374,15 @@ export class NotionAPIImporter extends FormatImporter {
 	 * earlier run may have been interrupted before it could turn its
 	 * placeholders into links, so what is still waiting in the file is read back
 	 * out of it here and resolved with everything else once the import is done.
+	 *
+	 * Unless the note has been edited in Obsidian since it was imported. Then it
+	 * is the user's, and the most this import may do is remember where it is.
 	 */
-	protected async adoptSkippedNote(file: TFile, notionId: string): Promise<void> {
+	protected async adoptSkippedNote(file: TFile, notionId: string, mayRewrite = true): Promise<void> {
+		// Other pages link to it whatever this import does with it, so where it
+		// is has to be known even when nothing may be written to it.
 		this.notionIdToPath.set(notionId, file.path.replace(/\.md$/, ''));
+		if (!mayRewrite) return;
 
 		try {
 			await this.collectUnresolvedPlaceholders(await this.vault.read(file), notionId, file.path);

--- a/src/formats/notion-api.ts
+++ b/src/formats/notion-api.ts
@@ -662,6 +662,10 @@ export class NotionAPIImporter extends FormatImporter {
 				downloadExternalAttachments: this.downloadExternalAttachments,
 				singleLineBreaks: this.singleLineBreaks, // Single line breaks mode
 				incrementalImport: this.incrementalImport, // Skip attachments with same path and size
+				// A page being left as it is still has to be walked, because a
+				// child of it may have changed. Nothing the walk turns up is
+				// worth downloading: the markdown around it is thrown away.
+				forChildrenOnly: shouldSkipParentFile,
 				indentLevel: 0,
 				blocksCache, // reuse cached blocks
 				mentionedIds, // collect mentioned IDs
@@ -727,8 +731,10 @@ export class NotionAPIImporter extends FormatImporter {
 				frontMatter[this.databasePropertyName] = `[[${databaseTag}]]`;
 			}
 
-			// Extract all other properties from the page
-			const extractedProps = await extractFrontMatter({
+			// Extract all other properties from the page. Only the note being
+			// written has any use for them, and reading them downloads whatever
+			// its file properties point at.
+			const extractedProps = shouldSkipParentFile ? {} : await extractFrontMatter({
 				page,
 				formulaStrategy: this.formulaStrategy,
 				client: this.notionClient!,

--- a/src/formats/notion-api.ts
+++ b/src/formats/notion-api.ts
@@ -60,7 +60,7 @@ export class NotionAPIImporter extends FormatImporter {
 	get incrementalImport(): boolean {
 		return this.duplicateHandling !== DuplicateHandling.CreateCopy;
 	}
-	private notionClient: Client | null = null;
+	protected notionClient: Client | null = null;
 	private processedPages: Set<string> = new Set();
 	private requestCount: number = 0;
 	// The total grows as databases and page blocks reveal more pages.
@@ -531,7 +531,7 @@ export class NotionAPIImporter extends FormatImporter {
 	/**
 	 * Fetch and import a Notion page recursively
 	 */
-	private async fetchAndImportPage(params: FetchAndImportPageParams): Promise<void> {
+	protected async fetchAndImportPage(params: FetchAndImportPageParams): Promise<void> {
 		const { ctx, pageId, parentPath, databaseTag, customFileName } = params;
 
 		if (await ctx.shouldStop()) return;

--- a/src/formats/notion-api.ts
+++ b/src/formats/notion-api.ts
@@ -40,6 +40,24 @@ function childPageIds(blocksCache: Map<string, { id: string, type: string }[]>):
 	return ids;
 }
 
+/**
+ * The folder holding what belongs to a page: the one named after its note.
+ *
+ * A page importing for the first time is written inside that folder, so the
+ * folder is the one already holding it. A note the user has moved, or one
+ * written when the page had no children to keep, is not - and its children go
+ * into a folder of the note's name beside it rather than into whatever folder
+ * the note happens to be sharing.
+ */
+export function childFolderOf(notePath: string): string {
+	const { parent, basename } = parseFilePath(notePath);
+	const holding = parent.slice(parent.lastIndexOf('/') + 1);
+
+	if (holding.toLowerCase() === basename.toLowerCase()) return parent;
+
+	return normalizePath(parent ? `${parent}/${basename}` : basename);
+}
+
 export class NotionAPIImporter extends FormatImporter {
 	interruption = 'pause' as const;
 
@@ -586,58 +604,48 @@ export class NotionAPIImporter extends FormatImporter {
 			// Discover all children first so remaining decreases monotonically.
 			this.pagesDiscovered(ctx, childPageIds(blocksCache));
 
-			// Determine file structure based on whether page has children
-			let pageFolderPath: string; // Folder for child pages/databases
-			let mdFilePath: string;
-			let shouldSkipParentFile = false; // Flag to track if parent file should be skipped
+			// A page with children keeps them in a folder of its own name; one
+			// without is a file where it stands. The folder is chosen before the
+			// note so a page importing for the first time lands inside it, as
+			// it always has.
+			const homeFolder = hasChildren ? this.pageFolder(parentPath, sanitizedTitle) : parentPath;
 
-			if (hasChildren) {
-				// Create folder structure for pages with children
-				// The folder will contain the page content file and child pages/databases
-				// For incremental import: reuse existing folder if it exists, otherwise create a unique one
-				const baseFolderPath = normalizePath(parentPath ? `${parentPath}/${sanitizedTitle}` : sanitizedTitle);
-				const existingFolder = this.vault.getAbstractFileByPath(baseFolderPath);
+			// "Create a copy" is not looking for a note to write over, but one
+			// this run wrote before it was interrupted is still its own.
+			const desiredPath = normalizePath(homeFolder ? `${homeFolder}/${sanitizedTitle}.md` : `${sanitizedTitle}.md`);
+			const recovered = this.duplicateHandling === DuplicateHandling.CreateCopy
+				&& await this.alreadyWrittenByAnUnfinishedImport(desiredPath, pageId, ctx);
 
-				if (existingFolder instanceof TFolder) {
-					// Reuse existing folder for incremental import
-					pageFolderPath = baseFolderPath;
-				}
-				else {
-					// Create new folder with unique name if needed
-					pageFolderPath = getUniqueFilePath(this.vault, parentPath, sanitizedTitle);
-					await this.createFolders(pageFolderPath);
-				}
+			// Where the note goes, settled before a block is converted: its
+			// attachments, its links and its child pages are all placed
+			// relative to it, and a page the user moved keeps the note it has.
+			const planned = recovered ? null : this.planNote(homeFolder, sanitizedTitle, pageId);
+			const disposition = planned ? this.preflightNote(ctx, planned) : 'skip';
+			const mdFilePath = planned ? planned.targetPath : desiredPath;
 
-				// Check if file already exists with same notion-id
-				const fileName = `${sanitizedTitle}.md`;
-				const potentialFilePath = normalizePath(`${pageFolderPath}/${fileName}`);
-				shouldSkipParentFile = await this.shouldSkipExistingFile(potentialFilePath, pageId, ctx);
-
-				mdFilePath = potentialFilePath;
-			}
-			else {
-				// Create file directly for pages without children
-				// No folder needed since there are no child pages or databases
-				pageFolderPath = parentPath;
-				// Check for incremental import before creating file
-				const filePathOrNull = await this.getUniqueFilePathWithIncrementalCheck(
-					parentPath,
-					`${sanitizedTitle}.md`,
-					pageId,
-					ctx
-				);
-				if (!filePathOrNull) {
-					// File skipped due to incremental import (no children, so nothing else to do)
-					// Update progress for skipped page
-					this.pageFinished(ctx);
-					return;
-				}
-				mdFilePath = filePathOrNull;
+			if (planned?.file && disposition === 'skip') {
+				await this.adoptSkippedNote(planned.file, pageId);
 			}
 
-			// Extract the folder path from the markdown file path for attachments
-			// This ensures attachments are placed relative to where the file actually is
-			const { parent: currentFileFolderPath } = parseFilePath(mdFilePath);
+			// A skipped page still has its children to reach, and they are
+			// reached by converting it. One with none has nothing left to do.
+			const shouldSkipParentFile = disposition === 'skip';
+			if (shouldSkipParentFile && !hasChildren) {
+				this.pageFinished(ctx);
+				return;
+			}
+
+			// Where everything belonging to this page goes. Children go in the
+			// folder named after the note: the one holding it when the note is
+			// where this import would have put it, and a folder beside it when
+			// the user has moved the note or a leaf has grown children. A page
+			// without children keeps its synced blocks wherever the note is.
+			const pageFolderPath = hasChildren
+				? childFolderOf(mdFilePath)
+				: parseFilePath(mdFilePath).parent;
+			if (hasChildren) await this.createFolders(pageFolderPath);
+
+			const currentFileFolderPath = pageFolderPath;
 
 			// Convert blocks to markdown with nested children support
 			// Pass the blocksCache to reuse already fetched blocks
@@ -825,23 +833,23 @@ export class NotionAPIImporter extends FormatImporter {
 			}
 
 			// Create the markdown file (only if not skipped)
-			if (!shouldSkipParentFile) {
+			if (!shouldSkipParentFile && planned) {
 				const fullContent = serializeFrontMatter(frontMatter) + markdownContent;
 
+				// The path was settled before the conversion, and everything the
+				// conversion resolved - attachments, links, the folder the child
+				// pages went into - was resolved against it. Choosing another one
+				// here would leave all of that pointing at a note that is not here.
+				const options: DataWriteOptions = {};
+				if (page.created_time) options.ctime = new Date(page.created_time).getTime();
+				if (page.last_edited_time) options.mtime = new Date(page.last_edited_time).getTime();
 
-				// Get unique file path (will append " 1", " 2", etc. if file exists)
-				const { parent: parentPath, name: fileName } = parseFilePath(mdFilePath);
-				const finalPath = getUniqueFilePath(this.vault, parentPath, fileName);
-
-
+				let written: TFile;
 				try {
-					const options: DataWriteOptions = {};
-					if (page.created_time) options.ctime = new Date(page.created_time).getTime();
-					if (page.last_edited_time) options.mtime = new Date(page.last_edited_time).getTime();
-					await this.createMarkdown(normalizePath(finalPath), fullContent, options);
+					({ file: written } = await this.writePlannedNote(ctx, planned, fullContent, { ...options, disposition }));
 				}
 				catch (error) {
-					console.error(`[CREATE FILE] Failed to create file: ${finalPath}`);
+					console.error(`[CREATE FILE] Failed to create file: ${mdFilePath}`);
 					console.error(`[CREATE FILE] Page ID: ${pageId}, Page Title: ${sanitizedTitle}`);
 					console.error(`[CREATE FILE] Error:`, error);
 					throw error;
@@ -849,14 +857,14 @@ export class NotionAPIImporter extends FormatImporter {
 
 				// Record page ID to path mapping for mention replacement
 				// Store path without extension for wiki link generation
-				const pathWithoutExt = finalPath.replace(/\.md$/, '');
+				const pathWithoutExt = written.path.replace(/\.md$/, '');
 				this.notionIdToPath.set(pageId, pathWithoutExt);
 				this.writtenPaths.add(pathWithoutExt);
 
 				// Record mention placeholders if any mentions were found
 				// Use file path as key for O(1) lookup during replacement
 				if (mentionedIds.size > 0) {
-					this.mentionPlaceholders.set(finalPath, mentionedIds);
+					this.mentionPlaceholders.set(written.path, mentionedIds);
 				}
 			}
 
@@ -1309,7 +1317,7 @@ export class NotionAPIImporter extends FormatImporter {
 	}
 
 	/** Find a page left by an unfinished import. */
-	private async alreadyWrittenByAnUnfinishedImport(
+	protected async alreadyWrittenByAnUnfinishedImport(
 		filePath: string,
 		notionId: string,
 		ctx: ImportContext
@@ -1339,36 +1347,36 @@ export class NotionAPIImporter extends FormatImporter {
 		}
 	}
 
-	protected async shouldSkipExistingFile(
-		filePath: string,
-		notionId: string,
-		ctx: ImportContext
-	): Promise<boolean> {
-		if (this.duplicateHandling === DuplicateHandling.CreateCopy) {
-			return await this.alreadyWrittenByAnUnfinishedImport(filePath, notionId, ctx);
-		}
-
-		const file = this.previouslyImported(normalizePath(filePath), notionId);
-		if (!file) {
-			return false; // Not imported before, don't skip
-		}
+	/**
+	 * Take on a note this import is leaving as it stands.
+	 *
+	 * Being left alone is not being left out. Pages link to one another, and an
+	 * earlier run may have been interrupted before it could turn its
+	 * placeholders into links, so what is still waiting in the file is read back
+	 * out of it here and resolved with everything else once the import is done.
+	 */
+	protected async adoptSkippedNote(file: TFile, notionId: string): Promise<void> {
+		this.notionIdToPath.set(notionId, file.path.replace(/\.md$/, ''));
 
 		try {
-			const content = await this.vault.read(file);
-			const { basename } = parseFilePath(file.path);
-			ctx.reportSkipped(basename, i18n.reason.alreadyInVault());
-
-			const filePathWithoutExtension = file.path.replace(/\.md$/, '');
-			this.notionIdToPath.set(notionId, filePathWithoutExtension);
-
-			await this.collectUnresolvedPlaceholders(content, notionId, file.path);
-
-			return true;
+			await this.collectUnresolvedPlaceholders(await this.vault.read(file), notionId, file.path);
 		}
 		catch (error) {
-			console.error(`Failed to read file ${filePath} for duplicate check:`, error);
-			return false; // On error, don't skip
+			console.error(`Could not read the note already at: ${file.path}`, error);
 		}
+	}
+
+	/**
+	 * The folder a page with children keeps them in.
+	 *
+	 * Reused when it is already there, so a second import adds to the folder it
+	 * made rather than making another one beside it.
+	 */
+	private pageFolder(parentPath: string, title: string): string {
+		const base = normalizePath(parentPath ? `${parentPath}/${title}` : title);
+		if (this.vault.getAbstractFileByPath(base) instanceof TFolder) return base;
+
+		return getUniqueFilePath(this.vault, parentPath, title);
 	}
 
 	/** Remove temporary IDs from pages owned by this run. */
@@ -1538,39 +1546,6 @@ export class NotionAPIImporter extends FormatImporter {
 		if (syncedDbIds.size > 0) {
 			this.syncedChildDatabasePlaceholders.set(filePath, syncedDbIds);
 		}
-	}
-
-	/**
-	 * Get unique file path with incremental import check
-	 * @param parentPath - Parent folder path
-	 * @param fileName - File name
-	 * @param notionId - Notion ID of the page being imported
-	 * @param ctx - Import context for reporting
-	 * @returns File path or null if should be skipped
-	 */
-	private async getUniqueFilePathWithIncrementalCheck(
-		parentPath: string,
-		fileName: string,
-		notionId: string,
-		ctx: ImportContext
-	): Promise<string | null> {
-		const basePath = parentPath ? `${parentPath}/${fileName}` : fileName;
-
-		// Check if file already exists with same notion-id
-		const shouldSkip = await this.shouldSkipExistingFile(basePath, notionId, ctx);
-		if (shouldSkip) {
-			return null;
-		}
-
-		// If file doesn't exist, return base path
-		const file = this.vault.getAbstractFileByPath(normalizePath(basePath));
-		if (!file) {
-			return basePath;
-		}
-
-		// File exists but has different notion-id (or no notion-id)
-		// Use standard unique path logic
-		return getUniqueFilePath(this.vault, parentPath, fileName);
 	}
 
 	private async modifyPreservingTimestamps(file: TFile, content: string): Promise<void> {

--- a/src/formats/notion-api.ts
+++ b/src/formats/notion-api.ts
@@ -12,7 +12,7 @@ import { parseFilePath } from '../filesystem';
 
 // Import helper modules
 import { NOTION_ID_PROPERTY } from '../constants';
-import { createPlaceholder, PlaceholderType } from './notion-api/utils';
+import { createPlaceholder, extractPlaceholderIds, PlaceholderType } from './notion-api/utils';
 import {
 	makeNotionRequest,
 	fetchAllBlocks,
@@ -124,6 +124,16 @@ export class NotionAPIImporter extends FormatImporter {
 	// Separated by type to avoid unnecessary placeholder checks
 	private syncedChildPagePlaceholders: Map<string, Set<string>> = new Map();
 	private syncedChildDatabasePlaceholders: Map<string, Set<string>> = new Map();
+	/**
+	 * Pages and databases under a synced block whose note is not being written.
+	 *
+	 * What is under a synced block and what is written into its note are two
+	 * questions. A note left alone still has its children fetched - they may
+	 * have changed, or be gone from the vault - but a note the user has edited
+	 * is not rewritten to point at them. Keeping the two apart is what lets a
+	 * preserved note keep its children without the note being touched.
+	 */
+	private syncedChildrenToReach: Set<string> = new Set();
 
 	init() {
 		// No file chooser needed since we're importing via API
@@ -384,6 +394,7 @@ export class NotionAPIImporter extends FormatImporter {
 	async import(ctx: ImportContext): Promise<void> {
 		this.writtenPaths.clear();
 		this.recoveredPaths.clear();
+		this.syncedChildrenToReach.clear();
 
 		// Validate inputs
 		if (!this.notionToken) {
@@ -1192,7 +1203,9 @@ export class NotionAPIImporter extends FormatImporter {
  * 
  * Performance: Only processes files that contain synced child placeholders (O(n) where n = files with placeholders)
  */
-	private async replaceSyncedChildPlaceholders(ctx: ImportContext): Promise<void> {
+	protected async replaceSyncedChildPlaceholders(ctx: ImportContext): Promise<void> {
+		await this.reachSyncedChildren(ctx);
+
 		if (this.syncedChildPagePlaceholders.size === 0 && this.syncedChildDatabasePlaceholders.size === 0) {
 			return;
 		}
@@ -1409,24 +1422,45 @@ export class NotionAPIImporter extends FormatImporter {
 	protected async importSyncedBlockFile(ctx: ImportContext, request: SyncedBlockRequest): Promise<string> {
 		const { blockId, folderPath, fileName, createdTime, lastEditedTime, convert } = request;
 
+		// "Create a copy" is not looking for a note to reuse, but one this run
+		// wrote before it was interrupted is still its own - and with the ids
+		// index turned off in that mode, the file itself is the only place left
+		// to recognise it from.
+		const recovered = this.duplicateHandling === DuplicateHandling.CreateCopy
+			? await this.recoverSyncedBlockNote(ctx, folderPath, fileName, blockId)
+			: null;
+		if (recovered) return recovered;
+
 		const planned = this.planNote(folderPath, fileName.replace(/\.md$/i, ''), blockId);
 		const sourceMtime = lastEditedTime ? new Date(lastEditedTime).getTime() : undefined;
 		const disposition = this.preflightNote(ctx, planned, sourceMtime);
 
-		// A note the user has edited since the import is theirs: its placeholders
-		// stay unrecorded, because recording them is what would have it rewritten
-		// once the import is done. Which means a page nested inside a synced
-		// block they have edited stops arriving - the note wins over the nesting.
 		const leavingItAlone = disposition === 'skip'
 			|| disposition === 'unchanged'
 			|| disposition === 'preserve';
 
+		// The placeholders of a note being left alone are the ones in the note,
+		// not the ones in what was just converted: an earlier run may have been
+		// interrupted before it could resolve them, and what it left behind is
+		// what needs repairing. Reading them out of the file is adoptSkippedNote,
+		// the same as a page's - unless the user has edited it, when the note is
+		// theirs and nothing may rewrite it.
 		const markdown = await convert(planned.targetPath, {
 			forChildrenOnly: leavingItAlone,
-			keepPlaceholders: disposition !== 'preserve',
+			keepPlaceholders: !leavingItAlone,
 		});
 
-		if (leavingItAlone) return planned.file?.path ?? planned.targetPath;
+		if (leavingItAlone) {
+			if (planned.file) await this.adoptSkippedNote(planned.file, blockId, disposition !== 'preserve');
+
+			// Whatever is under it is still fetched, whether or not its note is
+			// ever touched again.
+			for (const type of [PlaceholderType.SYNCED_CHILD_PAGE, PlaceholderType.SYNCED_CHILD_DATABASE]) {
+				for (const id of extractPlaceholderIds(markdown, type)) this.syncedChildrenToReach.add(id);
+			}
+
+			return planned.file?.path ?? planned.targetPath;
+		}
 
 		// The id goes in whether or not the user asked to keep it, as a page's
 		// does: an import that is interrupted leaves notes it can recognise as
@@ -1440,6 +1474,60 @@ export class NotionAPIImporter extends FormatImporter {
 		this.writtenPaths.add(file.path.replace(/\.md$/, ''));
 
 		return file.path;
+	}
+
+	/**
+	 * Import what sits under a synced block whose note is not being rewritten.
+	 *
+	 * The pass that resolves placeholders imports what it finds missing, but it
+	 * only looks inside files it is going to rewrite. A note left alone is not
+	 * one of those, and a note the user has edited must never be - so what is
+	 * under it is fetched here instead, where no file is touched.
+	 */
+	private async reachSyncedChildren(ctx: ImportContext): Promise<void> {
+		for (const id of this.syncedChildrenToReach) {
+			if (await ctx.shouldStop()) return;
+			if (this.notionIdToPath.has(id) || this.processedDatabases.has(id)) continue;
+
+			try {
+				await this.fetchAndImportPage({ ctx, pageId: id, parentPath: this.outputRootPath });
+			}
+			catch {
+				// Not a page, or not one this token can read. A database of that
+				// id is the other thing it can be, and the last thing to try.
+				try {
+					await this.importTopLevelDatabase(ctx, id, this.outputRootPath);
+				}
+				catch (error) {
+					console.warn(`Could not import what a synced block holds: ${id}`, error);
+				}
+			}
+		}
+	}
+
+	/**
+	 * A synced block's note left behind by a run that did not finish.
+	 *
+	 * Two synced blocks on one page are named alike, so which numbered name a
+	 * given block ended up under is not something a path can be guessed from -
+	 * the names have to be tried in turn until one of them holds this block's
+	 * id. Stopping at the first name nothing holds is what bounds the search.
+	 */
+	private async recoverSyncedBlockNote(
+		ctx: ImportContext,
+		folderPath: string,
+		fileName: string,
+		blockId: string,
+	): Promise<string | null> {
+		const { basename, extension } = parseFilePath(fileName);
+
+		for (let nth = 0; ; nth++) {
+			const candidate = nth === 0 ? fileName : `${basename} ${nth}.${extension}`;
+			const path = normalizePath(folderPath ? `${folderPath}/${candidate}` : candidate);
+
+			if (!(this.vault.getAbstractFileByPath(path) instanceof TFile)) return null;
+			if (await this.alreadyWrittenByAnUnfinishedImport(path, blockId, ctx)) return path;
+		}
 	}
 
 	/**

--- a/src/formats/notion-api.ts
+++ b/src/formats/notion-api.ts
@@ -702,6 +702,8 @@ export class NotionAPIImporter extends FormatImporter {
 				writeMarkdownFile: async (path: string, content: string) => {
 					return await this.createMarkdown(path, content);
 				},
+				syncedBlockFile: (blockId, folderPath, fileName, convert) =>
+					this.importSyncedBlockFile(ctx, blockId, folderPath, fileName, convert),
 			});
 
 			// Process database placeholders
@@ -1390,6 +1392,34 @@ export class NotionAPIImporter extends FormatImporter {
 		catch (error) {
 			console.error(`Could not read the note already at: ${file.path}`, error);
 		}
+	}
+
+	/**
+	 * Write a synced block's own note, once per synced block rather than once
+	 * per import.
+	 *
+	 * It used to ask for a name nothing was using, so every import wrote
+	 * another one: "Page synced block 1.md", then "Page synced block 2.md". The
+	 * note carries the block's id now, which is what lets a later import find
+	 * the one it wrote before and leave it, or bring it up to date.
+	 *
+	 * Converted whatever is decided, because a synced block can hold child
+	 * pages of its own and they are reached by converting it.
+	 */
+	protected async importSyncedBlockFile(
+		ctx: ImportContext,
+		blockId: string,
+		folderPath: string,
+		fileName: string,
+		convert: (filePath: string) => Promise<string>,
+	): Promise<string> {
+		const planned = this.planNote(folderPath, fileName.replace(/\.md$/i, ''), blockId);
+		const markdown = await convert(planned.targetPath);
+
+		const { file, written } = await this.writePlannedNote(ctx, planned, markdown, { sourceId: blockId });
+		if (written) this.writtenPaths.add(file.path.replace(/\.md$/, ''));
+
+		return file.path;
 	}
 
 	/**

--- a/src/formats/notion-api.ts
+++ b/src/formats/notion-api.ts
@@ -75,7 +75,14 @@ export class NotionAPIImporter extends FormatImporter {
 	singleLineBreaks: boolean = false; // Single line breaks between blocks (default: disabled)
 	coverPropertyName: string = 'cover'; // Custom property name for page cover
 	databasePropertyName: string = 'base'; // Property name for linking pages to their database
-	get incrementalImport(): boolean {
+	/**
+	 * Whether a file already in the vault may stand in for one being imported.
+	 *
+	 * Every mode but "Create a copy": the point of making a copy is to leave
+	 * what is there alone and write your own, and that goes for the attachments
+	 * as much as the notes.
+	 */
+	get reuseExistingAttachments(): boolean {
 		return this.duplicateHandling !== DuplicateHandling.CreateCopy;
 	}
 	protected notionClient: Client | null = null;
@@ -675,7 +682,7 @@ export class NotionAPIImporter extends FormatImporter {
 				app: this.app,
 				downloadExternalAttachments: this.downloadExternalAttachments,
 				singleLineBreaks: this.singleLineBreaks, // Single line breaks mode
-				incrementalImport: this.incrementalImport, // Skip attachments with same path and size
+				reuseExistingAttachments: this.reuseExistingAttachments,
 				// A page being left as it is still has to be walked, because a
 				// child of it may have changed. Nothing the walk turns up is
 				// worth downloading: the markdown around it is thrown away.
@@ -698,9 +705,6 @@ export class NotionAPIImporter extends FormatImporter {
 				// Pass mdFilePath so attachments are placed relative to the actual page file
 				getAvailableAttachmentPath: async (filename: string) => {
 					return await this.getAvailablePathForAttachment(filename, [], mdFilePath);
-				},
-				writeMarkdownFile: async (path: string, content: string) => {
-					return await this.createMarkdown(path, content);
 				},
 				syncedBlockFile: request => this.importSyncedBlockFile(ctx, request),
 			});
@@ -760,7 +764,7 @@ export class NotionAPIImporter extends FormatImporter {
 				currentFilePath: mdFilePath,
 				currentFolderPath: pageFolderPath,
 				downloadExternalAttachments: this.downloadExternalAttachments,
-				incrementalImport: this.incrementalImport,
+				reuseExistingAttachments: this.reuseExistingAttachments,
 				onAttachmentDownloaded: (filename: string) => ctx.reportAttachmentSuccess(filename),
 				// Pass mdFilePath so attachments are placed relative to the actual page file
 				getAvailableAttachmentPath: async (filename: string) => {
@@ -798,14 +802,11 @@ export class NotionAPIImporter extends FormatImporter {
 							vault: this.vault,
 							app: this.app,
 							downloadExternalAttachments: true, // Always download cover images
-							incrementalImport: this.incrementalImport,
+							reuseExistingAttachments: this.reuseExistingAttachments,
 							currentPageTitle: sanitizedTitle,
 							// Pass mdFilePath so attachments are placed relative to the actual page file
 							getAvailableAttachmentPath: async (filename: string) => {
 								return await this.getAvailablePathForAttachment(filename, [], mdFilePath);
-							},
-							writeMarkdownFile: async (path: string, content: string) => {
-								return await this.createMarkdown(path, content);
 							},
 						}
 					);

--- a/src/formats/notion-api/api-helpers.ts
+++ b/src/formats/notion-api/api-helpers.ts
@@ -348,7 +348,7 @@ export interface ExtractFrontMatterParams {
 	currentFilePath?: string;
 	currentFolderPath?: string;
 	downloadExternalAttachments?: boolean;
-	incrementalImport?: boolean;
+	reuseExistingAttachments?: boolean;
 	onAttachmentDownloaded?: (filename: string) => void;
 	getAvailableAttachmentPath?: (filename: string) => Promise<string>;
 }
@@ -567,7 +567,7 @@ async function mapFilesPropertyToFrontmatter(
 		return null;
 	}
 
-	const { vault, app, ctx, currentFilePath, currentFolderPath, incrementalImport, onAttachmentDownloaded, getAvailableAttachmentPath } = params;
+	const { vault, app, ctx, currentFilePath, currentFolderPath, reuseExistingAttachments, onAttachmentDownloaded, getAvailableAttachmentPath } = params;
 
 	if (!vault || !app || !ctx) {
 		// Fallback to URL if we don't have required parameters
@@ -614,7 +614,7 @@ async function mapFilesPropertyToFrontmatter(
 					currentFilePath,
 					currentFolderPath,
 					downloadExternalAttachments: true,  // Always download files property attachments
-					incrementalImport: incrementalImport || false,
+					reuseExistingAttachments: reuseExistingAttachments || false,
 					onAttachmentDownloaded,
 					getAvailableAttachmentPath
 				},

--- a/src/formats/notion-api/attachment-helpers.ts
+++ b/src/formats/notion-api/attachment-helpers.ts
@@ -109,7 +109,7 @@ export async function downloadAttachment(
 	attachment: NotionAttachment,
 	context: BlockConversionContext
 ): Promise<AttachmentResult> {
-	const { vault, ctx, downloadExternalAttachments, currentPageTitle, incrementalImport } = context;
+	const { vault, ctx, downloadExternalAttachments, currentPageTitle, reuseExistingAttachments } = context;
 
 	// Determine if we should download this attachment
 	const shouldDownload = !context.forChildrenOnly
@@ -135,7 +135,7 @@ export async function downloadAttachment(
 
 		const probe = context.rangeProbe ??= { answered: true };
 
-		if (incrementalImport && !isDataUrl && probe.answered) {
+		if (reuseExistingAttachments && !isDataUrl && probe.answered) {
 			const probed = await probeAttachmentSize(attachment.url, probe);
 
 			if (probed) {
@@ -175,7 +175,7 @@ export async function downloadAttachment(
 		filename = withInferredExtension(filename, downloaded.contentType);
 		let targetFilePath = await resolveTargetPath(context, filename);
 
-		if (incrementalImport) {
+		if (reuseExistingAttachments) {
 			const existingFile = attachmentAlreadyImported(vault, targetFilePath, filename, downloaded.arrayBuffer.byteLength);
 
 			if (existingFile) return skipExisting(ctx, existingFile, filename);
@@ -203,7 +203,7 @@ export async function downloadAttachment(
 
 				if (attemptedPaths.size > MAX_NAME_COLLISIONS || await ctx.shouldStop()) throw error;
 
-				if (incrementalImport && occupied instanceof TFile && occupied.stat.size === downloaded.arrayBuffer.byteLength) {
+				if (reuseExistingAttachments && occupied instanceof TFile && occupied.stat.size === downloaded.arrayBuffer.byteLength) {
 					return skipExisting(ctx, occupied, filename);
 				}
 
@@ -556,7 +556,7 @@ export async function downloadAndFormatAttachment(
 		currentFilePath?: string;
 		currentFolderPath?: string;
 		downloadExternalAttachments?: boolean;
-		incrementalImport?: boolean;
+		reuseExistingAttachments?: boolean;
 		onAttachmentDownloaded?: (filename: string) => void;
 		getAvailableAttachmentPath?: (filename: string) => Promise<string>;
 	},

--- a/src/formats/notion-api/attachment-helpers.ts
+++ b/src/formats/notion-api/attachment-helpers.ts
@@ -112,7 +112,8 @@ export async function downloadAttachment(
 	const { vault, ctx, downloadExternalAttachments, currentPageTitle, incrementalImport } = context;
 
 	// Determine if we should download this attachment
-	const shouldDownload = attachment.type === 'file' || (attachment.type === 'external' && downloadExternalAttachments);
+	const shouldDownload = !context.forChildrenOnly
+		&& (attachment.type === 'file' || (attachment.type === 'external' && downloadExternalAttachments));
 
 	if (!shouldDownload) {
 		// Return original URL for external files when download is disabled

--- a/src/formats/notion-api/block-converter.ts
+++ b/src/formats/notion-api/block-converter.ts
@@ -29,7 +29,6 @@ import { getBlockChildren, processBlockChildren } from './api-helpers';
 import { downloadAndFormatAttachment, extractAttachmentFromBlock, getCaptionFromBlock } from './attachment-helpers';
 import { BlockConversionContext, AttachmentType, AttachmentBlockConfig, BlockContext, HeaderContentWithRichTextAndColorResponse } from './types';
 import { createPlaceholder, extractPlaceholderIds, PlaceholderType } from './utils';
-import { getUniqueFilePath } from '../../util';
 
 
 /**
@@ -800,10 +799,14 @@ async function createSyncedBlockFile(
 	blockId: string,
 	context: BlockConversionContext
 ): Promise<string> {
-	const { client, ctx, vault, currentFolderPath, currentPageTitle } = context;
-	
+	const { client, ctx, currentFolderPath, currentPageTitle, syncedBlockFile } = context;
+
 	if (!currentFolderPath) {
 		throw new Error('currentFolderPath is required for synced blocks');
+	}
+
+	if (!syncedBlockFile) {
+		throw new Error('syncedBlockFile is required for synced blocks');
 	}
 	
 	// Use page title for synced block filename
@@ -827,47 +830,45 @@ async function createSyncedBlockFile(
 			? await getBlockChildren(blockId, client, ctx, context.blocksCache)
 			: [];
 		
-		// Generate unique file path in the same folder as the page
-		// If multiple synced blocks exist, they will be named: "Page synced block.md", "Page synced block 1.md", etc.
-		const filePath = getUniqueFilePath(vault, currentFolderPath, `${fileName}.md`);
-	
-		// Create a new context for synced block content
-		// Keep currentFolderPath the same so nested synced blocks are also placed correctly
-		// Set isProcessingSyncedBlock flag to indicate we're inside a synced block
-		const syncedBlockContext: BlockConversionContext = {
-			...context,
-			currentFilePath: filePath, // Update current file path for link generation
-			isProcessingSyncedBlock: true // Mark that we're processing synced block content
-		};
-	
-		// Convert children to markdown
-		const markdown = await convertBlocksToMarkdown(children, syncedBlockContext);
+		// Where the file goes, and whether it needs writing, are the importer's
+		// to answer: it is the only side that knows what the vault already
+		// holds. The conversion happens inside that answer, because the path it
+		// settles on is the one this block's own links are generated against.
+		return await syncedBlockFile(blockId, currentFolderPath, `${fileName}.md`, async filePath => {
+			// Create a new context for synced block content
+			// Keep currentFolderPath the same so nested synced blocks are also placed correctly
+			// Set isProcessingSyncedBlock flag to indicate we're inside a synced block
+			const syncedBlockContext: BlockConversionContext = {
+				...context,
+				currentFilePath: filePath, // Update current file path for link generation
+				isProcessingSyncedBlock: true // Mark that we're processing synced block content
+			};
 
-		// Extract synced child IDs from the markdown content
-		// This allows us to efficiently replace placeholders later without scanning all files
-		// Separated by type to avoid unnecessary placeholder checks during replacement
+			// Convert children to markdown
+			const markdown = await convertBlocksToMarkdown(children, syncedBlockContext);
 
-		// Find SYNCED_CHILD_PAGE placeholders
-		const pageIds = extractPlaceholderIds(markdown, PlaceholderType.SYNCED_CHILD_PAGE);
-		if (context.syncedChildPagePlaceholders && pageIds.length > 0) {
-			const existingPageIds = context.syncedChildPagePlaceholders.get(filePath) || new Set<string>();
-			pageIds.forEach(id => existingPageIds.add(id));
-			context.syncedChildPagePlaceholders.set(filePath, existingPageIds);
-		}
+			// Extract synced child IDs from the markdown content
+			// This allows us to efficiently replace placeholders later without scanning all files
+			// Separated by type to avoid unnecessary placeholder checks during replacement
 
-		// Find SYNCED_CHILD_DATABASE placeholders
-		const dbIds = extractPlaceholderIds(markdown, PlaceholderType.SYNCED_CHILD_DATABASE);
-		if (context.syncedChildDatabasePlaceholders && dbIds.length > 0) {
-			const existingDbIds = context.syncedChildDatabasePlaceholders.get(filePath) || new Set<string>();
-			dbIds.forEach(id => existingDbIds.add(id));
-			context.syncedChildDatabasePlaceholders.set(filePath, existingDbIds);
-		}
-	
-		// Create the file
-		await context.writeMarkdownFile(filePath, markdown);
-		
-		
-		return filePath;
+			// Find SYNCED_CHILD_PAGE placeholders
+			const pageIds = extractPlaceholderIds(markdown, PlaceholderType.SYNCED_CHILD_PAGE);
+			if (context.syncedChildPagePlaceholders && pageIds.length > 0) {
+				const existingPageIds = context.syncedChildPagePlaceholders.get(filePath) || new Set<string>();
+				pageIds.forEach(id => existingPageIds.add(id));
+				context.syncedChildPagePlaceholders.set(filePath, existingPageIds);
+			}
+
+			// Find SYNCED_CHILD_DATABASE placeholders
+			const dbIds = extractPlaceholderIds(markdown, PlaceholderType.SYNCED_CHILD_DATABASE);
+			if (context.syncedChildDatabasePlaceholders && dbIds.length > 0) {
+				const existingDbIds = context.syncedChildDatabasePlaceholders.get(filePath) || new Set<string>();
+				dbIds.forEach(id => existingDbIds.add(id));
+				context.syncedChildDatabasePlaceholders.set(filePath, existingDbIds);
+			}
+
+			return markdown;
+		});
 	}
 	catch (error) {
 		const errorMsg = error instanceof Error ? error.message : String(error);

--- a/src/formats/notion-api/block-converter.ts
+++ b/src/formats/notion-api/block-converter.ts
@@ -830,10 +830,6 @@ async function createSyncedBlockFile(
 			? await getBlockChildren(blockId, client, ctx, context.blocksCache)
 			: [];
 		
-		// Where the file goes, and whether it needs writing, are the importer's
-		// to answer: it is the only side that knows what the vault already
-		// holds. The conversion happens inside that answer, because the path it
-		// settles on is the one this block's own links are generated against.
 		return await syncedBlockFile({
 			blockId,
 			folderPath: currentFolderPath,
@@ -848,10 +844,9 @@ async function createSyncedBlockFile(
 					...context,
 					currentFilePath: filePath, // Update current file path for link generation
 					isProcessingSyncedBlock: true, // Mark that we're processing synced block content
-					// The block's own answer, not the page's. A synced block has
-					// a note of its own, and one that has to be written needs
-					// what it points at whether or not the page holding it is
-					// being left alone.
+					// The block's own answer, not the page's: a note that has to
+					// be written needs what it points at whether or not the page
+					// holding it is being left alone.
 					forChildrenOnly,
 				};
 

--- a/src/formats/notion-api/block-converter.ts
+++ b/src/formats/notion-api/block-converter.ts
@@ -848,7 +848,11 @@ async function createSyncedBlockFile(
 					...context,
 					currentFilePath: filePath, // Update current file path for link generation
 					isProcessingSyncedBlock: true, // Mark that we're processing synced block content
-					forChildrenOnly: forChildrenOnly || context.forChildrenOnly,
+					// The block's own answer, not the page's. A synced block has
+					// a note of its own, and one that has to be written needs
+					// what it points at whether or not the page holding it is
+					// being left alone.
+					forChildrenOnly,
 				};
 
 				// Convert children to markdown

--- a/src/formats/notion-api/block-converter.ts
+++ b/src/formats/notion-api/block-converter.ts
@@ -834,40 +834,49 @@ async function createSyncedBlockFile(
 		// to answer: it is the only side that knows what the vault already
 		// holds. The conversion happens inside that answer, because the path it
 		// settles on is the one this block's own links are generated against.
-		return await syncedBlockFile(blockId, currentFolderPath, `${fileName}.md`, async filePath => {
-			// Create a new context for synced block content
-			// Keep currentFolderPath the same so nested synced blocks are also placed correctly
-			// Set isProcessingSyncedBlock flag to indicate we're inside a synced block
-			const syncedBlockContext: BlockConversionContext = {
-				...context,
-				currentFilePath: filePath, // Update current file path for link generation
-				isProcessingSyncedBlock: true // Mark that we're processing synced block content
-			};
+		return await syncedBlockFile({
+			blockId,
+			folderPath: currentFolderPath,
+			fileName: `${fileName}.md`,
+			createdTime: 'created_time' in block ? block.created_time : undefined,
+			lastEditedTime: 'last_edited_time' in block ? block.last_edited_time : undefined,
+			convert: async (filePath, { forChildrenOnly, keepPlaceholders }) => {
+				// Create a new context for synced block content
+				// Keep currentFolderPath the same so nested synced blocks are also placed correctly
+				// Set isProcessingSyncedBlock flag to indicate we're inside a synced block
+				const syncedBlockContext: BlockConversionContext = {
+					...context,
+					currentFilePath: filePath, // Update current file path for link generation
+					isProcessingSyncedBlock: true, // Mark that we're processing synced block content
+					forChildrenOnly: forChildrenOnly || context.forChildrenOnly,
+				};
 
-			// Convert children to markdown
-			const markdown = await convertBlocksToMarkdown(children, syncedBlockContext);
+				// Convert children to markdown
+				const markdown = await convertBlocksToMarkdown(children, syncedBlockContext);
+				if (!keepPlaceholders) return markdown;
 
-			// Extract synced child IDs from the markdown content
-			// This allows us to efficiently replace placeholders later without scanning all files
-			// Separated by type to avoid unnecessary placeholder checks during replacement
+				// Extract synced child IDs from the markdown content
+				// This allows us to efficiently replace placeholders later without scanning all files
+				// Separated by type to avoid unnecessary placeholder checks during replacement
 
-			// Find SYNCED_CHILD_PAGE placeholders
-			const pageIds = extractPlaceholderIds(markdown, PlaceholderType.SYNCED_CHILD_PAGE);
-			if (context.syncedChildPagePlaceholders && pageIds.length > 0) {
-				const existingPageIds = context.syncedChildPagePlaceholders.get(filePath) || new Set<string>();
-				pageIds.forEach(id => existingPageIds.add(id));
-				context.syncedChildPagePlaceholders.set(filePath, existingPageIds);
-			}
+				// Find SYNCED_CHILD_PAGE placeholders
+				const pageIds = extractPlaceholderIds(markdown, PlaceholderType.SYNCED_CHILD_PAGE);
+				if (context.syncedChildPagePlaceholders && pageIds.length > 0) {
+					const existingPageIds = context.syncedChildPagePlaceholders.get(filePath) || new Set<string>();
+					pageIds.forEach(id => existingPageIds.add(id));
+					context.syncedChildPagePlaceholders.set(filePath, existingPageIds);
+				}
 
-			// Find SYNCED_CHILD_DATABASE placeholders
-			const dbIds = extractPlaceholderIds(markdown, PlaceholderType.SYNCED_CHILD_DATABASE);
-			if (context.syncedChildDatabasePlaceholders && dbIds.length > 0) {
-				const existingDbIds = context.syncedChildDatabasePlaceholders.get(filePath) || new Set<string>();
-				dbIds.forEach(id => existingDbIds.add(id));
-				context.syncedChildDatabasePlaceholders.set(filePath, existingDbIds);
-			}
+				// Find SYNCED_CHILD_DATABASE placeholders
+				const dbIds = extractPlaceholderIds(markdown, PlaceholderType.SYNCED_CHILD_DATABASE);
+				if (context.syncedChildDatabasePlaceholders && dbIds.length > 0) {
+					const existingDbIds = context.syncedChildDatabasePlaceholders.get(filePath) || new Set<string>();
+					dbIds.forEach(id => existingDbIds.add(id));
+					context.syncedChildDatabasePlaceholders.set(filePath, existingDbIds);
+				}
 
-			return markdown;
+				return markdown;
+			},
 		});
 	}
 	catch (error) {

--- a/src/formats/notion-api/database-helpers.ts
+++ b/src/formats/notion-api/database-helpers.ts
@@ -378,7 +378,11 @@ export async function createBaseFile(params: CreateBaseFileParams): Promise<stri
 	// Create or update .base file in the database folder (same level as database pages)
 	const baseFilePath = normalizePath(`${databaseFolderPath}/${databaseName}.base`);
 
-	// For incremental import: update existing .base file if it exists
+	// A .base is generated from the database's schema, not imported from a note,
+	// so it is replaced with what the schema now says rather than being treated
+	// as something a duplicate mode has an opinion about. Nothing here reads
+	// duplicateHandling, deliberately: "Skip" is about not writing over notes,
+	// and a stale view of a schema that has moved on is no use to anyone.
 	// Use adapter.exists for reliable check
 	if (await vault.adapter.exists(baseFilePath)) {
 		// Update existing .base file with latest database properties

--- a/src/formats/notion-api/database-helpers.ts
+++ b/src/formats/notion-api/database-helpers.ts
@@ -378,11 +378,9 @@ export async function createBaseFile(params: CreateBaseFileParams): Promise<stri
 	// Create or update .base file in the database folder (same level as database pages)
 	const baseFilePath = normalizePath(`${databaseFolderPath}/${databaseName}.base`);
 
-	// A .base is generated from the database's schema, not imported from a note,
-	// so it is replaced with what the schema now says rather than being treated
-	// as something a duplicate mode has an opinion about. Nothing here reads
-	// duplicateHandling, deliberately: "Skip" is about not writing over notes,
-	// and a stale view of a schema that has moved on is no use to anyone.
+	// Nothing here reads duplicateHandling, deliberately: "Skip" is about not
+	// writing over notes, and a .base is generated from the schema, which a
+	// stale view of is no use to anyone.
 	// Use adapter.exists for reliable check
 	if (await vault.adapter.exists(baseFilePath)) {
 		// Update existing .base file with latest database properties

--- a/src/formats/notion-api/types.ts
+++ b/src/formats/notion-api/types.ts
@@ -240,6 +240,21 @@ export interface BlockConversionContext {
 	isProcessingSyncedBlock?: boolean; // Flag to indicate we're processing synced block content
 	getAvailableAttachmentPath?: (filename: string) => Promise<string>; // Function to get available attachment path
 	writeMarkdownFile: (path: string, content: string) => Promise<TFile>; // Importer-owned writer, so post-import normalization tracks the file
+	/**
+	 * Place, convert and write a synced block's own note, and say where it went.
+	 *
+	 * The importer owns it because only it knows what the vault already holds -
+	 * a synced block imported before has a note already, and writing a second
+	 * one beside it every time is how "Page synced block 1.md" turned into
+	 * "Page synced block 2.md". Conversion happens inside, because the path
+	 * decided here is the one the block's own links are generated against.
+	 */
+	syncedBlockFile?: (
+		blockId: string,
+		folderPath: string,
+		fileName: string,
+		convert: (filePath: string) => Promise<string>,
+	) => Promise<string>;
 }
 
 /**

--- a/src/formats/notion-api/types.ts
+++ b/src/formats/notion-api/types.ts
@@ -217,6 +217,14 @@ export interface BlockConversionContext {
 	downloadExternalAttachments: boolean;
 	singleLineBreaks?: boolean; // Single line breaks between blocks (default: false)
 	incrementalImport?: boolean;
+	/**
+	 * This page is being walked to reach what is under it, not to be written.
+	 *
+	 * Its child pages and databases are still imported - they may have changed
+	 * even where their parent has not - but the markdown is thrown away, so
+	 * nothing it points at is worth fetching.
+	 */
+	forChildrenOnly?: boolean;
 	rangeProbe?: { answered: boolean };
 	indentLevel?: number;
 	blocksCache?: Map<string, BlockObjectResponse[]>;

--- a/src/formats/notion-api/types.ts
+++ b/src/formats/notion-api/types.ts
@@ -11,7 +11,7 @@ import {
 	PageObjectResponse,
 	Heading1BlockObjectResponse
 } from '@notionhq/client';
-import { Vault, App, TFile } from 'obsidian';
+import { Vault, App } from 'obsidian';
 import { ImportContext } from '../../import-context';
 import type { FormulaImportStrategy } from '../../base';
 
@@ -49,9 +49,6 @@ export interface DatabaseProcessingContext {
 	blocksCache?: Map<string, BlockObjectResponse[]>; // Cache of fetched blocks for recursive search
 }
 
-/**
- * Information about a processed database
- */
 /** What the converter has to say about a synced block's own note. */
 export interface SyncedBlockRequest {
 	blockId: string;
@@ -75,6 +72,9 @@ export interface SyncedBlockConversion {
 	keepPlaceholders: boolean;
 }
 
+/**
+ * Information about a processed database
+ */
 export interface DatabaseInfo {
 	id: string;
 	title: string;
@@ -239,7 +239,7 @@ export interface BlockConversionContext {
 	app: App;
 	downloadExternalAttachments: boolean;
 	singleLineBreaks?: boolean; // Single line breaks between blocks (default: false)
-	incrementalImport?: boolean;
+	reuseExistingAttachments?: boolean;
 	/**
 	 * This page is being walked to reach what is under it, not to be written.
 	 *
@@ -262,7 +262,6 @@ export interface BlockConversionContext {
 	currentPageTitle?: string; // Current page title for attachment naming fallback
 	isProcessingSyncedBlock?: boolean; // Flag to indicate we're processing synced block content
 	getAvailableAttachmentPath?: (filename: string) => Promise<string>; // Function to get available attachment path
-	writeMarkdownFile: (path: string, content: string) => Promise<TFile>; // Importer-owned writer, so post-import normalization tracks the file
 	/**
 	 * Place, convert and write a synced block's own note, and say where it went.
 	 *

--- a/src/formats/notion-api/types.ts
+++ b/src/formats/notion-api/types.ts
@@ -52,6 +52,29 @@ export interface DatabaseProcessingContext {
 /**
  * Information about a processed database
  */
+/** What the converter has to say about a synced block's own note. */
+export interface SyncedBlockRequest {
+	blockId: string;
+	folderPath: string;
+	fileName: string;
+	/** When Notion made and last changed the block, for deciding staleness. */
+	createdTime?: string;
+	lastEditedTime?: string;
+	convert: (filePath: string, options: SyncedBlockConversion) => Promise<string>;
+}
+
+export interface SyncedBlockConversion {
+	/** Walking it for what is under it, so nothing it points at is fetched. */
+	forChildrenOnly: boolean;
+	/**
+	 * Whether its unresolved placeholders may be recorded.
+	 *
+	 * Recording them is what has the file rewritten once the import is done,
+	 * which a note the user has edited since the import must not be.
+	 */
+	keepPlaceholders: boolean;
+}
+
 export interface DatabaseInfo {
 	id: string;
 	title: string;
@@ -249,12 +272,7 @@ export interface BlockConversionContext {
 	 * "Page synced block 2.md". Conversion happens inside, because the path
 	 * decided here is the one the block's own links are generated against.
 	 */
-	syncedBlockFile?: (
-		blockId: string,
-		folderPath: string,
-		fileName: string,
-		convert: (filePath: string) => Promise<string>,
-	) => Promise<string>;
+	syncedBlockFile?: (request: SyncedBlockRequest) => Promise<string>;
 }
 
 /**

--- a/src/formats/notion-api/types.ts
+++ b/src/formats/notion-api/types.ts
@@ -64,10 +64,8 @@ export interface SyncedBlockConversion {
 	/** Walking it for what is under it, so nothing it points at is fetched. */
 	forChildrenOnly: boolean;
 	/**
-	 * Whether its unresolved placeholders may be recorded.
-	 *
-	 * Recording them is what has the file rewritten once the import is done,
-	 * which a note the user has edited since the import must not be.
+	 * Recording unresolved placeholders is what has the file rewritten once the
+	 * import is done, which a note the user has edited must not be.
 	 */
 	keepPlaceholders: boolean;
 }
@@ -242,10 +240,8 @@ export interface BlockConversionContext {
 	reuseExistingAttachments?: boolean;
 	/**
 	 * This page is being walked to reach what is under it, not to be written.
-	 *
-	 * Its child pages and databases are still imported - they may have changed
-	 * even where their parent has not - but the markdown is thrown away, so
-	 * nothing it points at is worth fetching.
+	 * Its child pages and databases are still imported, but the markdown is
+	 * thrown away, so nothing it points at is worth fetching.
 	 */
 	forChildrenOnly?: boolean;
 	rangeProbe?: { answered: boolean };
@@ -265,11 +261,9 @@ export interface BlockConversionContext {
 	/**
 	 * Place, convert and write a synced block's own note, and say where it went.
 	 *
-	 * The importer owns it because only it knows what the vault already holds -
-	 * a synced block imported before has a note already, and writing a second
-	 * one beside it every time is how "Page synced block 1.md" turned into
-	 * "Page synced block 2.md". Conversion happens inside, because the path
-	 * decided here is the one the block's own links are generated against.
+	 * The importer owns it because only it knows what the vault already holds.
+	 * Conversion happens inside, because the path it settles on is the one the
+	 * block's own links are generated against.
 	 */
 	syncedBlockFile?: (request: SyncedBlockRequest) => Promise<string>;
 }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -273,6 +273,7 @@ export const en = {
 			statusDownloadingAttachment: 'Downloading attachment: {{name}}',
 			reasonNoRecordNames: 'Could not read record names',
 			reasonEmptyRecord: 'Empty record',
+			descNoModifiedTime: 'Airtable does not say when a record last changed, so "{{update}}" compares the note with the record instead. A note you have edited yourself reads as changed, and will be written over.',
 		},
 		appleNotes: {
 			name: 'Apple Notes',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -273,7 +273,6 @@ export const en = {
 			statusDownloadingAttachment: 'Downloading attachment: {{name}}',
 			reasonNoRecordNames: 'Could not read record names',
 			reasonEmptyRecord: 'Empty record',
-			reasonAlreadyImported: 'Already imported',
 		},
 		appleNotes: {
 			name: 'Apple Notes',

--- a/src/i18n/locales.ts
+++ b/src/i18n/locales.ts
@@ -214,7 +214,6 @@ export const locales: Record<string, Bundle> = {
 		'importer.airtable-api.status-downloading-attachment': 'Téléchargement de la pièce jointe : {{name}}',
 		'importer.airtable-api.reason-no-record-names': 'Impossible de lire les noms des enregistrements',
 		'importer.airtable-api.reason-empty-record': 'Enregistrement vide',
-		'importer.airtable-api.reason-already-imported': 'Déjà importé',
 		'importer.apple-notes.label-id': 'l\'identifiant Apple Notes',
 		'importer.apple-notes.msg-platform': 'En raison de limitations de la plateforme, Apple Notes ne peut pas être exporté depuis cet appareil. Ouvrez votre coffre sur un Mac pour exporter depuis Apple Notes.',
 		'importer.apple-notes.name-prefix-format': 'Format du préfixe de fichier',

--- a/tests/airtable/attachments.test.ts
+++ b/tests/airtable/attachments.test.ts
@@ -6,10 +6,9 @@
  * A name and a size together are what it has: the same name holding the same
  * number of bytes is this attachment again.
  *
- * Getting that wrong is not just a wasted download. Every import found its own
- * file already there, wrote "cover 1.png" beside it and changed the note to
- * point at the new one - so under "Update" the record had changed every time
- * it was looked at, forever.
+ * Getting that wrong is not just a wasted download: every import found its own
+ * file already there, wrote "cover 1.png" beside it and pointed the note at
+ * the new one, so under "Update" the record changed every time it was seen.
  */
 import '../shims/dom';
 import '../shims/runtime';

--- a/tests/airtable/attachments.test.ts
+++ b/tests/airtable/attachments.test.ts
@@ -1,0 +1,143 @@
+/**
+ * What a second Airtable import does to an attachment it already downloaded.
+ *
+ * Airtable hands out an id for every attachment, but nothing writes it into
+ * the vault, so a later import has only the file itself to recognise it by.
+ * A name and a size together are what it has: the same name holding the same
+ * number of bytes is this attachment again.
+ *
+ * Getting that wrong is not just a wasted download. Every import found its own
+ * file already there, wrote "cover 1.png" beside it and changed the note to
+ * point at the new one - so under "Update" the record had changed every time
+ * it was looked at, forever.
+ */
+import '../shims/dom';
+import '../shims/runtime';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { AirtableAPIImporter } from '../../src/formats/airtable-api';
+import { downloadAttachmentList } from '../../src/formats/airtable-api/attachment-helpers';
+import { ImportContext } from '../../src/import-context';
+import type { AirtableAttachment, AttachmentPlacement } from '../../src/formats/airtable-api/types';
+import { answerRequests } from '../shims/obsidian';
+import { MemoryVault, memoryApp } from '../shims/vault';
+
+const NOTE = 'Airtable/Books/Dune.md';
+const COVER: AirtableAttachment = {
+	id: 'attExample00000001',
+	url: 'https://v5.airtableusercontent.com/example/cover.png',
+	filename: 'cover.png',
+	size: 4,
+	type: 'image/png',
+};
+
+const BYTES = new Uint8Array([137, 80, 78, 71]);
+
+const fetched: string[] = [];
+
+answerRequests(request => {
+	fetched.push(request.url);
+
+	return { status: 200, arrayBuffer: BYTES.buffer, text: '', headers: {} } as never;
+});
+
+class PlacingImporter extends AirtableAPIImporter {
+	placer(notePath: string): (filename: string, size: number | undefined) => Promise<AttachmentPlacement> {
+		return this.attachmentPlacer(notePath);
+	}
+}
+
+/** One import's worth of attachment handling, over a vault that may hold some. */
+async function resolve(vault: MemoryVault, attachments: AirtableAttachment[]) {
+	const subject = new PlacingImporter(memoryApp(vault), { sourceEl: null, optionsEl: null } as never);
+	subject.indexImportedNotes();
+
+	const ctx = new ImportContext();
+	const results = await downloadAttachmentList(attachments, {
+		ctx,
+		vault: vault as never,
+		downloadAttachments: true,
+		placeAttachment: subject.placer(NOTE),
+	});
+
+	return { ctx, results };
+}
+
+const files = (vault: MemoryVault) => vault.paths().filter(path => !path.endsWith('.md')).sort();
+
+test('the first import downloads the attachment and keeps its name', async () => {
+	const vault = new MemoryVault();
+	fetched.length = 0;
+
+	const { results } = await resolve(vault, [COVER]);
+
+	assert.deepEqual(fetched, [COVER.url]);
+	assert.deepEqual(files(vault), ['cover.png']);
+	assert.equal(results[0].path, 'cover.png');
+	assert.equal(results[0].isLocal, true);
+});
+
+test('a second import recognises it, downloads nothing, and writes nothing', async () => {
+	const vault = new MemoryVault();
+	await resolve(vault, [COVER]);
+	fetched.length = 0;
+
+	const { results, ctx } = await resolve(vault, [COVER]);
+
+	assert.deepEqual(fetched, [], 'the bytes are already in the vault');
+	assert.deepEqual(files(vault), ['cover.png'], 'and there is still only one copy of them');
+	assert.equal(results[0].path, 'cover.png', 'so the note says exactly what it said before');
+	assert.deepEqual(ctx.skipped, ['cover.png']);
+});
+
+test('a file of the same name that is not this attachment is left where it is', async () => {
+	const vault = new MemoryVault();
+	await vault.createBinary('cover.png', new Uint8Array([1, 2, 3, 4, 5, 6]).buffer);
+	fetched.length = 0;
+
+	const { results } = await resolve(vault, [COVER]);
+
+	assert.deepEqual(files(vault), ['cover 1.png', 'cover.png']);
+	assert.equal(results[0].path, 'cover 1.png');
+	assert.equal((vault.contents.get('cover.png') as ArrayBuffer).byteLength, 6, 'the other file is untouched');
+});
+
+// Once it has settled on "cover 1.png" it stays there, rather than adding a
+// "cover 2.png" on the next import and a "cover 3.png" after that.
+test('and the name it settles on is the one the next import finds', async () => {
+	const vault = new MemoryVault();
+	await vault.createBinary('cover.png', new Uint8Array([1, 2, 3, 4, 5, 6]).buffer);
+	await resolve(vault, [COVER]);
+	fetched.length = 0;
+
+	const { results } = await resolve(vault, [COVER]);
+
+	assert.deepEqual(files(vault), ['cover 1.png', 'cover.png']);
+	assert.equal(results[0].path, 'cover 1.png');
+	assert.deepEqual(fetched, []);
+});
+
+test('two attachments of one name in a single record stay two files', async () => {
+	const vault = new MemoryVault();
+	const other = { ...COVER, id: 'attExample00000002', url: 'https://example.invalid/other.png', size: 4 };
+	fetched.length = 0;
+
+	const { results } = await resolve(vault, [COVER, other]);
+
+	assert.deepEqual(files(vault), ['cover 1.png', 'cover.png']);
+	assert.deepEqual(results.map(result => result.path), ['cover.png', 'cover 1.png']);
+});
+
+test('an attachment whose size Airtable did not report is never mistaken for another', async () => {
+	const vault = new MemoryVault();
+	const unsized = { ...COVER, size: undefined };
+	await resolve(vault, [unsized]);
+	fetched.length = 0;
+
+	await resolve(vault, [unsized]);
+
+	assert.deepEqual(files(vault), ['cover 1.png', 'cover.png'], 'with nothing to compare, it takes a fresh name');
+	assert.deepEqual(fetched, [unsized.url]);
+});

--- a/tests/airtable/attachments.test.ts
+++ b/tests/airtable/attachments.test.ts
@@ -47,6 +47,10 @@ class PlacingImporter extends AirtableAPIImporter {
 	placer(notePath: string): (filename: string, size: number | undefined) => Promise<AttachmentPlacement> {
 		return this.attachmentPlacer(notePath);
 	}
+
+	release(path: string): void {
+		this.releasePath(path);
+	}
 }
 
 /** One import's worth of attachment handling, over a vault that may hold some. */
@@ -60,6 +64,7 @@ async function resolve(vault: MemoryVault, attachments: AirtableAttachment[]) {
 		vault: vault as never,
 		downloadAttachments: true,
 		placeAttachment: subject.placer(NOTE),
+		releasePath: path => subject.release(path),
 	});
 
 	return { ctx, results };

--- a/tests/airtable/planning.test.ts
+++ b/tests/airtable/planning.test.ts
@@ -16,7 +16,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { AirtableAPIImporter } from '../../src/formats/airtable-api';
-import { DuplicateHandling } from '../../src/format-importer';
+import { DuplicateHandling, NoteDisposition } from '../../src/format-importer';
 import { ImportContext } from '../../src/import-context';
 import { RECORD_ID_PROPERTY, recordSourceIds, recordTimestamps } from '../../src/formats/airtable-api/record-note';
 import type { AirtableRecord, PreparedTableData, TablePlan } from '../../src/formats/airtable-api/types';
@@ -28,6 +28,11 @@ class PlanningImporter extends AirtableAPIImporter {
 	plan(ctx: ImportContext, rootPath: string, tables: PreparedTableData[]): Promise<TablePlan[]> {
 		this.preparedData = tables;
 		return this.planRecordPaths(ctx, rootPath);
+	}
+
+	/** What the importer decides about a planned record before rendering it. */
+	preflight(ctx: ImportContext, planned: TablePlan): NoteDisposition {
+		return this.preflightNote(ctx, planned.records[0].note!);
 	}
 }
 
@@ -164,6 +169,45 @@ test('but not once it has moved, where no base can claim it', async () => {
 
 	assert.equal(plans[0].records[0].note?.file, null);
 	assert.deepEqual(paths(plans), ['Airtable/Books/Dune.md']);
+});
+
+test('the importer offers all three ways of meeting a note it already wrote', async () => {
+	const subject = await planning(new MemoryVault(), DuplicateHandling.Update);
+
+	assert.deepEqual(subject.duplicateModes, [
+		DuplicateHandling.CreateCopy,
+		DuplicateHandling.Skip,
+		DuplicateHandling.Update,
+	]);
+});
+
+/** A vault holding one note for rec1, and the plan that finds it. */
+async function planOver(mode: DuplicateHandling) {
+	const vault = new MemoryVault();
+	await vault.createFolder('Airtable');
+	await vault.createFolder('Airtable/Books');
+	await vault.create('Airtable/Books/Dune.md', `---\nairtable-id: ${BASE_ID}:rec1\n---\nold\n`);
+
+	const subject = await planning(vault, mode);
+	const ctx = new ImportContext();
+	const plans = await subject.plan(ctx, 'Airtable', [table([record('rec1', 'Dune')])]);
+
+	return { subject, ctx, plans };
+}
+
+// Which matters for more than the writing: rendering a record downloads its
+// attachments, so a decision made after it is a decision made too late.
+test('"Skip" is settled before the record is rendered', async () => {
+	const { subject, ctx, plans } = await planOver(DuplicateHandling.Skip);
+
+	assert.equal(subject.preflight(ctx, plans[0]), 'skip');
+});
+
+test('"Update" cannot settle it, because Airtable will not say when the record changed', async () => {
+	const { subject, ctx, plans } = await planOver(DuplicateHandling.Update);
+
+	assert.equal(subject.preflight(ctx, plans[0]), 'compare-content');
+	assert.deepEqual(ctx.skipped, [], 'nothing is decided yet, so nothing is reported');
 });
 
 test('the property a record note is recognised by is airtable-id', () => {

--- a/tests/airtable/planning.test.ts
+++ b/tests/airtable/planning.test.ts
@@ -18,7 +18,7 @@ import assert from 'node:assert/strict';
 import { AirtableAPIImporter } from '../../src/formats/airtable-api';
 import { DuplicateHandling } from '../../src/format-importer';
 import { ImportContext } from '../../src/import-context';
-import { RECORD_ID_PROPERTY } from '../../src/formats/airtable-api/record-note';
+import { RECORD_ID_PROPERTY, recordTimestamps } from '../../src/formats/airtable-api/record-note';
 import type { AirtableRecord, PreparedTableData, TablePlan } from '../../src/formats/airtable-api/types';
 import { MemoryVault, memoryApp } from '../shims/vault';
 
@@ -118,6 +118,15 @@ test('"Create a copy" plans beside the note rather than onto it', async () => {
 
 	assert.deepEqual(paths(plans), ['Airtable/Books/Dune 1.md']);
 	assert.equal(plans[0].records[0].note?.file, null);
+});
+
+test('a record note is stamped with when Airtable says the record was made', () => {
+	assert.deepEqual(recordTimestamps(record('rec1', 'Dune')), { ctime: Date.parse('2024-01-01T00:00:00.000Z') });
+});
+
+test('and with nothing at all when there is no time to read', () => {
+	assert.deepEqual(recordTimestamps({ id: 'rec1', fields: {} } as never), {});
+	assert.deepEqual(recordTimestamps({ id: 'rec1', createdTime: 'not a date', fields: {} }), {});
 });
 
 test('an empty record is passed over before it is ever planned', async () => {

--- a/tests/airtable/planning.test.ts
+++ b/tests/airtable/planning.test.ts
@@ -86,7 +86,7 @@ test('a record an earlier import wrote is planned onto that note', async () => {
 	const vault = new MemoryVault();
 	await vault.createFolder('Airtable');
 	await vault.createFolder('Airtable/Books');
-	await vault.create('Airtable/Books/Dune.md', `---\n${RECORD_ID_PROPERTY}: rec1\n---\nold\n`);
+	await vault.create('Airtable/Books/Dune.md', '---\nairtable-id: rec1\n---\nold\n');
 
 	const subject = await planning(vault, DuplicateHandling.Skip);
 	const plans = await subject.plan(new ImportContext(), 'Airtable', [table([record('rec1', 'Dune')])]);
@@ -98,7 +98,7 @@ test('a record an earlier import wrote is planned onto that note', async () => {
 test('and is still planned onto it after the user moved it', async () => {
 	const vault = new MemoryVault();
 	await vault.createFolder('Reading');
-	await vault.create('Reading/Dune.md', `---\n${RECORD_ID_PROPERTY}: rec1\n---\nold\n`);
+	await vault.create('Reading/Dune.md', `---\nairtable-id: ${BASE_ID}:rec1\n---\nold\n`);
 
 	const subject = await planning(vault, DuplicateHandling.Skip);
 	const plans = await subject.plan(new ImportContext(), 'Airtable', [table([record('rec1', 'Dune')])]);
@@ -107,11 +107,30 @@ test('and is still planned onto it after the user moved it', async () => {
 	assert.equal(plans[0].records[0].note?.desiredPath, 'Airtable/Books/Dune.md');
 });
 
+// One legacy note, two records that would both be titled for it. Planning
+// happens before any of them is written, so nothing but the claim stops the
+// second from being planned onto the note the first took.
+test('two records cannot both be planned onto one untitled legacy note', async () => {
+	const vault = new MemoryVault();
+	await vault.createFolder('Airtable');
+	await vault.createFolder('Airtable/Books');
+	await vault.create('Airtable/Books/Dune.md', 'imported before ids were recorded\n');
+
+	const subject = await planning(vault, DuplicateHandling.Skip);
+	const plans = await subject.plan(new ImportContext(), 'Airtable', [table([
+		record('rec1', 'Dune'),
+		record('rec2', 'Dune'),
+	])]);
+
+	assert.deepEqual(paths(plans), ['Airtable/Books/Dune.md', 'Airtable/Books/Dune 1.md']);
+	assert.equal(plans[0].records[1].note?.file, null);
+});
+
 test('"Create a copy" plans beside the note rather than onto it', async () => {
 	const vault = new MemoryVault();
 	await vault.createFolder('Airtable');
 	await vault.createFolder('Airtable/Books');
-	await vault.create('Airtable/Books/Dune.md', `---\n${RECORD_ID_PROPERTY}: rec1\n---\nold\n`);
+	await vault.create('Airtable/Books/Dune.md', '---\nairtable-id: rec1\n---\nold\n');
 
 	const subject = await planning(vault, DuplicateHandling.CreateCopy);
 	const plans = await subject.plan(new ImportContext(), 'Airtable', [table([record('rec1', 'Dune')])]);
@@ -120,19 +139,39 @@ test('"Create a copy" plans beside the note rather than onto it', async () => {
 	assert.equal(plans[0].records[0].note?.file, null);
 });
 
-test('a record note carrying only the bare id is still that record', async () => {
+test('a note carrying only the bare id is still that record, where it was left', async () => {
 	const vault = new MemoryVault();
-	await vault.createFolder('Reading');
-	await vault.create('Reading/Dune.md', `---\n${RECORD_ID_PROPERTY}: rec1\n---\nwritten before ids carried a base\n`);
+	await vault.createFolder('Airtable');
+	await vault.createFolder('Airtable/Books');
+	await vault.create('Airtable/Books/Dune.md', '---\nairtable-id: rec1\n---\nwritten before ids carried a base\n');
 
 	const subject = await planning(vault, DuplicateHandling.Skip);
 	const plans = await subject.plan(new ImportContext(), 'Airtable', [table([record('rec1', 'Dune')])]);
 
-	assert.equal(plans[0].records[0].note?.file?.path, 'Reading/Dune.md');
+	assert.equal(plans[0].records[0].note?.file?.path, 'Airtable/Books/Dune.md');
+});
+
+// A bare id cannot say which base it came from, so a note that has moved away
+// from where the version that wrote it would have put it could belong to any
+// base's rec1. It gets a new note rather than the wrong record's contents.
+test('but not once it has moved, where no base can claim it', async () => {
+	const vault = new MemoryVault();
+	await vault.createFolder('Reading');
+	await vault.create('Reading/Dune.md', '---\nairtable-id: rec1\n---\nwritten before ids carried a base\n');
+
+	const subject = await planning(vault, DuplicateHandling.Skip);
+	const plans = await subject.plan(new ImportContext(), 'Airtable', [table([record('rec1', 'Dune')])]);
+
+	assert.equal(plans[0].records[0].note?.file, null);
+	assert.deepEqual(paths(plans), ['Airtable/Books/Dune.md']);
+});
+
+test('the property a record note is recognised by is airtable-id', () => {
+	assert.equal(RECORD_ID_PROPERTY, 'airtable-id');
 });
 
 test('a record note is written with the base its record belongs to', () => {
-	assert.deepEqual(recordSourceIds(BASE_ID, 'rec1'), [`${BASE_ID}:rec1`, 'rec1']);
+	assert.deepEqual(recordSourceIds(BASE_ID, 'rec1'), { id: `${BASE_ID}:rec1`, formerly: ['rec1'] });
 });
 
 test('a record note is stamped with when Airtable says the record was made', () => {

--- a/tests/airtable/planning.test.ts
+++ b/tests/airtable/planning.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Where each Airtable record's note is going, settled before any is written.
+ *
+ * Records link to each other, so every path has to be known before the first
+ * note is built - including the path of a note an earlier import already
+ * wrote, wherever the user has since moved it to. This is the step that
+ * decides them.
+ *
+ * convert.test.ts covers turning a record into markdown; this covers naming
+ * the file it lands in.
+ */
+import '../shims/dom';
+import '../shims/runtime';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { AirtableAPIImporter } from '../../src/formats/airtable-api';
+import { DuplicateHandling } from '../../src/format-importer';
+import { ImportContext } from '../../src/import-context';
+import { RECORD_ID_PROPERTY } from '../../src/formats/airtable-api/record-note';
+import type { AirtableRecord, PreparedTableData, TablePlan } from '../../src/formats/airtable-api/types';
+import { MemoryVault, memoryApp } from '../shims/vault';
+
+const BASE_ID = 'appExample00000001';
+
+class PlanningImporter extends AirtableAPIImporter {
+	plan(ctx: ImportContext, rootPath: string, tables: PreparedTableData[]): Promise<TablePlan[]> {
+		this.preparedData = tables;
+		return this.planRecordPaths(ctx, rootPath);
+	}
+}
+
+function record(id: string, title: string): AirtableRecord {
+	return { id, createdTime: '2024-01-01T00:00:00.000Z', fields: { Name: title } };
+}
+
+function table(records: AirtableRecord[]): PreparedTableData {
+	return {
+		baseId: BASE_ID,
+		baseName: '',
+		tableName: 'Books',
+		primaryFieldId: 'fldName0000000001',
+		fields: [{ id: 'fldName0000000001', name: 'Name', type: 'singleLineText' }] as never,
+		views: [],
+		records,
+		recordViewMemberships: new Map(),
+		viewsShowingEveryRecord: new Set(),
+	};
+}
+
+async function planning(vault: MemoryVault, mode: DuplicateHandling) {
+	const subject = new PlanningImporter(memoryApp(vault), { sourceEl: null, optionsEl: null } as never);
+	subject.duplicateHandling = mode;
+	subject.indexImportedNotes();
+
+	return subject;
+}
+
+/** Each record's planned path, in the order the table has them. */
+const paths = (plans: TablePlan[]) => plans[0].records.map(planned => planned.filePath);
+
+test('a record nothing matches is planned at its title', async () => {
+	const vault = new MemoryVault();
+	const subject = await planning(vault, DuplicateHandling.Skip);
+
+	const plans = await subject.plan(new ImportContext(), 'Airtable', [table([record('rec1', 'The Long Way')])]);
+
+	assert.deepEqual(paths(plans), ['Airtable/Books/The Long Way.md']);
+	assert.equal(plans[0].records[0].note?.file, null);
+});
+
+test('two records of one title are planned as two notes', async () => {
+	const vault = new MemoryVault();
+	const subject = await planning(vault, DuplicateHandling.Skip);
+
+	const plans = await subject.plan(new ImportContext(), 'Airtable', [table([
+		record('rec1', 'Dune'),
+		record('rec2', 'Dune'),
+	])]);
+
+	assert.deepEqual(paths(plans), ['Airtable/Books/Dune.md', 'Airtable/Books/Dune 1.md']);
+});
+
+test('a record an earlier import wrote is planned onto that note', async () => {
+	const vault = new MemoryVault();
+	await vault.createFolder('Airtable');
+	await vault.createFolder('Airtable/Books');
+	await vault.create('Airtable/Books/Dune.md', `---\n${RECORD_ID_PROPERTY}: rec1\n---\nold\n`);
+
+	const subject = await planning(vault, DuplicateHandling.Skip);
+	const plans = await subject.plan(new ImportContext(), 'Airtable', [table([record('rec1', 'Dune')])]);
+
+	assert.deepEqual(paths(plans), ['Airtable/Books/Dune.md']);
+	assert.equal(plans[0].records[0].note?.file?.path, 'Airtable/Books/Dune.md');
+});
+
+test('and is still planned onto it after the user moved it', async () => {
+	const vault = new MemoryVault();
+	await vault.createFolder('Reading');
+	await vault.create('Reading/Dune.md', `---\n${RECORD_ID_PROPERTY}: rec1\n---\nold\n`);
+
+	const subject = await planning(vault, DuplicateHandling.Skip);
+	const plans = await subject.plan(new ImportContext(), 'Airtable', [table([record('rec1', 'Dune')])]);
+
+	assert.deepEqual(paths(plans), ['Reading/Dune.md'], 'the note it already wrote is where the record belongs');
+	assert.equal(plans[0].records[0].note?.desiredPath, 'Airtable/Books/Dune.md');
+});
+
+test('"Create a copy" plans beside the note rather than onto it', async () => {
+	const vault = new MemoryVault();
+	await vault.createFolder('Airtable');
+	await vault.createFolder('Airtable/Books');
+	await vault.create('Airtable/Books/Dune.md', `---\n${RECORD_ID_PROPERTY}: rec1\n---\nold\n`);
+
+	const subject = await planning(vault, DuplicateHandling.CreateCopy);
+	const plans = await subject.plan(new ImportContext(), 'Airtable', [table([record('rec1', 'Dune')])]);
+
+	assert.deepEqual(paths(plans), ['Airtable/Books/Dune 1.md']);
+	assert.equal(plans[0].records[0].note?.file, null);
+});
+
+test('an empty record is passed over before it is ever planned', async () => {
+	const vault = new MemoryVault();
+	const subject = await planning(vault, DuplicateHandling.Skip);
+
+	const plans = await subject.plan(new ImportContext(), 'Airtable', [table([
+		{ id: 'rec1', createdTime: '2024-01-01T00:00:00.000Z', fields: {} },
+	])]);
+
+	assert.equal(plans[0].records[0].note, null);
+	assert.equal(plans[0].records[0].filePath, '');
+	assert.ok(plans[0].records[0].skipped);
+});

--- a/tests/airtable/planning.test.ts
+++ b/tests/airtable/planning.test.ts
@@ -18,7 +18,7 @@ import assert from 'node:assert/strict';
 import { AirtableAPIImporter } from '../../src/formats/airtable-api';
 import { DuplicateHandling } from '../../src/format-importer';
 import { ImportContext } from '../../src/import-context';
-import { RECORD_ID_PROPERTY, recordTimestamps } from '../../src/formats/airtable-api/record-note';
+import { RECORD_ID_PROPERTY, recordSourceIds, recordTimestamps } from '../../src/formats/airtable-api/record-note';
 import type { AirtableRecord, PreparedTableData, TablePlan } from '../../src/formats/airtable-api/types';
 import { MemoryVault, memoryApp } from '../shims/vault';
 
@@ -118,6 +118,21 @@ test('"Create a copy" plans beside the note rather than onto it', async () => {
 
 	assert.deepEqual(paths(plans), ['Airtable/Books/Dune 1.md']);
 	assert.equal(plans[0].records[0].note?.file, null);
+});
+
+test('a record note carrying only the bare id is still that record', async () => {
+	const vault = new MemoryVault();
+	await vault.createFolder('Reading');
+	await vault.create('Reading/Dune.md', `---\n${RECORD_ID_PROPERTY}: rec1\n---\nwritten before ids carried a base\n`);
+
+	const subject = await planning(vault, DuplicateHandling.Skip);
+	const plans = await subject.plan(new ImportContext(), 'Airtable', [table([record('rec1', 'Dune')])]);
+
+	assert.equal(plans[0].records[0].note?.file?.path, 'Reading/Dune.md');
+});
+
+test('a record note is written with the base its record belongs to', () => {
+	assert.deepEqual(recordSourceIds(BASE_ID, 'rec1'), [`${BASE_ID}:rec1`, 'rec1']);
 });
 
 test('a record note is stamped with when Airtable says the record was made', () => {

--- a/tests/airtable/planning.test.ts
+++ b/tests/airtable/planning.test.ts
@@ -18,7 +18,7 @@ import assert from 'node:assert/strict';
 import { AirtableAPIImporter } from '../../src/formats/airtable-api';
 import { DuplicateHandling, NoteDisposition } from '../../src/format-importer';
 import { ImportContext } from '../../src/import-context';
-import { RECORD_ID_PROPERTY, recordSourceIds, recordTimestamps } from '../../src/formats/airtable-api/record-note';
+import { RECORD_ID_PROPERTY, recordTimestamps } from '../../src/formats/airtable-api/record-note';
 import type { AirtableRecord, PreparedTableData, TablePlan } from '../../src/formats/airtable-api/types';
 import { MemoryVault, memoryApp } from '../shims/vault';
 
@@ -103,7 +103,7 @@ test('a record an earlier import wrote is planned onto that note', async () => {
 test('and is still planned onto it after the user moved it', async () => {
 	const vault = new MemoryVault();
 	await vault.createFolder('Reading');
-	await vault.create('Reading/Dune.md', `---\nairtable-id: ${BASE_ID}:rec1\n---\nold\n`);
+	await vault.create('Reading/Dune.md', '---\nairtable-id: rec1\n---\nold\n');
 
 	const subject = await planning(vault, DuplicateHandling.Skip);
 	const plans = await subject.plan(new ImportContext(), 'Airtable', [table([record('rec1', 'Dune')])]);
@@ -144,33 +144,6 @@ test('"Create a copy" plans beside the note rather than onto it', async () => {
 	assert.equal(plans[0].records[0].note?.file, null);
 });
 
-test('a note carrying only the bare id is still that record, where it was left', async () => {
-	const vault = new MemoryVault();
-	await vault.createFolder('Airtable');
-	await vault.createFolder('Airtable/Books');
-	await vault.create('Airtable/Books/Dune.md', '---\nairtable-id: rec1\n---\nwritten before ids carried a base\n');
-
-	const subject = await planning(vault, DuplicateHandling.Skip);
-	const plans = await subject.plan(new ImportContext(), 'Airtable', [table([record('rec1', 'Dune')])]);
-
-	assert.equal(plans[0].records[0].note?.file?.path, 'Airtable/Books/Dune.md');
-});
-
-// A bare id cannot say which base it came from, so a note that has moved away
-// from where the version that wrote it would have put it could belong to any
-// base's rec1. It gets a new note rather than the wrong record's contents.
-test('but not once it has moved, where no base can claim it', async () => {
-	const vault = new MemoryVault();
-	await vault.createFolder('Reading');
-	await vault.create('Reading/Dune.md', '---\nairtable-id: rec1\n---\nwritten before ids carried a base\n');
-
-	const subject = await planning(vault, DuplicateHandling.Skip);
-	const plans = await subject.plan(new ImportContext(), 'Airtable', [table([record('rec1', 'Dune')])]);
-
-	assert.equal(plans[0].records[0].note?.file, null);
-	assert.deepEqual(paths(plans), ['Airtable/Books/Dune.md']);
-});
-
 test('the importer offers all three ways of meeting a note it already wrote', async () => {
 	const subject = await planning(new MemoryVault(), DuplicateHandling.Update);
 
@@ -186,7 +159,7 @@ async function planOver(mode: DuplicateHandling) {
 	const vault = new MemoryVault();
 	await vault.createFolder('Airtable');
 	await vault.createFolder('Airtable/Books');
-	await vault.create('Airtable/Books/Dune.md', `---\nairtable-id: ${BASE_ID}:rec1\n---\nold\n`);
+	await vault.create('Airtable/Books/Dune.md', '---\nairtable-id: rec1\n---\nold\n');
 
 	const subject = await planning(vault, mode);
 	const ctx = new ImportContext();
@@ -212,10 +185,6 @@ test('"Update" cannot settle it, because Airtable will not say when the record c
 
 test('the property a record note is recognised by is airtable-id', () => {
 	assert.equal(RECORD_ID_PROPERTY, 'airtable-id');
-});
-
-test('a record note is written with the base its record belongs to', () => {
-	assert.deepEqual(recordSourceIds(BASE_ID, 'rec1'), { id: `${BASE_ID}:rec1`, formerly: ['rec1'] });
 });
 
 test('a record note is stamped with when Airtable says the record was made', () => {

--- a/tests/notion-api/attachments.test.ts
+++ b/tests/notion-api/attachments.test.ts
@@ -110,7 +110,7 @@ test('a malformed data URL fails that attachment and leaves the URL in place', a
 	assert.deepEqual(result, { path: url, isLocal: false });
 });
 
-function contextOverVault(vault: MemoryVault, incrementalImport: boolean): BlockConversionContext {
+function contextOverVault(vault: MemoryVault, reuseExistingAttachments: boolean): BlockConversionContext {
 	const skipped: string[] = [];
 
 	return {
@@ -127,7 +127,7 @@ function contextOverVault(vault: MemoryVault, incrementalImport: boolean): Block
 		vault,
 		app: {},
 		downloadExternalAttachments: true,
-		incrementalImport,
+		reuseExistingAttachments,
 		getAvailableAttachmentPath: async (filename: string) => {
 			const dot = filename.lastIndexOf('.');
 			const base = dot > 0 ? filename.slice(0, dot) : filename;

--- a/tests/notion-api/convert.test.ts
+++ b/tests/notion-api/convert.test.ts
@@ -132,15 +132,15 @@ test('hands a synced block\'s own note to the importer to place and write', asyn
 		syncedBlocksMap: new Map(),
 		vault,
 		app: memoryApp(vault),
-		syncedBlockFile: async (
+		syncedBlockFile: async ({ blockId, folderPath, fileName, convert }: {
 			blockId: string,
-			folder: string,
-			name: string,
-			convert: (path: string) => Promise<string>,
-		) => {
-			asked.push({ blockId, folder, name });
-			const path = `${folder}/${name}`;
-			await vault.create(path, await convert(path));
+			folderPath: string,
+			fileName: string,
+			convert: (path: string, options: { forChildrenOnly: boolean, keepPlaceholders: boolean }) => Promise<string>,
+		}) => {
+			asked.push({ blockId, folder: folderPath, name: fileName });
+			const path = `${folderPath}/${fileName}`;
+			await vault.create(path, await convert(path, { forChildrenOnly: false, keepPlaceholders: true }));
 
 			return path;
 		},

--- a/tests/notion-api/convert.test.ts
+++ b/tests/notion-api/convert.test.ts
@@ -112,7 +112,7 @@ test('writes one line between blocks when asked to', async () => {
 	assert.doesNotMatch(tight, /\n\n\n/);
 });
 
-test('creates synced-block notes through the importer-owned Markdown writer', async () => {
+test('hands a synced block\'s own note to the importer to place and write', async () => {
 	const vault = new MemoryVault();
 	await vault.createFolder('Notion');
 	const block = {
@@ -121,7 +121,7 @@ test('creates synced-block notes through the importer-owned Markdown writer', as
 		has_children: false,
 		synced_block: { synced_from: null },
 	};
-	let writtenPath = '';
+	const asked: { blockId: string, folder: string, name: string }[] = [];
 	const syncedContext = {
 		ctx: REPORTER,
 		client: { blocks: { retrieve: async () => block } },
@@ -132,14 +132,22 @@ test('creates synced-block notes through the importer-owned Markdown writer', as
 		syncedBlocksMap: new Map(),
 		vault,
 		app: memoryApp(vault),
-		writeMarkdownFile: async (path: string, content: string) => {
-			writtenPath = path;
-			return await vault.create(path, content) as never;
+		syncedBlockFile: async (
+			blockId: string,
+			folder: string,
+			name: string,
+			convert: (path: string) => Promise<string>,
+		) => {
+			asked.push({ blockId, folder, name });
+			const path = `${folder}/${name}`;
+			await vault.create(path, await convert(path));
+
+			return path;
 		},
 	} as unknown as BlockConversionContext;
 
 	const link = await convertSyncedBlock(block as never, syncedContext);
 
-	assert.equal(writtenPath, 'Notion/Example synced block.md');
+	assert.deepEqual(asked, [{ blockId: 'synced-id', folder: 'Notion', name: 'Example synced block.md' }]);
 	assert.equal(link, '![[Notion/Example synced block.md]]');
 });

--- a/tests/notion-api/progress.test.ts
+++ b/tests/notion-api/progress.test.ts
@@ -10,7 +10,7 @@ import { MemoryVault, memoryApp } from '../shims/vault';
 
 class CountingImporter extends NotionAPIImporter {
 	useStubClient(children: Record<string, string[]> = {}): void {
-		(this as unknown as { notionClient: unknown }).notionClient = {
+		this.notionClient = {
 			pages: { retrieve: async ({ page_id }: { page_id: string }) => ({ id: page_id, properties: {} }) },
 			blocks: {
 				children: {
@@ -24,13 +24,17 @@ class CountingImporter extends NotionAPIImporter {
 					}),
 				},
 			},
-		};
+		} as never;
+	}
+
+	useFailingClient(): void {
+		this.notionClient = {
+			pages: { retrieve: async () => { throw new Error('Page could not be read'); } },
+		} as never;
 	}
 
 	importPage(ctx: ImportContext, pageId: string) {
-		return (this as unknown as {
-			fetchAndImportPage(params: { ctx: ImportContext, pageId: string, parentPath: string }): Promise<void>;
-		}).fetchAndImportPage({ ctx, pageId, parentPath: 'Notion' });
+		return this.fetchAndImportPage({ ctx, pageId, parentPath: 'Notion' });
 	}
 
 	discover(ctx: ImportContext, pageIds: string[]) {
@@ -86,9 +90,7 @@ test('a page reached twice is counted once', async () => {
 
 test('a page that fails counts too, so remaining still reaches zero', async () => {
 	const { subject, ctx } = await importer();
-	(subject as unknown as { notionClient: unknown }).notionClient = {
-		pages: { retrieve: async () => { throw new Error('Page could not be read'); } },
-	};
+	subject.useFailingClient();
 
 	await subject.importPage(ctx, 'page-1');
 

--- a/tests/notion-api/reimport-workspace.json
+++ b/tests/notion-api/reimport-workspace.json
@@ -1,0 +1,63 @@
+{
+	"_comment": "Hand-written to the shape of Notion's API responses (https://developers.notion.com/reference). `pages` is keyed by page id, each value as GET /v1/pages/{id} returns it; `blocks` is keyed by block id, each value as GET /v1/blocks/{id}/children returns it. Unlike example-page.json this carries the page envelope too, because reimport.test.ts drives the importer itself rather than the block conversion, and the importer reads created_time and last_edited_time off the page. A parent with one child page is enough to cover both file-structure branches: a page with children becomes a folder, a page without stays a bare note. The ids are made up and so is the content.",
+
+	"pages": {
+		"10000000-0000-4000-8000-000000000101": {
+			"object": "page",
+			"id": "10000000-0000-4000-8000-000000000101",
+			"created_time": "2024-01-01T00:00:00.000Z",
+			"last_edited_time": "2024-03-01T00:00:00.000Z",
+			"archived": false,
+			"properties": {
+				"title": {
+					"id": "title",
+					"type": "title",
+					"title": [{ "type": "text", "text": { "content": "Roadmap", "link": null }, "annotations": { "bold": false, "italic": false, "strikethrough": false, "underline": false, "code": false, "color": "default" }, "plain_text": "Roadmap", "href": null }]
+				}
+			}
+		},
+		"10000000-0000-4000-8000-000000000102": {
+			"object": "page",
+			"id": "10000000-0000-4000-8000-000000000102",
+			"created_time": "2024-01-02T00:00:00.000Z",
+			"last_edited_time": "2024-03-02T00:00:00.000Z",
+			"archived": false,
+			"properties": {
+				"title": {
+					"id": "title",
+					"type": "title",
+					"title": [{ "type": "text", "text": { "content": "Milestones", "link": null }, "annotations": { "bold": false, "italic": false, "strikethrough": false, "underline": false, "code": false, "color": "default" }, "plain_text": "Milestones", "href": null }]
+				}
+			}
+		}
+	},
+
+	"blocks": {
+		"10000000-0000-4000-8000-000000000101": {
+			"object": "list",
+			"has_more": false,
+			"next_cursor": null,
+			"results": [
+				{
+					"object": "block", "id": "20000000-0000-4000-8000-000000000101", "type": "paragraph", "has_children": false, "archived": false,
+					"paragraph": { "rich_text": [{ "type": "text", "text": { "content": "What we are building this year.", "link": null }, "annotations": { "bold": false, "italic": false, "strikethrough": false, "underline": false, "code": false, "color": "default" }, "plain_text": "What we are building this year.", "href": null }], "color": "default" }
+				},
+				{
+					"object": "block", "id": "10000000-0000-4000-8000-000000000102", "type": "child_page", "has_children": true, "archived": false,
+					"child_page": { "title": "Milestones" }
+				}
+			]
+		},
+		"10000000-0000-4000-8000-000000000102": {
+			"object": "list",
+			"has_more": false,
+			"next_cursor": null,
+			"results": [
+				{
+					"object": "block", "id": "20000000-0000-4000-8000-000000000102", "type": "paragraph", "has_children": false, "archived": false,
+					"paragraph": { "rich_text": [{ "type": "text", "text": { "content": "First release in spring.", "link": null }, "annotations": { "bold": false, "italic": false, "strikethrough": false, "underline": false, "code": false, "color": "default" }, "plain_text": "First release in spring.", "href": null }], "color": "default" }
+				}
+			]
+		}
+	}
+}

--- a/tests/notion-api/reimport-workspace.json
+++ b/tests/notion-api/reimport-workspace.json
@@ -1,5 +1,5 @@
 {
-	"_comment": "Hand-written to the shape of Notion's API responses (https://developers.notion.com/reference). `pages` is keyed by page id, each value as GET /v1/pages/{id} returns it; `blocks` is keyed by block id, each value as GET /v1/blocks/{id}/children returns it. Unlike example-page.json this carries the page envelope too, because reimport.test.ts drives the importer itself rather than the block conversion, and the importer reads created_time and last_edited_time off the page. A parent with one child page is enough to cover both file-structure branches: a page with children becomes a folder, a page without stays a bare note. The ids are made up and so is the content.",
+	"_comment": "Hand-written to the shape of Notion's API responses (https://developers.notion.com/reference). `pages` is keyed by page id, each value as GET /v1/pages/{id} returns it; `blocks` is keyed by block id, each value as GET /v1/blocks/{id}/children returns it. Unlike example-page.json this carries the page envelope too, because reimport.test.ts drives the importer itself rather than the block conversion, and the importer reads created_time and last_edited_time off the page. A parent with one child page is enough to cover both file-structure branches: a page with children becomes a folder, a page without stays a bare note. The parent holds a Notion-hosted image, which is what a second import must not fetch again. The ids are made up and so is the content, and example.invalid is reserved by RFC 2606 so nothing resolves it.",
 
 	"pages": {
 		"10000000-0000-4000-8000-000000000101": {
@@ -41,6 +41,10 @@
 				{
 					"object": "block", "id": "20000000-0000-4000-8000-000000000101", "type": "paragraph", "has_children": false, "archived": false,
 					"paragraph": { "rich_text": [{ "type": "text", "text": { "content": "What we are building this year.", "link": null }, "annotations": { "bold": false, "italic": false, "strikethrough": false, "underline": false, "code": false, "color": "default" }, "plain_text": "What we are building this year.", "href": null }], "color": "default" }
+				},
+				{
+					"object": "block", "id": "20000000-0000-4000-8000-000000000103", "type": "image", "has_children": false, "archived": false,
+					"image": { "type": "file", "file": { "url": "https://example.invalid/roadmap-chart.png", "expiry_time": "2024-03-01T01:00:00.000Z" }, "caption": [] }
 				},
 				{
 					"object": "block", "id": "10000000-0000-4000-8000-000000000102", "type": "child_page", "has_children": true, "archived": false,

--- a/tests/notion-api/reimport.test.ts
+++ b/tests/notion-api/reimport.test.ts
@@ -19,7 +19,7 @@ import assert from 'node:assert/strict';
 import * as nodeFs from 'node:fs';
 import * as nodePath from 'node:path';
 
-import type { TFolder } from 'obsidian';
+import type { TFile, TFolder } from 'obsidian';
 
 import { childFolderOf, NotionAPIImporter } from '../../src/formats/notion-api';
 import { DuplicateHandling, PlannedNote } from '../../src/format-importer';
@@ -55,13 +55,20 @@ class ImportingTwice extends NotionAPIImporter {
 		return note;
 	}
 
-	answerFromFixture(): void {
+	/** Whether the passes after the import will rewrite this note. */
+	queuedForRewriting(path: string): boolean {
+		return this.mentionPlaceholders.has(path);
+	}
+
+	answerFromFixture(editedAt?: string): void {
 		this.notionClient = {
 			pages: {
 				retrieve: async ({ page_id }: { page_id: string }) => {
 					const page = workspace.pages[page_id];
 					if (!page) throw new Error(`no page ${page_id} in the fixture`);
-					return page;
+
+					// Standing in for someone editing the page in Notion.
+					return editedAt ? { ...(page as object), last_edited_time: editedAt } : page;
 				},
 			},
 			blocks: {
@@ -93,12 +100,22 @@ answerRequests(request => {
 	return { status: 200, arrayBuffer: new Uint8Array([137, 80, 78, 71]).buffer, text: '', headers: {} } as never;
 });
 
+interface Run {
+	saveSourceId?: boolean;
+	/** When Notion last changed every page, for a run that follows an edit. */
+	editedAt?: string;
+}
+
 /** One import of the whole fixture, over a vault that may already hold one. */
-async function importOnce(vault: MemoryVault, mode: DuplicateHandling, saveSourceId = true): Promise<ImportContext> {
+async function importOnce(
+	vault: MemoryVault,
+	mode: DuplicateHandling,
+	{ saveSourceId = true, editedAt }: Run = {},
+): Promise<{ ctx: ImportContext, subject: ImportingTwice }> {
 	const subject = new ImportingTwice(memoryApp(vault), { sourceEl: null, optionsEl: null } as never);
 	subject.duplicateHandling = mode;
 	subject.saveSourceId = saveSourceId;
-	subject.answerFromFixture();
+	subject.answerFromFixture(editedAt);
 	subject.indexImportedNotes();
 
 	const ctx = new ImportContext();
@@ -114,7 +131,7 @@ async function importOnce(vault: MemoryVault, mode: DuplicateHandling, saveSourc
 		assert.ok(subject.planned.includes(path), `${path} was written but never planned`);
 	}
 
-	return ctx;
+	return { ctx, subject };
 }
 
 async function vaultWithOneImport(mode: DuplicateHandling): Promise<MemoryVault> {
@@ -149,7 +166,7 @@ test('importing again with "Skip" leaves the vault as it was', async () => {
 	const vault = await vaultWithOneImport(DuplicateHandling.Skip);
 	const before = markdown(vault).map(path => [path, vault.contents.get(path)] as const);
 
-	const second = await importOnce(vault, DuplicateHandling.Skip);
+	const { ctx: second } = await importOnce(vault, DuplicateHandling.Skip);
 
 	assert.deepEqual(markdown(vault), before.map(([path]) => path), 'no note should have been added');
 	for (const [path, content] of before) {
@@ -211,6 +228,92 @@ test('and the walk still reaches a child that is no longer there', async () => {
 	assert.deepEqual(fetched, [], 'and the parent still fetched nothing of its own');
 });
 
+const ROADMAP = 'Notion/Roadmap/Roadmap.md';
+/** What the fixture says Notion last changed the page. */
+const NOTION_EDITED = '2024-03-01T00:00:00.000Z';
+const LATER = '2024-09-01T00:00:00.000Z';
+
+/** Stand in for the user editing a note in Obsidian after the import. */
+async function editInObsidian(vault: MemoryVault, path: string, body: string, at: string): Promise<void> {
+	const file = vault.getAbstractFileByPath(path) as unknown as TFile;
+	await vault.modify(file, body, { mtime: Date.parse(at), ctime: file.stat.ctime });
+}
+
+const modifiedAt = (vault: MemoryVault, path: string) =>
+	(vault.getAbstractFileByPath(path) as unknown as TFile).stat.mtime;
+
+test('the importer offers all three ways of meeting a note it already wrote', () => {
+	const subject = new ImportingTwice(memoryApp(new MemoryVault()), { sourceEl: null, optionsEl: null } as never);
+
+	assert.deepEqual(subject.duplicateModes, [
+		DuplicateHandling.CreateCopy,
+		DuplicateHandling.Skip,
+		DuplicateHandling.Update,
+	]);
+});
+
+test('"Update" leaves a page Notion has not changed since the import', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.Update);
+	const before = vault.contents.get(ROADMAP);
+
+	const { ctx } = await importOnce(vault, DuplicateHandling.Update);
+
+	assert.equal(vault.contents.get(ROADMAP), before);
+	assert.equal(ctx.skipped.length, 2);
+	assert.deepEqual(fetched, [], 'and it is known to be unchanged without reading a word of it');
+});
+
+// The body the user replaced comes back, in the note they replaced it in,
+// because Notion changed the page after they did.
+test('"Update" writes over a page Notion has changed, in place', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.Update);
+	await editInObsidian(vault, ROADMAP, 'Something else entirely.\n', '2024-04-01T00:00:00.000Z');
+
+	const { ctx } = await importOnce(vault, DuplicateHandling.Update, { editedAt: LATER });
+
+	assert.deepEqual(markdown(vault), ['Notion/Roadmap/Milestones.md', ROADMAP], 'no second copy');
+	assert.match(String(vault.contents.get(ROADMAP)), /What we are building this year\./);
+	assert.ok(!ctx.skipped.includes('Roadmap'), 'the note was written, not passed over');
+	assert.equal(modifiedAt(vault, ROADMAP), Date.parse(LATER), 'stamped with when Notion changed it');
+});
+
+test('"Update" does not write over work done in Obsidian since the import', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.Update);
+	const mine = `---\n${NOTION_ID_PROPERTY}: ${ROOT_PAGE}\n---\nMy own notes.\n`;
+	await editInObsidian(vault, ROADMAP, mine, '2024-12-01T00:00:00.000Z');
+
+	await importOnce(vault, DuplicateHandling.Update, { editedAt: LATER });
+
+	assert.equal(vault.contents.get(ROADMAP), mine, 'the note is the user\'s now');
+});
+
+// The three ways of leaving a note alone are not the same. Two of them let the
+// passes after the import repair links an interrupted run left unresolved; the
+// third is a note the user owns, which nothing here may write to.
+test('a note left alone can still have its unresolved links repaired', async () => {
+	for (const mode of [DuplicateHandling.Skip, DuplicateHandling.Update]) {
+		const vault = await vaultWithOneImport(mode);
+		await editInObsidian(vault, ROADMAP,
+			`---\n${NOTION_ID_PROPERTY}: ${ROOT_PAGE}\n---\n[[NOTION_PAGE:${CHILD_PAGE}]]\n`,
+			NOTION_EDITED);
+
+		const { subject } = await importOnce(vault, mode);
+
+		assert.equal(subject.queuedForRewriting(ROADMAP), true, mode);
+	}
+});
+
+test('but a note the user has edited is not queued for rewriting at all', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.Update);
+	await editInObsidian(vault, ROADMAP,
+		`---\n${NOTION_ID_PROPERTY}: ${ROOT_PAGE}\n---\n[[NOTION_PAGE:${CHILD_PAGE}]] and my own notes.\n`,
+		'2024-12-01T00:00:00.000Z');
+
+	const { subject } = await importOnce(vault, DuplicateHandling.Update, { editedAt: LATER });
+
+	assert.equal(subject.queuedForRewriting(ROADMAP), false);
+});
+
 test('a page with children keeps them in the folder holding its note', async () => {
 	const vault = await vaultWithOneImport(DuplicateHandling.Skip);
 
@@ -250,7 +353,7 @@ test('a note the user moved is still recognised, because the id travels with it'
 	await vault.create(moved, String(vault.contents.get('Notion/Roadmap/Roadmap.md')));
 	vault.remove('Notion/Roadmap/Roadmap.md');
 
-	const second = await importOnce(vault, DuplicateHandling.Skip);
+	const { ctx: second } = await importOnce(vault, DuplicateHandling.Skip);
 
 	assert.ok(markdown(vault).includes(moved), 'the moved note should still be there');
 	assert.ok(

--- a/tests/notion-api/reimport.test.ts
+++ b/tests/notion-api/reimport.test.ts
@@ -25,6 +25,7 @@ import { childFolderOf, NotionAPIImporter } from '../../src/formats/notion-api';
 import { DuplicateHandling, PlannedNote } from '../../src/format-importer';
 import { ImportContext } from '../../src/import-context';
 import { NOTION_ID_PROPERTY } from '../../src/constants';
+import { answerRequests } from '../shims/obsidian';
 import { MemoryVault, memoryApp } from '../shims/vault';
 
 interface Workspace {
@@ -83,6 +84,15 @@ class ImportingTwice extends NotionAPIImporter {
 	}
 }
 
+/** Every URL the import asked for, so a second one can be shown not to ask. */
+const fetched: string[] = [];
+
+answerRequests(request => {
+	fetched.push(request.url);
+
+	return { status: 200, arrayBuffer: new Uint8Array([137, 80, 78, 71]).buffer, text: '', headers: {} } as never;
+});
+
 /** One import of the whole fixture, over a vault that may already hold one. */
 async function importOnce(vault: MemoryVault, mode: DuplicateHandling, saveSourceId = true): Promise<ImportContext> {
 	const subject = new ImportingTwice(memoryApp(vault), { sourceEl: null, optionsEl: null } as never);
@@ -111,6 +121,8 @@ async function vaultWithOneImport(mode: DuplicateHandling): Promise<MemoryVault>
 	const vault = new MemoryVault();
 	await vault.createFolder(OUTPUT);
 	await importOnce(vault, mode);
+	fetched.length = 0;
+
 	return vault;
 }
 
@@ -162,6 +174,43 @@ test('importing again with "Create a copy" gives the copy its own children', asy
 	]);
 });
 
+test('the first import fetches what the page points at', async () => {
+	const vault = new MemoryVault();
+	await vault.createFolder(OUTPUT);
+	fetched.length = 0;
+
+	await importOnce(vault, DuplicateHandling.Skip);
+
+	// Twice: how big it is, then the bytes. The shim answers a range request
+	// with a whole response, which is what turns the probing off after one go.
+	assert.deepEqual([...new Set(fetched)], ['https://example.invalid/roadmap-chart.png']);
+	assert.equal(fetched.length, 2);
+	assert.ok(vault.paths().some(path => path.endsWith('roadmap-chart.png')));
+});
+
+// The page is still walked - a child of it may have changed - but nothing the
+// walk turns up is downloaded, because the markdown around it is thrown away.
+test('a second import fetches nothing for a page it is leaving alone', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.Skip);
+
+	await importOnce(vault, DuplicateHandling.Skip);
+
+	assert.deepEqual(fetched, []);
+});
+
+test('and the walk still reaches a child that is no longer there', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.Skip);
+	vault.remove('Notion/Roadmap/Milestones.md');
+
+	await importOnce(vault, DuplicateHandling.Skip);
+
+	assert.ok(
+		markdown(vault).includes('Notion/Roadmap/Milestones.md'),
+		'the parent was skipped, but its child was reached through it'
+	);
+	assert.deepEqual(fetched, [], 'and the parent still fetched nothing of its own');
+});
+
 test('a page with children keeps them in the folder holding its note', async () => {
 	const vault = await vaultWithOneImport(DuplicateHandling.Skip);
 
@@ -186,8 +235,8 @@ test('a moved page is where its children are put', async () => {
 	const vault = await vaultWithOneImport(DuplicateHandling.Skip);
 	await vault.createFolder('Archive');
 	await vault.create('Archive/Roadmap.md', String(vault.contents.get('Notion/Roadmap/Roadmap.md')));
-	vault.contents.delete('Notion/Roadmap/Roadmap.md');
-	vault.contents.delete('Notion/Roadmap/Milestones.md');
+	vault.remove('Notion/Roadmap/Roadmap.md');
+	vault.remove('Notion/Roadmap/Milestones.md');
 
 	await importOnce(vault, DuplicateHandling.Skip);
 
@@ -199,7 +248,7 @@ test('a note the user moved is still recognised, because the id travels with it'
 	const moved = 'Archive/Roadmap.md';
 	await vault.createFolder('Archive');
 	await vault.create(moved, String(vault.contents.get('Notion/Roadmap/Roadmap.md')));
-	vault.contents.delete('Notion/Roadmap/Roadmap.md');
+	vault.remove('Notion/Roadmap/Roadmap.md');
 
 	const second = await importOnce(vault, DuplicateHandling.Skip);
 

--- a/tests/notion-api/reimport.test.ts
+++ b/tests/notion-api/reimport.test.ts
@@ -1,0 +1,156 @@
+/**
+ * What a second Notion API import does to a vault the first one already filled.
+ *
+ * The importer reads a workspace over the API, so the fixture is a saved set of
+ * responses: the page envelope GET /v1/pages/{id} returns, and the children of
+ * every block that has them. The client here answers out of that rather than
+ * over the network, which is what lets the same workspace be imported twice.
+ *
+ * This is the baseline the shared duplicate-handling work is measured against:
+ * it records what Skip and "Create a copy" do today, before either importer
+ * moves onto the shared resolve/write primitives. A refactor that changes what
+ * is recorded here has changed behaviour.
+ */
+import '../shims/dom';
+import '../shims/runtime';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import * as nodeFs from 'node:fs';
+import * as nodePath from 'node:path';
+
+import { NotionAPIImporter } from '../../src/formats/notion-api';
+import { DuplicateHandling } from '../../src/format-importer';
+import { ImportContext } from '../../src/import-context';
+import { NOTION_ID_PROPERTY } from '../../src/constants';
+import { MemoryVault, memoryApp } from '../shims/vault';
+
+interface Workspace {
+	pages: Record<string, unknown>;
+	blocks: Record<string, { results: unknown[], has_more: boolean, next_cursor: string | null }>;
+}
+
+const workspace = JSON.parse(
+	nodeFs.readFileSync(nodePath.join(__dirname, 'reimport-workspace.json'), 'utf8')
+) as Workspace;
+
+const ROOT_PAGE = '10000000-0000-4000-8000-000000000101';
+const CHILD_PAGE = '10000000-0000-4000-8000-000000000102';
+const OUTPUT = 'Notion';
+
+const EMPTY = { object: 'list', results: [], has_more: false, next_cursor: null };
+
+/** The seam the harness needs: a stubbed client, and one page to start from. */
+class ImportingTwice extends NotionAPIImporter {
+	answerFromFixture(): void {
+		this.notionClient = {
+			pages: {
+				retrieve: async ({ page_id }: { page_id: string }) => {
+					const page = workspace.pages[page_id];
+					if (!page) throw new Error(`no page ${page_id} in the fixture`);
+					return page;
+				},
+			},
+			blocks: {
+				children: {
+					list: async ({ block_id }: { block_id: string }) => workspace.blocks[block_id] ?? EMPTY,
+				},
+				retrieve: async ({ block_id }: { block_id: string }) => {
+					for (const { results } of Object.values(workspace.blocks)) {
+						const block = (results as { id: string }[]).find(candidate => candidate.id === block_id);
+						if (block) return block;
+					}
+					throw new Error(`no block ${block_id} in the fixture`);
+				},
+			},
+		} as never;
+	}
+
+	importPage(ctx: ImportContext, pageId: string): Promise<void> {
+		return this.fetchAndImportPage({ ctx, pageId, parentPath: OUTPUT });
+	}
+}
+
+/** One import of the whole fixture, over a vault that may already hold one. */
+async function importOnce(vault: MemoryVault, mode: DuplicateHandling, saveSourceId = true): Promise<ImportContext> {
+	const subject = new ImportingTwice(memoryApp(vault), { sourceEl: null, optionsEl: null } as never);
+	subject.duplicateHandling = mode;
+	subject.saveSourceId = saveSourceId;
+	subject.answerFromFixture();
+	subject.indexImportedNotes();
+
+	const ctx = new ImportContext();
+	await subject.importPage(ctx, ROOT_PAGE);
+	return ctx;
+}
+
+async function vaultWithOneImport(mode: DuplicateHandling): Promise<MemoryVault> {
+	const vault = new MemoryVault();
+	await vault.createFolder(OUTPUT);
+	await importOnce(vault, mode);
+	return vault;
+}
+
+const markdown = (vault: MemoryVault) => vault.paths().filter(path => path.endsWith('.md')).sort();
+
+test('a first import writes the page and its child', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.Skip);
+
+	assert.deepEqual(markdown(vault), [
+		'Notion/Roadmap/Milestones.md',
+		'Notion/Roadmap/Roadmap.md',
+	]);
+});
+
+test('every note it wrote carries the id the next import recognises it by', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.Skip);
+
+	for (const path of markdown(vault)) {
+		assert.match(String(vault.contents.get(path)), new RegExp(`${NOTION_ID_PROPERTY}: `), path);
+	}
+});
+
+test('importing again with "Skip" leaves the vault as it was', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.Skip);
+	const before = markdown(vault).map(path => [path, vault.contents.get(path)] as const);
+
+	const second = await importOnce(vault, DuplicateHandling.Skip);
+
+	assert.deepEqual(markdown(vault), before.map(([path]) => path), 'no note should have been added');
+	for (const [path, content] of before) {
+		assert.equal(vault.contents.get(path), content, `${path} should be untouched`);
+	}
+	assert.equal(second.skipped.length, 2, 'both notes should be reported as skipped');
+});
+
+// The page folder is reused whatever the mode, so the copies are numbered
+// inside it rather than landing in a second "Roadmap 1" folder.
+test('importing again with "Create a copy" numbers the notes inside the same folder', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.CreateCopy);
+
+	await importOnce(vault, DuplicateHandling.CreateCopy);
+
+	assert.deepEqual(markdown(vault), [
+		'Notion/Roadmap/Milestones 1.md',
+		'Notion/Roadmap/Milestones.md',
+		'Notion/Roadmap/Roadmap 1.md',
+		'Notion/Roadmap/Roadmap.md',
+	]);
+});
+
+test('a note the user moved is still recognised, because the id travels with it', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.Skip);
+	const moved = 'Archive/Roadmap.md';
+	await vault.createFolder('Archive');
+	await vault.create(moved, String(vault.contents.get('Notion/Roadmap/Roadmap.md')));
+	vault.contents.delete('Notion/Roadmap/Roadmap.md');
+
+	const second = await importOnce(vault, DuplicateHandling.Skip);
+
+	assert.ok(markdown(vault).includes(moved), 'the moved note should still be there');
+	assert.ok(
+		!markdown(vault).includes('Notion/Roadmap/Roadmap.md'),
+		'a note it already has should not be written again at the old path'
+	);
+	assert.equal(second.skipped.length, 2);
+});

--- a/tests/notion-api/reimport.test.ts
+++ b/tests/notion-api/reimport.test.ts
@@ -5,11 +5,6 @@
  * responses: the page envelope GET /v1/pages/{id} returns, and the children of
  * every block that has them. The client here answers out of that rather than
  * over the network, which is what lets the same workspace be imported twice.
- *
- * This is the baseline the shared duplicate-handling work is measured against:
- * it records what Skip and "Create a copy" do today, before either importer
- * moves onto the shared resolve/write primitives. A refactor that changes what
- * is recorded here has changed behaviour.
  */
 import '../shims/dom';
 import '../shims/runtime';
@@ -122,10 +117,9 @@ async function importOnce(
 	const before = new Set(vault.paths());
 	await subject.importPage(ctx, ROOT_PAGE);
 
-	// The conversion resolves attachments and links against the path the note
-	// was planned at, so a note that lands anywhere else leaves all of it
-	// pointing at a file that is not there. Choosing the path a second time
-	// after converting is exactly how that used to happen.
+	// The conversion resolves attachments and links against the planned path,
+	// so a note that lands anywhere else leaves all of it pointing at a file
+	// that is not there.
 	for (const path of vault.paths()) {
 		if (before.has(path) || !path.endsWith('.md')) continue;
 		assert.ok(subject.planned.includes(path), `${path} was written but never planned`);

--- a/tests/notion-api/reimport.test.ts
+++ b/tests/notion-api/reimport.test.ts
@@ -19,8 +19,10 @@ import assert from 'node:assert/strict';
 import * as nodeFs from 'node:fs';
 import * as nodePath from 'node:path';
 
-import { NotionAPIImporter } from '../../src/formats/notion-api';
-import { DuplicateHandling } from '../../src/format-importer';
+import type { TFolder } from 'obsidian';
+
+import { childFolderOf, NotionAPIImporter } from '../../src/formats/notion-api';
+import { DuplicateHandling, PlannedNote } from '../../src/format-importer';
 import { ImportContext } from '../../src/import-context';
 import { NOTION_ID_PROPERTY } from '../../src/constants';
 import { MemoryVault, memoryApp } from '../shims/vault';
@@ -42,6 +44,16 @@ const EMPTY = { object: 'list', results: [], has_more: false, next_cursor: null 
 
 /** The seam the harness needs: a stubbed client, and one page to start from. */
 class ImportingTwice extends NotionAPIImporter {
+	/** Every path this import settled on, before it wrote anything. */
+	readonly planned: string[] = [];
+
+	planNote(folder: TFolder | string, title: string, sourceId?: string): PlannedNote {
+		const note = super.planNote(folder, title, sourceId);
+		this.planned.push(note.targetPath);
+
+		return note;
+	}
+
 	answerFromFixture(): void {
 		this.notionClient = {
 			pages: {
@@ -80,7 +92,18 @@ async function importOnce(vault: MemoryVault, mode: DuplicateHandling, saveSourc
 	subject.indexImportedNotes();
 
 	const ctx = new ImportContext();
+	const before = new Set(vault.paths());
 	await subject.importPage(ctx, ROOT_PAGE);
+
+	// The conversion resolves attachments and links against the path the note
+	// was planned at, so a note that lands anywhere else leaves all of it
+	// pointing at a file that is not there. Choosing the path a second time
+	// after converting is exactly how that used to happen.
+	for (const path of vault.paths()) {
+		if (before.has(path) || !path.endsWith('.md')) continue;
+		assert.ok(subject.planned.includes(path), `${path} was written but never planned`);
+	}
+
 	return ctx;
 }
 
@@ -123,19 +146,52 @@ test('importing again with "Skip" leaves the vault as it was', async () => {
 	assert.equal(second.skipped.length, 2, 'both notes should be reported as skipped');
 });
 
-// The page folder is reused whatever the mode, so the copies are numbered
-// inside it rather than landing in a second "Roadmap 1" folder.
-test('importing again with "Create a copy" numbers the notes inside the same folder', async () => {
+// The copy is a page in its own right, so it keeps its children in a folder
+// of its own name. They used to be numbered alongside the first import's,
+// which left no way to tell which copy a child belonged to.
+test('importing again with "Create a copy" gives the copy its own children', async () => {
 	const vault = await vaultWithOneImport(DuplicateHandling.CreateCopy);
 
 	await importOnce(vault, DuplicateHandling.CreateCopy);
 
 	assert.deepEqual(markdown(vault), [
-		'Notion/Roadmap/Milestones 1.md',
 		'Notion/Roadmap/Milestones.md',
 		'Notion/Roadmap/Roadmap 1.md',
+		'Notion/Roadmap/Roadmap 1/Milestones.md',
 		'Notion/Roadmap/Roadmap.md',
 	]);
+});
+
+test('a page with children keeps them in the folder holding its note', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.Skip);
+
+	assert.equal(childFolderOf('Notion/Roadmap/Roadmap.md'), 'Notion/Roadmap');
+	assert.ok(markdown(vault).includes('Notion/Roadmap/Milestones.md'));
+});
+
+// The note was written when the page had nothing under it, so it is not in a
+// folder of its own. It stays where it is and the children arrive beside it.
+test('a page that has grown children leaves its note where it is', async () => {
+	assert.equal(childFolderOf('Notion/Roadmap.md'), 'Notion/Roadmap');
+});
+
+test('and a note the user moved takes its children with it', async () => {
+	assert.equal(childFolderOf('Archive/Roadmap.md'), 'Archive/Roadmap');
+});
+
+// The parent is recognised where the user put it and skipped, but its child
+// is gone and imported again - into the folder belonging to the note that
+// actually exists, not the one this import would have made.
+test('a moved page is where its children are put', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.Skip);
+	await vault.createFolder('Archive');
+	await vault.create('Archive/Roadmap.md', String(vault.contents.get('Notion/Roadmap/Roadmap.md')));
+	vault.contents.delete('Notion/Roadmap/Roadmap.md');
+	vault.contents.delete('Notion/Roadmap/Milestones.md');
+
+	await importOnce(vault, DuplicateHandling.Skip);
+
+	assert.deepEqual(markdown(vault), ['Archive/Roadmap.md', 'Archive/Roadmap/Milestones.md']);
 });
 
 test('a note the user moved is still recognised, because the id travels with it', async () => {

--- a/tests/notion-api/resume.test.ts
+++ b/tests/notion-api/resume.test.ts
@@ -8,14 +8,26 @@ import { NotionAPIImporter } from '../../src/formats/notion-api';
 import { DuplicateHandling } from '../../src/format-importer';
 import { ImportContext } from '../../src/import-context';
 import { NOTION_ID_PROPERTY } from '../../src/constants';
+import { parseFilePath } from '../../src/filesystem';
 import { MemoryVault, memoryApp } from '../shims/vault';
 
 const PAGE_ID = 'abc-123';
 const PAGE_PATH = 'Notion/Roadmap.md';
 
 class ResumingImporter extends NotionAPIImporter {
-	skips(filePath: string, notionId: string, ctx: ImportContext) {
-		return this.shouldSkipExistingFile(filePath, notionId, ctx);
+	/** A page this run wrote before it was interrupted. */
+	recovers(filePath: string, notionId: string, ctx: ImportContext) {
+		return this.alreadyWrittenByAnUnfinishedImport(filePath, notionId, ctx);
+	}
+
+	/** What the importer does with a page it is leaving as it stands. */
+	async skips(filePath: string, notionId: string, ctx: ImportContext): Promise<boolean> {
+		const { parent, basename } = parseFilePath(filePath);
+		const planned = this.planNote(parent, basename, notionId);
+		if (this.preflightNote(ctx, planned) !== 'skip' || !planned.file) return false;
+
+		await this.adoptSkippedNote(planned.file, notionId);
+		return true;
 	}
 
 	cleanUp(ctx: ImportContext) {
@@ -52,14 +64,14 @@ async function importing(mode: DuplicateHandling, saveSourceId: boolean) {
 test('a page an unfinished import wrote is not written twice', async () => {
 	const { subject, ctx } = await importing(DuplicateHandling.CreateCopy, false);
 
-	assert.equal(await subject.skips(PAGE_PATH, PAGE_ID, ctx), true);
+	assert.equal(await subject.recovers(PAGE_PATH, PAGE_ID, ctx), true);
 	assert.equal(ctx.skipped.length, 1);
 });
 
 test('and its id is cleared, so the next import stops recognising it', async () => {
 	const { vault, subject, ctx } = await importing(DuplicateHandling.CreateCopy, false);
 
-	await subject.skips(PAGE_PATH, PAGE_ID, ctx);
+	await subject.recovers(PAGE_PATH, PAGE_ID, ctx);
 	await subject.cleanUp(ctx);
 
 	assert.doesNotMatch(String(vault.contents.get(PAGE_PATH)), new RegExp(NOTION_ID_PROPERTY));
@@ -78,14 +90,14 @@ test('a page the user asked to skip keeps its id', async () => {
 test('with ids kept, "Create a copy" copies rather than recognising anything', async () => {
 	const { subject, ctx } = await importing(DuplicateHandling.CreateCopy, true);
 
-	assert.equal(await subject.skips(PAGE_PATH, PAGE_ID, ctx), false);
+	assert.equal(await subject.recovers(PAGE_PATH, PAGE_ID, ctx), false);
 	assert.deepEqual(ctx.skipped, []);
 });
 
 test('a page carrying a different id is not one of ours', async () => {
 	const { subject, ctx } = await importing(DuplicateHandling.CreateCopy, false);
 
-	assert.equal(await subject.skips(PAGE_PATH, 'def-456', ctx), false);
+	assert.equal(await subject.recovers(PAGE_PATH, 'def-456', ctx), false);
 });
 
 test('a page that fails before its title loads keeps its full Notion id', async () => {

--- a/tests/notion-api/resume.test.ts
+++ b/tests/notion-api/resume.test.ts
@@ -21,6 +21,20 @@ class ResumingImporter extends NotionAPIImporter {
 	cleanUp(ctx: ImportContext) {
 		return this.cleanupNotionIds(ctx);
 	}
+
+	useUnreadableClient(): void {
+		this.notionClient = {
+			pages: {
+				retrieve: async () => {
+					throw Object.assign(new Error('Page could not be read'), { status: 404 });
+				},
+			},
+		} as never;
+	}
+
+	importPage(ctx: ImportContext, pageId: string) {
+		return this.fetchAndImportPage({ ctx, pageId, parentPath: 'Notion' });
+	}
 }
 
 async function importing(mode: DuplicateHandling, saveSourceId: boolean) {
@@ -79,17 +93,8 @@ test('a page that fails before its title loads keeps its full Notion id', async 
 	const subject = new ResumingImporter(memoryApp(vault), { sourceEl: null, optionsEl: null } as never);
 	const ctx = new ImportContext();
 
-	(subject as unknown as { notionClient: unknown }).notionClient = {
-		pages: {
-			retrieve: async () => {
-				throw Object.assign(new Error('Page could not be read'), { status: 404 });
-			},
-		},
-	};
-
-	await (subject as unknown as {
-		fetchAndImportPage(params: { ctx: ImportContext, pageId: string, parentPath: string }): Promise<void>;
-	}).fetchAndImportPage({ ctx, pageId: PAGE_ID, parentPath: 'Notion' });
+	subject.useUnreadableClient();
+	await subject.importPage(ctx, PAGE_ID);
 
 	assert.deepEqual(ctx.failed, [`Page ${PAGE_ID}`]);
 });

--- a/tests/notion-api/synced-blocks.test.ts
+++ b/tests/notion-api/synced-blocks.test.ts
@@ -1,0 +1,158 @@
+/**
+ * The note a synced block keeps, across more than one import.
+ *
+ * A synced block is content Notion shows in several places at once, so the
+ * importer gives it a note of its own and embeds that note wherever the block
+ * appears. It used to ask for a name nothing was using, which meant every
+ * import wrote another one: "Handbook synced block 1.md", then
+ * "Handbook synced block 2.md", and so on for as long as the user kept
+ * importing.
+ *
+ * The note carries the block's id now, so a later import finds the one it
+ * wrote before.
+ */
+import '../shims/dom';
+import '../shims/runtime';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import * as nodeFs from 'node:fs';
+import * as nodePath from 'node:path';
+
+import { NotionAPIImporter } from '../../src/formats/notion-api';
+import { DuplicateHandling } from '../../src/format-importer';
+import { ImportContext } from '../../src/import-context';
+import { NOTION_ID_PROPERTY } from '../../src/constants';
+import { MemoryVault, memoryApp } from '../shims/vault';
+
+interface Workspace {
+	pages: Record<string, unknown>;
+	blocks: Record<string, { results: unknown[], has_more: boolean, next_cursor: string | null }>;
+}
+
+const workspace = JSON.parse(
+	nodeFs.readFileSync(nodePath.join(__dirname, 'synced-workspace.json'), 'utf8')
+) as Workspace;
+
+const PAGE = '10000000-0000-4000-8000-000000000201';
+const FIRST_BLOCK = '30000000-0000-4000-8000-000000000201';
+const EMPTY = { object: 'list', results: [], has_more: false, next_cursor: null };
+
+class ImportingSyncedBlocks extends NotionAPIImporter {
+	answerFromFixture(): void {
+		this.notionClient = {
+			pages: {
+				retrieve: async ({ page_id }: { page_id: string }) => workspace.pages[page_id],
+			},
+			blocks: {
+				children: {
+					list: async ({ block_id }: { block_id: string }) => workspace.blocks[block_id] ?? EMPTY,
+				},
+				retrieve: async ({ block_id }: { block_id: string }) => {
+					for (const { results } of Object.values(workspace.blocks)) {
+						const block = (results as { id: string }[]).find(candidate => candidate.id === block_id);
+						if (block) return block;
+					}
+					throw new Error(`no block ${block_id} in the fixture`);
+				},
+			},
+		} as never;
+	}
+
+	importPage(ctx: ImportContext): Promise<void> {
+		return this.fetchAndImportPage({ ctx, pageId: PAGE, parentPath: 'Notion' });
+	}
+
+	cleanUp(ctx: ImportContext): Promise<void> {
+		return this.cleanupNotionIds(ctx);
+	}
+}
+
+async function importOnce(vault: MemoryVault, mode: DuplicateHandling, saveSourceId = true) {
+	const subject = new ImportingSyncedBlocks(memoryApp(vault), { sourceEl: null, optionsEl: null } as never);
+	subject.duplicateHandling = mode;
+	subject.saveSourceId = saveSourceId;
+	subject.answerFromFixture();
+	subject.indexImportedNotes();
+
+	const ctx = new ImportContext();
+	await subject.importPage(ctx);
+
+	return { ctx, subject };
+}
+
+async function vaultWithOneImport(mode: DuplicateHandling, saveSourceId = true): Promise<MemoryVault> {
+	const vault = new MemoryVault();
+	await vault.createFolder('Notion');
+	await importOnce(vault, mode, saveSourceId);
+
+	return vault;
+}
+
+const markdown = (vault: MemoryVault) => vault.paths().filter(path => path.endsWith('.md')).sort();
+
+// The page has a child page, so it is a folder, and its synced blocks go in
+// there beside its note. That it has children is what keeps the page being
+// converted on a later import even when its note is left alone - which is
+// exactly when another synced block note used to appear.
+const SYNCED = [
+	'Notion/Handbook/Handbook synced block 1.md',
+	'Notion/Handbook/Handbook synced block.md',
+];
+const PAGE_NOTE = 'Notion/Handbook/Handbook.md';
+const CHILD_NOTE = 'Notion/Handbook/Chapter one.md';
+
+test('each synced block on a page gets a note of its own', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.Skip);
+
+	assert.deepEqual(markdown(vault), [CHILD_NOTE, ...SYNCED, PAGE_NOTE]);
+});
+
+test('and carries the id of the block it holds', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.Skip);
+
+	assert.match(String(vault.contents.get(SYNCED[1])), new RegExp(`${NOTION_ID_PROPERTY}: ${FIRST_BLOCK}`));
+});
+
+test('a second import leaves them alone rather than writing more', async () => {
+	for (const mode of [DuplicateHandling.Skip, DuplicateHandling.Update]) {
+		const vault = await vaultWithOneImport(mode);
+
+		await importOnce(vault, mode);
+
+		assert.deepEqual(markdown(vault), [CHILD_NOTE, ...SYNCED, PAGE_NOTE], mode);
+	}
+});
+
+// The two of them share a generated name, so the second is "… 1.md". Which
+// one that is has to hold from one import to the next, or they swap contents.
+test('and the two of them keep the notes they had', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.Update);
+	const before = SYNCED.map(path => vault.contents.get(path));
+
+	await importOnce(vault, DuplicateHandling.Update);
+
+	assert.deepEqual(SYNCED.map(path => vault.contents.get(path)), before);
+});
+
+test('a third import adds nothing either', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.Skip);
+
+	await importOnce(vault, DuplicateHandling.Skip);
+	await importOnce(vault, DuplicateHandling.Skip);
+
+	assert.deepEqual(markdown(vault), [CHILD_NOTE, ...SYNCED, PAGE_NOTE]);
+});
+
+// With the id turned off there is nothing to recognise them by, so a second
+// import writes its own. Worth knowing rather than worth pretending otherwise.
+test('with "Save source ID" off, the id is cleared once the import is done', async () => {
+	const vault = new MemoryVault();
+	await vault.createFolder('Notion');
+	const { ctx, subject } = await importOnce(vault, DuplicateHandling.Skip, false);
+	await subject.cleanUp(ctx);
+
+	for (const path of SYNCED) {
+		assert.doesNotMatch(String(vault.contents.get(path)), new RegExp(NOTION_ID_PROPERTY), path);
+	}
+});

--- a/tests/notion-api/synced-blocks.test.ts
+++ b/tests/notion-api/synced-blocks.test.ts
@@ -43,6 +43,7 @@ const FIRST_BLOCK = '30000000-0000-4000-8000-000000000201';
 const CHAPTER_ONE = '10000000-0000-4000-8000-000000000202';
 const EMPTY = { object: 'list', results: [], has_more: false, next_cursor: null };
 const DIAGRAM = 'handbook-diagram.png';
+const QUESTIONS_DB = '60000000-0000-4000-8000-000000000201';
 
 /** Every URL an import asked for, so it can be shown to ask or not to ask. */
 const fetched: string[] = [];
@@ -85,9 +86,24 @@ class ImportingSyncedBlocks extends NotionAPIImporter {
 		return this.cleanupNotionIds(ctx);
 	}
 
-	/** The pass that resolves what a synced block holds, run as import() runs it. */
-	finishSyncedBlocks(ctx: ImportContext): Promise<void> {
-		return this.replaceSyncedChildPlaceholders(ctx);
+	/** Every database this import asked for as a database. */
+	readonly databasesAsked: string[] = [];
+
+	protected importTopLevelDatabase(ctx: ImportContext, databaseId: string, parentPath: string): Promise<void> {
+		this.databasesAsked.push(databaseId);
+
+		return super.importTopLevelDatabase(ctx, databaseId, parentPath);
+	}
+
+	/** What import() does after the pages, in the order it does it. */
+	async finishSyncedBlocks(ctx: ImportContext): Promise<void> {
+		await this.reachSyncedChildren(ctx);
+		await this.replaceSyncedChildPlaceholders(ctx);
+	}
+
+	/** Only the half that fetches, so the placeholder pass cannot stand in. */
+	reachOnly(ctx: ImportContext): Promise<void> {
+		return this.reachSyncedChildren(ctx);
 	}
 }
 
@@ -147,6 +163,31 @@ test('a synced note being rewritten fetches what it points at, skipped page or n
 	assert.ok(vault.paths().includes(DIAGRAM), 'and what it embeds is there to embed');
 	// Twice: how big it is, then the bytes, as any first fetch of a file is.
 	assert.deepEqual([...new Set(fetched)], ['https://example.invalid/handbook-diagram.png']);
+});
+
+// A database under a synced block is not a page, and asking for it as one
+// cannot be recovered from: fetchAndImportPage reports its own failures rather
+// than raising them, so nothing would ever fall through to the database.
+//
+// The note has to be one this import leaves alone, because that is when what
+// is under it is fetched separately from what its own file says. Only the
+// fetching half runs here: the placeholder pass imports databases too, and
+// would otherwise answer for a dispatch that never happened.
+test('a database under a synced block is asked for as a database', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.Skip);
+
+	const subject = new ImportingSyncedBlocks(memoryApp(vault), { sourceEl: null, optionsEl: null } as never);
+	subject.duplicateHandling = DuplicateHandling.Skip;
+	subject.answerFromFixture();
+	subject.indexImportedNotes();
+
+	const ctx = new ImportContext();
+	await subject.importPage(ctx);
+	await subject.reachOnly(ctx);
+
+	assert.deepEqual(subject.databasesAsked, [QUESTIONS_DB]);
+	assert.deepEqual(ctx.failed.filter(name => name.includes(QUESTIONS_DB)), [],
+		'and is not reported as a page that could not be read');
 });
 
 test('each synced block on a page gets a note of its own', async () => {
@@ -209,6 +250,22 @@ test('with "Save source ID" off, the id is written and then cleared', async () =
 		assert.doesNotMatch(String(vault.contents.get(path)), new RegExp(NOTION_ID_PROPERTY), `${path} after`);
 		assert.match(String(vault.contents.get(path)), /How we work\.|Who to ask\./, `${path} kept its content`);
 	}
+});
+
+// The ids are what a later import recognises these notes by, and with "Save
+// source ID" off they are taken out at the end of every run. What is left is
+// two notes of near-identical names and nothing to tell them apart.
+test('with "Save source ID" off, a second import still writes no more notes', async () => {
+	const vault = new MemoryVault();
+	await vault.createFolder('Notion');
+	const first = await importOnce(vault, DuplicateHandling.Skip, false);
+	await first.subject.cleanUp(first.ctx);
+	const before = markdown(vault);
+
+	const second = await importOnce(vault, DuplicateHandling.Skip, false);
+	await second.subject.cleanUp(second.ctx);
+
+	assert.deepEqual(markdown(vault), before);
 });
 
 // "Create a copy" turns off the index of ids, so the only way to know a note

--- a/tests/notion-api/synced-blocks.test.ts
+++ b/tests/notion-api/synced-blocks.test.ts
@@ -26,6 +26,7 @@ import { NOTION_ID_PROPERTY } from '../../src/constants';
 import { createPlaceholder, PlaceholderType } from '../../src/formats/notion-api/utils';
 import type { TFile } from 'obsidian';
 
+import { answerRequests } from '../shims/obsidian';
 import { MemoryVault, memoryApp } from '../shims/vault';
 
 interface Workspace {
@@ -41,6 +42,16 @@ const PAGE = '10000000-0000-4000-8000-000000000201';
 const FIRST_BLOCK = '30000000-0000-4000-8000-000000000201';
 const CHAPTER_ONE = '10000000-0000-4000-8000-000000000202';
 const EMPTY = { object: 'list', results: [], has_more: false, next_cursor: null };
+const DIAGRAM = 'handbook-diagram.png';
+
+/** Every URL an import asked for, so it can be shown to ask or not to ask. */
+const fetched: string[] = [];
+
+answerRequests(request => {
+	fetched.push(request.url);
+
+	return { status: 200, arrayBuffer: new Uint8Array([137, 80, 78, 71]).buffer, text: '', headers: {} } as never;
+});
 
 class ImportingSyncedBlocks extends NotionAPIImporter {
 	answerFromFixture(editedAt?: string): void {
@@ -118,6 +129,25 @@ const CHILD_NOTE = 'Notion/Handbook/Chapter one.md';
 // and fetched afterwards, into the import's root folder.
 const NESTED = 'Nested in a synced block.md';
 const EVERYTHING = [NESTED, CHILD_NOTE, ...SYNCED, PAGE_NOTE];
+
+// A synced block whose note has to be written needs what that note points at,
+// and whether the page around it is being left alone has no bearing on that.
+test('a synced note being rewritten fetches what it points at, skipped page or not', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.Skip);
+	assert.ok(vault.paths().includes(DIAGRAM), 'the first import fetched it');
+
+	// The user deleted the note and its image; the page itself has not changed.
+	vault.remove(SYNCED[0]);
+	vault.remove(DIAGRAM);
+	fetched.length = 0;
+
+	await importOnce(vault, DuplicateHandling.Skip);
+
+	assert.ok(markdown(vault).includes(SYNCED[0]), 'the note is written again');
+	assert.ok(vault.paths().includes(DIAGRAM), 'and what it embeds is there to embed');
+	// Twice: how big it is, then the bytes, as any first fetch of a file is.
+	assert.deepEqual([...new Set(fetched)], ['https://example.invalid/handbook-diagram.png']);
+});
 
 test('each synced block on a page gets a note of its own', async () => {
 	const vault = await vaultWithOneImport(DuplicateHandling.Skip);

--- a/tests/notion-api/synced-blocks.test.ts
+++ b/tests/notion-api/synced-blocks.test.ts
@@ -3,13 +3,10 @@
  *
  * A synced block is content Notion shows in several places at once, so the
  * importer gives it a note of its own and embeds that note wherever the block
- * appears. It used to ask for a name nothing was using, which meant every
- * import wrote another one: "Handbook synced block 1.md", then
- * "Handbook synced block 2.md", and so on for as long as the user kept
- * importing.
- *
- * The note carries the block's id now, so a later import finds the one it
- * wrote before.
+ * appears. It used to ask for a name nothing was using, so every import wrote
+ * another one: "Handbook synced block 1.md", then "Handbook synced block 2.md",
+ * for as long as the user kept importing. The note carries the block's id now,
+ * so a later import finds the one it wrote before.
  */
 import '../shims/dom';
 import '../shims/runtime';
@@ -131,10 +128,10 @@ async function vaultWithOneImport(mode: DuplicateHandling, saveSourceId = true):
 
 const markdown = (vault: MemoryVault) => vault.paths().filter(path => path.endsWith('.md')).sort();
 
-// The page has a child page, so it is a folder, and its synced blocks go in
-// there beside its note. That it has children is what keeps the page being
-// converted on a later import even when its note is left alone - which is
-// exactly when another synced block note used to appear.
+// The page has a child page, so it is a folder and its synced blocks go in
+// there beside its note. Having children is also what keeps it being converted
+// on a later import even when its note is left alone - which is exactly when
+// another synced block note used to appear.
 const SYNCED = [
 	'Notion/Handbook/Handbook synced block 1.md',
 	'Notion/Handbook/Handbook synced block.md',
@@ -165,14 +162,10 @@ test('a synced note being rewritten fetches what it points at, skipped page or n
 	assert.deepEqual([...new Set(fetched)], ['https://example.invalid/handbook-diagram.png']);
 });
 
-// A database under a synced block is not a page, and asking for it as one
-// cannot be recovered from: fetchAndImportPage reports its own failures rather
-// than raising them, so nothing would ever fall through to the database.
-//
-// The note has to be one this import leaves alone, because that is when what
-// is under it is fetched separately from what its own file says. Only the
-// fetching half runs here: the placeholder pass imports databases too, and
-// would otherwise answer for a dispatch that never happened.
+// Asking for it as a page cannot be recovered from: fetchAndImportPage reports
+// its own failures rather than raising them, so nothing would fall through to
+// the database. Only the fetching half runs here, because the placeholder pass
+// imports databases too and would answer for a dispatch that never happened.
 test('a database under a synced block is asked for as a database', async () => {
 	const vault = await vaultWithOneImport(DuplicateHandling.Skip);
 

--- a/tests/notion-api/synced-blocks.test.ts
+++ b/tests/notion-api/synced-blocks.test.ts
@@ -23,6 +23,7 @@ import { NotionAPIImporter } from '../../src/formats/notion-api';
 import { DuplicateHandling } from '../../src/format-importer';
 import { ImportContext } from '../../src/import-context';
 import { NOTION_ID_PROPERTY } from '../../src/constants';
+import { createPlaceholder, PlaceholderType } from '../../src/formats/notion-api/utils';
 import type { TFile } from 'obsidian';
 
 import { MemoryVault, memoryApp } from '../shims/vault';
@@ -38,6 +39,7 @@ const workspace = JSON.parse(
 
 const PAGE = '10000000-0000-4000-8000-000000000201';
 const FIRST_BLOCK = '30000000-0000-4000-8000-000000000201';
+const CHAPTER_ONE = '10000000-0000-4000-8000-000000000202';
 const EMPTY = { object: 'list', results: [], has_more: false, next_cursor: null };
 
 class ImportingSyncedBlocks extends NotionAPIImporter {
@@ -71,6 +73,11 @@ class ImportingSyncedBlocks extends NotionAPIImporter {
 	cleanUp(ctx: ImportContext): Promise<void> {
 		return this.cleanupNotionIds(ctx);
 	}
+
+	/** The pass that resolves what a synced block holds, run as import() runs it. */
+	finishSyncedBlocks(ctx: ImportContext): Promise<void> {
+		return this.replaceSyncedChildPlaceholders(ctx);
+	}
 }
 
 async function importOnce(vault: MemoryVault, mode: DuplicateHandling, saveSourceId = true, editedAt?: string) {
@@ -82,6 +89,7 @@ async function importOnce(vault: MemoryVault, mode: DuplicateHandling, saveSourc
 
 	const ctx = new ImportContext();
 	await subject.importPage(ctx);
+	await subject.finishSyncedBlocks(ctx);
 
 	return { ctx, subject };
 }
@@ -106,11 +114,15 @@ const SYNCED = [
 ];
 const PAGE_NOTE = 'Notion/Handbook/Handbook.md';
 const CHILD_NOTE = 'Notion/Handbook/Chapter one.md';
+// A page inside a synced block is not imported where it stands: it is noted
+// and fetched afterwards, into the import's root folder.
+const NESTED = 'Nested in a synced block.md';
+const EVERYTHING = [NESTED, CHILD_NOTE, ...SYNCED, PAGE_NOTE];
 
 test('each synced block on a page gets a note of its own', async () => {
 	const vault = await vaultWithOneImport(DuplicateHandling.Skip);
 
-	assert.deepEqual(markdown(vault), [CHILD_NOTE, ...SYNCED, PAGE_NOTE]);
+	assert.deepEqual(markdown(vault), EVERYTHING);
 });
 
 test('and carries the id of the block it holds', async () => {
@@ -125,7 +137,7 @@ test('a second import leaves them alone rather than writing more', async () => {
 
 		await importOnce(vault, mode);
 
-		assert.deepEqual(markdown(vault), [CHILD_NOTE, ...SYNCED, PAGE_NOTE], mode);
+		assert.deepEqual(markdown(vault), EVERYTHING, mode);
 	}
 });
 
@@ -146,7 +158,7 @@ test('a third import adds nothing either', async () => {
 	await importOnce(vault, DuplicateHandling.Skip);
 	await importOnce(vault, DuplicateHandling.Skip);
 
-	assert.deepEqual(markdown(vault), [CHILD_NOTE, ...SYNCED, PAGE_NOTE]);
+	assert.deepEqual(markdown(vault), EVERYTHING);
 });
 
 // The id goes in whether or not it is being kept, so that an import which is
@@ -167,6 +179,40 @@ test('with "Save source ID" off, the id is written and then cleared', async () =
 		assert.doesNotMatch(String(vault.contents.get(path)), new RegExp(NOTION_ID_PROPERTY), `${path} after`);
 		assert.match(String(vault.contents.get(path)), /How we work\.|Who to ask\./, `${path} kept its content`);
 	}
+});
+
+// "Create a copy" turns off the index of ids, so the only way to know a note
+// is one this run wrote is to read it. Without that, resuming a run that was
+// interrupted before its ids were cleared writes the whole lot again.
+test('resuming an interrupted "Create a copy" writes no second set', async () => {
+	const vault = new MemoryVault();
+	await vault.createFolder('Notion');
+	await importOnce(vault, DuplicateHandling.CreateCopy, false);
+	const before = markdown(vault);
+
+	// The run ended here, before cleanupNotionIds could take the ids out.
+	const { ctx, subject } = await importOnce(vault, DuplicateHandling.CreateCopy, false);
+
+	assert.deepEqual(markdown(vault), before);
+	await subject.cleanUp(ctx);
+
+	for (const path of SYNCED) {
+		assert.doesNotMatch(String(vault.contents.get(path)), new RegExp(NOTION_ID_PROPERTY), path);
+	}
+});
+
+test('and each note is recognised as the block it holds, not merely as taken', async () => {
+	const vault = new MemoryVault();
+	await vault.createFolder('Notion');
+	await importOnce(vault, DuplicateHandling.CreateCopy, false);
+
+	// Both blocks want the same name, so the second is under "… 1.md". A
+	// resumed run has to look past the first name to find it.
+	const second = String(vault.contents.get(SYNCED[0]));
+	await importOnce(vault, DuplicateHandling.CreateCopy, false);
+
+	assert.equal(vault.contents.get(SYNCED[0]), second);
+	assert.deepEqual(markdown(vault).filter(path => SYNCED.includes(path)), SYNCED);
 });
 
 const NOTION_EDITED = '2024-03-01T00:00:00.000Z';
@@ -201,7 +247,51 @@ test('"Update" writes over a synced block Notion has changed', async () => {
 	await importOnce(vault, DuplicateHandling.Update, true, LATER);
 
 	assert.match(String(vault.contents.get(SYNCED[1])), /How we work\./);
-	assert.deepEqual(markdown(vault), [CHILD_NOTE, ...SYNCED, PAGE_NOTE], 'and does not write a second one');
+	assert.deepEqual(markdown(vault), EVERYTHING, 'and does not write a second one');
+});
+
+// An earlier run may have stopped before it could turn a placeholder into a
+// link, and what it left behind is in the note rather than in what the source
+// converts to now. Repair has to read the note, or a placeholder for something
+// the source has since stopped mentioning stays in the file forever.
+test('a placeholder an interrupted run left behind is repaired from the note', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.Update);
+	const stale = createPlaceholder(PlaceholderType.SYNCED_CHILD_PAGE, CHAPTER_ONE);
+	await editInObsidian(vault, SYNCED[1],
+		`---\n${NOTION_ID_PROPERTY}: ${FIRST_BLOCK}\n---\nHow we work.\n\n${stale}\n`,
+		NOTION_EDITED);
+
+	await importOnce(vault, DuplicateHandling.Update);
+
+	const repaired = String(vault.contents.get(SYNCED[1]));
+	assert.ok(!repaired.includes(stale), 'the placeholder should be gone');
+	assert.match(repaired, /Chapter one/, 'replaced with a link to the page it named');
+});
+
+// What is under a synced block and what its note says are two questions. The
+// note the user edited is theirs and is never rewritten; the page beneath it
+// is still theirs to have, and is fetched whether or not the note mentions it.
+test('a page under a synced block arrives even when the note is left alone', async () => {
+	for (const mode of [DuplicateHandling.Skip, DuplicateHandling.Update]) {
+		const vault = await vaultWithOneImport(mode);
+		vault.remove(NESTED);
+
+		await importOnce(vault, mode);
+
+		assert.ok(markdown(vault).includes(NESTED), mode);
+	}
+});
+
+test('and even when the note is one the user has edited', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.Update);
+	const mine = 'My own notes on how we work.\n';
+	await editInObsidian(vault, SYNCED[1], mine, '2024-12-01T00:00:00.000Z');
+	vault.remove(NESTED);
+
+	await importOnce(vault, DuplicateHandling.Update, true, LATER);
+
+	assert.ok(markdown(vault).includes(NESTED), 'the page under it is still fetched');
+	assert.equal(vault.contents.get(SYNCED[1]), mine, 'and the note is untouched');
 });
 
 test('"Update" does not write over a synced block note edited in Obsidian', async () => {
@@ -212,5 +302,5 @@ test('"Update" does not write over a synced block note edited in Obsidian', asyn
 	await importOnce(vault, DuplicateHandling.Update, true, LATER);
 
 	assert.equal(vault.contents.get(SYNCED[1]), mine);
-	assert.deepEqual(markdown(vault), [CHILD_NOTE, ...SYNCED, PAGE_NOTE], 'and does not write a second one');
+	assert.deepEqual(markdown(vault), EVERYTHING, 'and does not write a second one');
 });

--- a/tests/notion-api/synced-blocks.test.ts
+++ b/tests/notion-api/synced-blocks.test.ts
@@ -23,6 +23,8 @@ import { NotionAPIImporter } from '../../src/formats/notion-api';
 import { DuplicateHandling } from '../../src/format-importer';
 import { ImportContext } from '../../src/import-context';
 import { NOTION_ID_PROPERTY } from '../../src/constants';
+import type { TFile } from 'obsidian';
+
 import { MemoryVault, memoryApp } from '../shims/vault';
 
 interface Workspace {
@@ -39,10 +41,13 @@ const FIRST_BLOCK = '30000000-0000-4000-8000-000000000201';
 const EMPTY = { object: 'list', results: [], has_more: false, next_cursor: null };
 
 class ImportingSyncedBlocks extends NotionAPIImporter {
-	answerFromFixture(): void {
+	answerFromFixture(editedAt?: string): void {
+		const edited = <T>(value: T): T =>
+			editedAt ? { ...(value as object), last_edited_time: editedAt } as T : value;
+
 		this.notionClient = {
 			pages: {
-				retrieve: async ({ page_id }: { page_id: string }) => workspace.pages[page_id],
+				retrieve: async ({ page_id }: { page_id: string }) => edited(workspace.pages[page_id]),
 			},
 			blocks: {
 				children: {
@@ -51,7 +56,7 @@ class ImportingSyncedBlocks extends NotionAPIImporter {
 				retrieve: async ({ block_id }: { block_id: string }) => {
 					for (const { results } of Object.values(workspace.blocks)) {
 						const block = (results as { id: string }[]).find(candidate => candidate.id === block_id);
-						if (block) return block;
+						if (block) return edited(block);
 					}
 					throw new Error(`no block ${block_id} in the fixture`);
 				},
@@ -68,11 +73,11 @@ class ImportingSyncedBlocks extends NotionAPIImporter {
 	}
 }
 
-async function importOnce(vault: MemoryVault, mode: DuplicateHandling, saveSourceId = true) {
+async function importOnce(vault: MemoryVault, mode: DuplicateHandling, saveSourceId = true, editedAt?: string) {
 	const subject = new ImportingSyncedBlocks(memoryApp(vault), { sourceEl: null, optionsEl: null } as never);
 	subject.duplicateHandling = mode;
 	subject.saveSourceId = saveSourceId;
-	subject.answerFromFixture();
+	subject.answerFromFixture(editedAt);
 	subject.indexImportedNotes();
 
 	const ctx = new ImportContext();
@@ -144,15 +149,68 @@ test('a third import adds nothing either', async () => {
 	assert.deepEqual(markdown(vault), [CHILD_NOTE, ...SYNCED, PAGE_NOTE]);
 });
 
-// With the id turned off there is nothing to recognise them by, so a second
-// import writes its own. Worth knowing rather than worth pretending otherwise.
-test('with "Save source ID" off, the id is cleared once the import is done', async () => {
+// The id goes in whether or not it is being kept, so that an import which is
+// interrupted leaves notes the next one can recognise as its own. Only at the
+// end is it taken back out.
+test('with "Save source ID" off, the id is written and then cleared', async () => {
 	const vault = new MemoryVault();
 	await vault.createFolder('Notion');
 	const { ctx, subject } = await importOnce(vault, DuplicateHandling.Skip, false);
+
+	for (const path of SYNCED) {
+		assert.match(String(vault.contents.get(path)), new RegExp(`${NOTION_ID_PROPERTY}: `), `${path} before`);
+	}
+
 	await subject.cleanUp(ctx);
 
 	for (const path of SYNCED) {
-		assert.doesNotMatch(String(vault.contents.get(path)), new RegExp(NOTION_ID_PROPERTY), path);
+		assert.doesNotMatch(String(vault.contents.get(path)), new RegExp(NOTION_ID_PROPERTY), `${path} after`);
+		assert.match(String(vault.contents.get(path)), /How we work\.|Who to ask\./, `${path} kept its content`);
 	}
+});
+
+const NOTION_EDITED = '2024-03-01T00:00:00.000Z';
+const LATER = '2024-09-01T00:00:00.000Z';
+
+/** Stand in for the user editing a synced block's note in Obsidian. */
+async function editInObsidian(vault: MemoryVault, path: string, body: string, at: string): Promise<void> {
+	const file = vault.getAbstractFileByPath(path) as unknown as TFile;
+	await vault.modify(file, body, { mtime: Date.parse(at), ctime: file.stat.ctime });
+}
+
+test('a synced block note is stamped with when Notion last changed the block', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.Update);
+	const file = vault.getAbstractFileByPath(SYNCED[1]) as unknown as TFile;
+
+	assert.equal(file.stat.mtime, Date.parse(NOTION_EDITED));
+});
+
+test('"Update" leaves a synced block Notion has not changed since', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.Update);
+	const before = vault.contents.get(SYNCED[1]);
+
+	await importOnce(vault, DuplicateHandling.Update);
+
+	assert.equal(vault.contents.get(SYNCED[1]), before);
+});
+
+test('"Update" writes over a synced block Notion has changed', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.Update);
+	await editInObsidian(vault, SYNCED[1], 'Something else entirely.\n', '2024-04-01T00:00:00.000Z');
+
+	await importOnce(vault, DuplicateHandling.Update, true, LATER);
+
+	assert.match(String(vault.contents.get(SYNCED[1])), /How we work\./);
+	assert.deepEqual(markdown(vault), [CHILD_NOTE, ...SYNCED, PAGE_NOTE], 'and does not write a second one');
+});
+
+test('"Update" does not write over a synced block note edited in Obsidian', async () => {
+	const vault = await vaultWithOneImport(DuplicateHandling.Update);
+	const mine = 'My own notes on how we work.\n';
+	await editInObsidian(vault, SYNCED[1], mine, '2024-12-01T00:00:00.000Z');
+
+	await importOnce(vault, DuplicateHandling.Update, true, LATER);
+
+	assert.equal(vault.contents.get(SYNCED[1]), mine);
+	assert.deepEqual(markdown(vault), [CHILD_NOTE, ...SYNCED, PAGE_NOTE], 'and does not write a second one');
 });

--- a/tests/notion-api/synced-workspace.json
+++ b/tests/notion-api/synced-workspace.json
@@ -1,5 +1,5 @@
 {
-	"_comment": "Hand-written to the shape of Notion's API responses (https://developers.notion.com/reference). One page holding two synced blocks, which is what it takes to show both things a second import has to get right: the note a synced block already has is not written again, and two synced blocks of one page do not collapse into one note. `pages` is keyed by page id as GET /v1/pages/{id} returns it; `blocks` is keyed by block id as GET /v1/blocks/{id}/children returns it. Every block object carries created_time and last_edited_time, which is what decides whether a synced block has changed since the last import. One synced block holds a child page, which inside a synced block is not imported where it stands but noted and fetched afterwards. The ids are made up and so is the content.",
+	"_comment": "Hand-written to the shape of Notion's API responses (https://developers.notion.com/reference). One page holding two synced blocks, which is what it takes to show both things a second import has to get right: the note a synced block already has is not written again, and two synced blocks of one page do not collapse into one note. `pages` is keyed by page id as GET /v1/pages/{id} returns it; `blocks` is keyed by block id as GET /v1/blocks/{id}/children returns it. Every block object carries created_time and last_edited_time, which is what decides whether a synced block has changed since the last import. One synced block holds a child page, which inside a synced block is not imported where it stands but noted and fetched afterwards. The second synced block holds an image, because a synced block whose note has to be written needs what it points at whether or not the page around it is being left alone. The ids are made up and so is the content.",
 	"pages": {
 		"10000000-0000-4000-8000-000000000202": {
 			"object": "page",
@@ -254,6 +254,23 @@
 							}
 						],
 						"color": "default"
+					}
+				},
+				{
+					"object": "block",
+					"id": "50000000-0000-4000-8000-000000000201",
+					"type": "image",
+					"has_children": false,
+					"archived": false,
+					"created_time": "2024-01-01T00:00:00.000Z",
+					"last_edited_time": "2024-03-01T00:00:00.000Z",
+					"image": {
+						"type": "file",
+						"file": {
+							"url": "https://example.invalid/handbook-diagram.png",
+							"expiry_time": "2024-03-01T01:00:00.000Z"
+						},
+						"caption": []
 					}
 				}
 			]

--- a/tests/notion-api/synced-workspace.json
+++ b/tests/notion-api/synced-workspace.json
@@ -1,0 +1,89 @@
+{
+	"_comment": "Hand-written to the shape of Notion's API responses (https://developers.notion.com/reference). One page holding two synced blocks, which is what it takes to show both things a second import has to get right: the note a synced block already has is not written again, and two synced blocks of one page do not collapse into one note. `pages` is keyed by page id as GET /v1/pages/{id} returns it; `blocks` is keyed by block id as GET /v1/blocks/{id}/children returns it. The ids are made up and so is the content.",
+
+	"pages": {
+		"10000000-0000-4000-8000-000000000202": {
+			"object": "page",
+			"id": "10000000-0000-4000-8000-000000000202",
+			"created_time": "2024-01-02T00:00:00.000Z",
+			"last_edited_time": "2024-03-02T00:00:00.000Z",
+			"archived": false,
+			"properties": {
+				"title": {
+					"id": "title",
+					"type": "title",
+					"title": [{ "type": "text", "text": { "content": "Chapter one", "link": null }, "annotations": { "bold": false, "italic": false, "strikethrough": false, "underline": false, "code": false, "color": "default" }, "plain_text": "Chapter one", "href": null }]
+				}
+			}
+		},
+		"10000000-0000-4000-8000-000000000201": {
+			"object": "page",
+			"id": "10000000-0000-4000-8000-000000000201",
+			"created_time": "2024-01-01T00:00:00.000Z",
+			"last_edited_time": "2024-03-01T00:00:00.000Z",
+			"archived": false,
+			"properties": {
+				"title": {
+					"id": "title",
+					"type": "title",
+					"title": [{ "type": "text", "text": { "content": "Handbook", "link": null }, "annotations": { "bold": false, "italic": false, "strikethrough": false, "underline": false, "code": false, "color": "default" }, "plain_text": "Handbook", "href": null }]
+				}
+			}
+		}
+	},
+
+	"blocks": {
+		"10000000-0000-4000-8000-000000000201": {
+			"object": "list",
+			"has_more": false,
+			"next_cursor": null,
+			"results": [
+				{
+					"object": "block", "id": "30000000-0000-4000-8000-000000000201", "type": "synced_block", "has_children": true, "archived": false,
+					"synced_block": { "synced_from": null }
+				},
+				{
+					"object": "block", "id": "30000000-0000-4000-8000-000000000202", "type": "synced_block", "has_children": true, "archived": false,
+					"synced_block": { "synced_from": null }
+				},
+				{
+					"object": "block", "id": "10000000-0000-4000-8000-000000000202", "type": "child_page", "has_children": false, "archived": false,
+					"child_page": { "title": "Chapter one" }
+				}
+			]
+		},
+		"10000000-0000-4000-8000-000000000202": {
+			"object": "list",
+			"has_more": false,
+			"next_cursor": null,
+			"results": [
+				{
+					"object": "block", "id": "40000000-0000-4000-8000-000000000203", "type": "paragraph", "has_children": false, "archived": false,
+					"paragraph": { "rich_text": [{ "type": "text", "text": { "content": "The first chapter.", "link": null }, "annotations": { "bold": false, "italic": false, "strikethrough": false, "underline": false, "code": false, "color": "default" }, "plain_text": "The first chapter.", "href": null }], "color": "default" }
+				}
+			]
+		},
+		"30000000-0000-4000-8000-000000000201": {
+			"object": "list",
+			"has_more": false,
+			"next_cursor": null,
+			"results": [
+				{
+					"object": "block", "id": "40000000-0000-4000-8000-000000000201", "type": "paragraph", "has_children": false, "archived": false,
+					"paragraph": { "rich_text": [{ "type": "text", "text": { "content": "How we work.", "link": null }, "annotations": { "bold": false, "italic": false, "strikethrough": false, "underline": false, "code": false, "color": "default" }, "plain_text": "How we work.", "href": null }], "color": "default" }
+				}
+			]
+		},
+		"30000000-0000-4000-8000-000000000202": {
+			"object": "list",
+			"has_more": false,
+			"next_cursor": null,
+			"results": [
+				{
+					"object": "block", "id": "40000000-0000-4000-8000-000000000202", "type": "paragraph", "has_children": false, "archived": false,
+					"paragraph": { "rich_text": [{ "type": "text", "text": { "content": "Who to ask.", "link": null }, "annotations": { "bold": false, "italic": false, "strikethrough": false, "underline": false, "code": false, "color": "default" }, "plain_text": "Who to ask.", "href": null }], "color": "default" }
+				}
+			]
+		}
+	}
+}

--- a/tests/notion-api/synced-workspace.json
+++ b/tests/notion-api/synced-workspace.json
@@ -1,6 +1,5 @@
 {
-	"_comment": "Hand-written to the shape of Notion's API responses (https://developers.notion.com/reference). One page holding two synced blocks, which is what it takes to show both things a second import has to get right: the note a synced block already has is not written again, and two synced blocks of one page do not collapse into one note. `pages` is keyed by page id as GET /v1/pages/{id} returns it; `blocks` is keyed by block id as GET /v1/blocks/{id}/children returns it. Every block object carries created_time and last_edited_time, which is what decides whether a synced block has changed since the last import. The ids are made up and so is the content.",
-
+	"_comment": "Hand-written to the shape of Notion's API responses (https://developers.notion.com/reference). One page holding two synced blocks, which is what it takes to show both things a second import has to get right: the note a synced block already has is not written again, and two synced blocks of one page do not collapse into one note. `pages` is keyed by page id as GET /v1/pages/{id} returns it; `blocks` is keyed by block id as GET /v1/blocks/{id}/children returns it. Every block object carries created_time and last_edited_time, which is what decides whether a synced block has changed since the last import. One synced block holds a child page, which inside a synced block is not imported where it stands but noted and fetched afterwards. The ids are made up and so is the content.",
 	"pages": {
 		"10000000-0000-4000-8000-000000000202": {
 			"object": "page",
@@ -12,7 +11,25 @@
 				"title": {
 					"id": "title",
 					"type": "title",
-					"title": [{ "type": "text", "text": { "content": "Chapter one", "link": null }, "annotations": { "bold": false, "italic": false, "strikethrough": false, "underline": false, "code": false, "color": "default" }, "plain_text": "Chapter one", "href": null }]
+					"title": [
+						{
+							"type": "text",
+							"text": {
+								"content": "Chapter one",
+								"link": null
+							},
+							"annotations": {
+								"bold": false,
+								"italic": false,
+								"strikethrough": false,
+								"underline": false,
+								"code": false,
+								"color": "default"
+							},
+							"plain_text": "Chapter one",
+							"href": null
+						}
+					]
 				}
 			}
 		},
@@ -26,12 +43,61 @@
 				"title": {
 					"id": "title",
 					"type": "title",
-					"title": [{ "type": "text", "text": { "content": "Handbook", "link": null }, "annotations": { "bold": false, "italic": false, "strikethrough": false, "underline": false, "code": false, "color": "default" }, "plain_text": "Handbook", "href": null }]
+					"title": [
+						{
+							"type": "text",
+							"text": {
+								"content": "Handbook",
+								"link": null
+							},
+							"annotations": {
+								"bold": false,
+								"italic": false,
+								"strikethrough": false,
+								"underline": false,
+								"code": false,
+								"color": "default"
+							},
+							"plain_text": "Handbook",
+							"href": null
+						}
+					]
+				}
+			}
+		},
+		"10000000-0000-4000-8000-000000000203": {
+			"object": "page",
+			"id": "10000000-0000-4000-8000-000000000203",
+			"created_time": "2024-01-03T00:00:00.000Z",
+			"last_edited_time": "2024-03-03T00:00:00.000Z",
+			"archived": false,
+			"properties": {
+				"title": {
+					"id": "title",
+					"type": "title",
+					"title": [
+						{
+							"type": "text",
+							"text": {
+								"content": "Nested in a synced block",
+								"link": null
+							},
+							"annotations": {
+								"bold": false,
+								"italic": false,
+								"strikethrough": false,
+								"underline": false,
+								"code": false,
+								"color": "default"
+							},
+							"plain_text": "Nested in a synced block",
+							"href": null
+						}
+					]
 				}
 			}
 		}
 	},
-
 	"blocks": {
 		"10000000-0000-4000-8000-000000000201": {
 			"object": "list",
@@ -39,16 +105,38 @@
 			"next_cursor": null,
 			"results": [
 				{
-					"object": "block", "id": "30000000-0000-4000-8000-000000000201", "type": "synced_block", "has_children": true, "archived": false, "created_time": "2024-01-01T00:00:00.000Z", "last_edited_time": "2024-03-01T00:00:00.000Z",
-					"synced_block": { "synced_from": null }
+					"object": "block",
+					"id": "30000000-0000-4000-8000-000000000201",
+					"type": "synced_block",
+					"has_children": true,
+					"archived": false,
+					"created_time": "2024-01-01T00:00:00.000Z",
+					"last_edited_time": "2024-03-01T00:00:00.000Z",
+					"synced_block": {
+						"synced_from": null
+					}
 				},
 				{
-					"object": "block", "id": "30000000-0000-4000-8000-000000000202", "type": "synced_block", "has_children": true, "archived": false, "created_time": "2024-01-01T00:00:00.000Z", "last_edited_time": "2024-03-01T00:00:00.000Z",
-					"synced_block": { "synced_from": null }
+					"object": "block",
+					"id": "30000000-0000-4000-8000-000000000202",
+					"type": "synced_block",
+					"has_children": true,
+					"archived": false,
+					"created_time": "2024-01-01T00:00:00.000Z",
+					"last_edited_time": "2024-03-01T00:00:00.000Z",
+					"synced_block": {
+						"synced_from": null
+					}
 				},
 				{
-					"object": "block", "id": "10000000-0000-4000-8000-000000000202", "type": "child_page", "has_children": false, "archived": false,
-					"child_page": { "title": "Chapter one" }
+					"object": "block",
+					"id": "10000000-0000-4000-8000-000000000202",
+					"type": "child_page",
+					"has_children": false,
+					"archived": false,
+					"child_page": {
+						"title": "Chapter one"
+					}
 				}
 			]
 		},
@@ -58,8 +146,33 @@
 			"next_cursor": null,
 			"results": [
 				{
-					"object": "block", "id": "40000000-0000-4000-8000-000000000203", "type": "paragraph", "has_children": false, "archived": false,
-					"paragraph": { "rich_text": [{ "type": "text", "text": { "content": "The first chapter.", "link": null }, "annotations": { "bold": false, "italic": false, "strikethrough": false, "underline": false, "code": false, "color": "default" }, "plain_text": "The first chapter.", "href": null }], "color": "default" }
+					"object": "block",
+					"id": "40000000-0000-4000-8000-000000000203",
+					"type": "paragraph",
+					"has_children": false,
+					"archived": false,
+					"paragraph": {
+						"rich_text": [
+							{
+								"type": "text",
+								"text": {
+									"content": "The first chapter.",
+									"link": null
+								},
+								"annotations": {
+									"bold": false,
+									"italic": false,
+									"strikethrough": false,
+									"underline": false,
+									"code": false,
+									"color": "default"
+								},
+								"plain_text": "The first chapter.",
+								"href": null
+							}
+						],
+						"color": "default"
+					}
 				}
 			]
 		},
@@ -69,8 +182,43 @@
 			"next_cursor": null,
 			"results": [
 				{
-					"object": "block", "id": "40000000-0000-4000-8000-000000000201", "type": "paragraph", "has_children": false, "archived": false,
-					"paragraph": { "rich_text": [{ "type": "text", "text": { "content": "How we work.", "link": null }, "annotations": { "bold": false, "italic": false, "strikethrough": false, "underline": false, "code": false, "color": "default" }, "plain_text": "How we work.", "href": null }], "color": "default" }
+					"object": "block",
+					"id": "40000000-0000-4000-8000-000000000201",
+					"type": "paragraph",
+					"has_children": false,
+					"archived": false,
+					"paragraph": {
+						"rich_text": [
+							{
+								"type": "text",
+								"text": {
+									"content": "How we work.",
+									"link": null
+								},
+								"annotations": {
+									"bold": false,
+									"italic": false,
+									"strikethrough": false,
+									"underline": false,
+									"code": false,
+									"color": "default"
+								},
+								"plain_text": "How we work.",
+								"href": null
+							}
+						],
+						"color": "default"
+					}
+				},
+				{
+					"object": "block",
+					"id": "10000000-0000-4000-8000-000000000203",
+					"type": "child_page",
+					"has_children": false,
+					"archived": false,
+					"child_page": {
+						"title": "Nested in a synced block"
+					}
 				}
 			]
 		},
@@ -80,8 +228,69 @@
 			"next_cursor": null,
 			"results": [
 				{
-					"object": "block", "id": "40000000-0000-4000-8000-000000000202", "type": "paragraph", "has_children": false, "archived": false,
-					"paragraph": { "rich_text": [{ "type": "text", "text": { "content": "Who to ask.", "link": null }, "annotations": { "bold": false, "italic": false, "strikethrough": false, "underline": false, "code": false, "color": "default" }, "plain_text": "Who to ask.", "href": null }], "color": "default" }
+					"object": "block",
+					"id": "40000000-0000-4000-8000-000000000202",
+					"type": "paragraph",
+					"has_children": false,
+					"archived": false,
+					"paragraph": {
+						"rich_text": [
+							{
+								"type": "text",
+								"text": {
+									"content": "Who to ask.",
+									"link": null
+								},
+								"annotations": {
+									"bold": false,
+									"italic": false,
+									"strikethrough": false,
+									"underline": false,
+									"code": false,
+									"color": "default"
+								},
+								"plain_text": "Who to ask.",
+								"href": null
+							}
+						],
+						"color": "default"
+					}
+				}
+			]
+		},
+		"10000000-0000-4000-8000-000000000203": {
+			"object": "list",
+			"has_more": false,
+			"next_cursor": null,
+			"results": [
+				{
+					"object": "block",
+					"id": "40000000-0000-4000-8000-000000000204",
+					"type": "paragraph",
+					"has_children": false,
+					"archived": false,
+					"paragraph": {
+						"rich_text": [
+							{
+								"type": "text",
+								"text": {
+									"content": "Reached through the synced block.",
+									"link": null
+								},
+								"annotations": {
+									"bold": false,
+									"italic": false,
+									"strikethrough": false,
+									"underline": false,
+									"code": false,
+									"color": "default"
+								},
+								"plain_text": "Reached through the synced block.",
+								"href": null
+							}
+						],
+						"color": "default"
+					}
 				}
 			]
 		}

--- a/tests/notion-api/synced-workspace.json
+++ b/tests/notion-api/synced-workspace.json
@@ -1,5 +1,5 @@
 {
-	"_comment": "Hand-written to the shape of Notion's API responses (https://developers.notion.com/reference). One page holding two synced blocks, which is what it takes to show both things a second import has to get right: the note a synced block already has is not written again, and two synced blocks of one page do not collapse into one note. `pages` is keyed by page id as GET /v1/pages/{id} returns it; `blocks` is keyed by block id as GET /v1/blocks/{id}/children returns it. The ids are made up and so is the content.",
+	"_comment": "Hand-written to the shape of Notion's API responses (https://developers.notion.com/reference). One page holding two synced blocks, which is what it takes to show both things a second import has to get right: the note a synced block already has is not written again, and two synced blocks of one page do not collapse into one note. `pages` is keyed by page id as GET /v1/pages/{id} returns it; `blocks` is keyed by block id as GET /v1/blocks/{id}/children returns it. Every block object carries created_time and last_edited_time, which is what decides whether a synced block has changed since the last import. The ids are made up and so is the content.",
 
 	"pages": {
 		"10000000-0000-4000-8000-000000000202": {
@@ -39,11 +39,11 @@
 			"next_cursor": null,
 			"results": [
 				{
-					"object": "block", "id": "30000000-0000-4000-8000-000000000201", "type": "synced_block", "has_children": true, "archived": false,
+					"object": "block", "id": "30000000-0000-4000-8000-000000000201", "type": "synced_block", "has_children": true, "archived": false, "created_time": "2024-01-01T00:00:00.000Z", "last_edited_time": "2024-03-01T00:00:00.000Z",
 					"synced_block": { "synced_from": null }
 				},
 				{
-					"object": "block", "id": "30000000-0000-4000-8000-000000000202", "type": "synced_block", "has_children": true, "archived": false,
+					"object": "block", "id": "30000000-0000-4000-8000-000000000202", "type": "synced_block", "has_children": true, "archived": false, "created_time": "2024-01-01T00:00:00.000Z", "last_edited_time": "2024-03-01T00:00:00.000Z",
 					"synced_block": { "synced_from": null }
 				},
 				{

--- a/tests/notion-api/synced-workspace.json
+++ b/tests/notion-api/synced-workspace.json
@@ -1,5 +1,5 @@
 {
-	"_comment": "Hand-written to the shape of Notion's API responses (https://developers.notion.com/reference). One page holding two synced blocks, which is what it takes to show both things a second import has to get right: the note a synced block already has is not written again, and two synced blocks of one page do not collapse into one note. `pages` is keyed by page id as GET /v1/pages/{id} returns it; `blocks` is keyed by block id as GET /v1/blocks/{id}/children returns it. Every block object carries created_time and last_edited_time, which is what decides whether a synced block has changed since the last import. One synced block holds a child page, which inside a synced block is not imported where it stands but noted and fetched afterwards. The second synced block holds an image, because a synced block whose note has to be written needs what it points at whether or not the page around it is being left alone. The ids are made up and so is the content.",
+	"_comment": "Hand-written to the shape of Notion's API responses (https://developers.notion.com/reference). One page holding two synced blocks, which is what it takes to show both things a second import has to get right: the note a synced block already has is not written again, and two synced blocks of one page do not collapse into one note. `pages` is keyed by page id as GET /v1/pages/{id} returns it; `blocks` is keyed by block id as GET /v1/blocks/{id}/children returns it. Every block object carries created_time and last_edited_time, which is what decides whether a synced block has changed since the last import. One synced block holds a child page, which inside a synced block is not imported where it stands but noted and fetched afterwards. The second synced block holds an image, because a synced block whose note has to be written needs what it points at whether or not the page around it is being left alone. It also holds a child database, which is a different thing to fetch than a page and has to be asked for as one. The ids are made up and so is the content.",
 	"pages": {
 		"10000000-0000-4000-8000-000000000202": {
 			"object": "page",
@@ -271,6 +271,18 @@
 							"expiry_time": "2024-03-01T01:00:00.000Z"
 						},
 						"caption": []
+					}
+				},
+				{
+					"object": "block",
+					"id": "60000000-0000-4000-8000-000000000201",
+					"type": "child_database",
+					"has_children": false,
+					"archived": false,
+					"created_time": "2024-01-01T00:00:00.000Z",
+					"last_edited_time": "2024-03-01T00:00:00.000Z",
+					"child_database": {
+						"title": "Questions"
 					}
 				}
 			]

--- a/tests/shims/vault.ts
+++ b/tests/shims/vault.ts
@@ -43,10 +43,8 @@ export class MemoryVault {
 	}
 
 	/**
-	 * The vault's own view of the files under it, below the file cache.
-	 *
-	 * Only what the importers reach for: whether a path is taken, and writing
-	 * to one the cache has no TFile for.
+	 * Only what the importers reach for below the file cache: whether a path is
+	 * taken, and writing to one the cache has no TFile for.
 	 */
 	readonly adapter = {
 		exists: async (path: string): Promise<boolean> =>
@@ -57,10 +55,8 @@ export class MemoryVault {
 	};
 
 	/**
-	 * Take a file out of the vault, as deleting it in Obsidian would.
-	 *
-	 * Both maps: what a file holds, and the vault's own record that it is
-	 * there. Emptying only the first leaves a file every lookup still finds.
+	 * Take a file out of the vault, as deleting it in Obsidian would. Both
+	 * maps: emptying only the contents leaves a file every lookup still finds.
 	 */
 	remove(path: string): void {
 		const normalized = normalizePath(path);

--- a/tests/shims/vault.ts
+++ b/tests/shims/vault.ts
@@ -42,6 +42,18 @@ export class MemoryVault {
 		return [...this.contents.keys()];
 	}
 
+	/**
+	 * Take a file out of the vault, as deleting it in Obsidian would.
+	 *
+	 * Both maps: what a file holds, and the vault's own record that it is
+	 * there. Emptying only the first leaves a file every lookup still finds.
+	 */
+	remove(path: string): void {
+		const normalized = normalizePath(path);
+		this.contents.delete(normalized);
+		this.entries.delete(normalized.toLowerCase());
+	}
+
 	/** Every file and folder the vault holds, as Obsidian hands them out. */
 	getAllLoadedFiles(): TAbstractFile[] {
 		return [...this.entries.values()];

--- a/tests/shims/vault.ts
+++ b/tests/shims/vault.ts
@@ -43,6 +43,20 @@ export class MemoryVault {
 	}
 
 	/**
+	 * The vault's own view of the files under it, below the file cache.
+	 *
+	 * Only what the importers reach for: whether a path is taken, and writing
+	 * to one the cache has no TFile for.
+	 */
+	readonly adapter = {
+		exists: async (path: string): Promise<boolean> =>
+			this.contents.has(normalizePath(path)),
+		write: async (path: string, data: string): Promise<void> => {
+			this.contents.set(normalizePath(path), data);
+		},
+	};
+
+	/**
 	 * Take a file out of the vault, as deleting it in Obsidian would.
 	 *
 	 * Both maps: what a file holds, and the vault's own record that it is

--- a/tests/shims/vault.ts
+++ b/tests/shims/vault.ts
@@ -200,6 +200,17 @@ export function memoryApp(vault: MemoryVault) {
 
 				return { frontmatter: parseFrontMatterBlock(content)?.frontMatter };
 			},
+			// A whole path resolves before a bare name does, which is what makes
+			// a link to "Books/Dune" reach that note rather than another "Dune".
+			getFirstLinkpathDest: (linkpath: string, _sourcePath: string) => {
+				const name = linkpath.toLowerCase().endsWith('.md') ? linkpath : `${linkpath}.md`;
+				const whole = vault.getAbstractFileByPathInsensitive(name);
+				if (whole) return whole;
+
+				const basename = name.slice(name.lastIndexOf('/') + 1).toLowerCase();
+				return vault.getMarkdownFiles()
+					.find(file => file.path.slice(file.path.lastIndexOf('/') + 1).toLowerCase() === basename) ?? null;
+			},
 		},
 		fileManager: {
 			generateMarkdownLink: (file: { path: string }, _sourcePath: string, subpath?: string, display?: string) =>

--- a/tests/write/base-files.test.ts
+++ b/tests/write/base-files.test.ts
@@ -65,7 +65,7 @@ test('and replaces what is in it with what the schema now says', async () => {
 
 test('a view the import brings replaces the one of that name', () => {
 	const merged = mergedBaseViews(
-		[{ type: 'table', name: 'All books' } as never],
+		{ views: [{ type: 'table', name: 'All books' }] },
 		[{ type: 'cards', name: 'All books' } as never],
 	);
 
@@ -74,7 +74,7 @@ test('a view the import brings replaces the one of that name', () => {
 
 test('a view the user added is kept beside the imported ones', () => {
 	const merged = mergedBaseViews(
-		[{ type: 'table', name: 'My shortlist' } as never],
+		{ views: [{ type: 'table', name: 'My shortlist' }] },
 		[{ type: 'table', name: 'All books' } as never],
 	);
 
@@ -84,7 +84,17 @@ test('a view the user added is kept beside the imported ones', () => {
 test('and a .base with no views yet is simply the imported ones', () => {
 	const imported = [{ type: 'table', name: 'All books' } as never];
 
-	assert.deepEqual(mergedBaseViews([], imported), imported);
+	assert.deepEqual(mergedBaseViews({ views: [] }, imported), imported);
+});
+
+// The file is the user's to edit, so it may be anything by the time an import
+// meets it again. Nothing in it that is not a named view is carried over.
+test('a .base edited into something unreadable is simply regenerated', () => {
+	const imported = [{ type: 'table', name: 'All books' } as never];
+
+	for (const existing of [null, undefined, 'not a config', 42, {}, { views: 'nope' }, { views: [null, { type: 'table' }] }]) {
+		assert.deepEqual(mergedBaseViews(existing, imported), imported, JSON.stringify(existing));
+	}
 });
 
 /** The code, without the prose around it. */

--- a/tests/write/base-files.test.ts
+++ b/tests/write/base-files.test.ts
@@ -95,7 +95,10 @@ test('and a .base with no views yet is simply the imported ones', () => {
 test('a .base edited into something unreadable is simply regenerated', () => {
 	const imported = [{ type: 'table', name: 'All books' } as never];
 
-	for (const existing of [null, undefined, 'not a config', 42, {}, { views: 'nope' }, { views: [null, { type: 'table' }] }]) {
+	const broken = [null, undefined, 'not a config', 42, {}, { views: 'nope' },
+		{ views: [null, { type: 'table' }, { name: 'No type of its own' }] }];
+
+	for (const existing of broken) {
 		assert.deepEqual(mergedBaseViews(existing, imported), imported, JSON.stringify(existing));
 	}
 });

--- a/tests/write/base-files.test.ts
+++ b/tests/write/base-files.test.ts
@@ -1,11 +1,9 @@
 /**
  * What a second import does to a .base file.
  *
- * A .base is generated from a table or database schema rather than imported
- * from a note, so it is not something the "Existing notes" setting has an
- * opinion about: a stale view of a schema that has moved on is no use to
- * anyone, whatever the user chose for their notes. Both importers regenerate
- * it, and neither reads duplicateHandling to decide.
+ * A .base is generated from a schema rather than imported from a note, so it
+ * is not something the "Existing notes" setting has an opinion about: both
+ * importers regenerate it, and neither reads duplicateHandling to decide.
  *
  * Where they differ is what they keep. Notion replaces the file. Airtable
  * keeps any view the user added beside the imported ones, because a view is
@@ -170,14 +168,13 @@ test('and keeps the user\'s own view in every mode, including "Skip"', async () 
 	}
 });
 
-/** The code, without the prose around it. */
+/** The code, without the comments that talk about the mode. */
 function withoutComments(source: string): string {
 	return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
 }
 
 // The policy in one assertion: no code path that writes a .base asks what the
-// user chose for their notes. Said here rather than left to be noticed, so
-// wiring the setting in has to be a decision rather than an accident.
+// user chose for their notes.
 test('neither importer decides a .base by the duplicate mode', () => {
 	const sources = [
 		'src/formats/notion-api/database-helpers.ts',

--- a/tests/write/base-files.test.ts
+++ b/tests/write/base-files.test.ts
@@ -1,0 +1,117 @@
+/**
+ * What a second import does to a .base file.
+ *
+ * A .base is generated from a table or database schema rather than imported
+ * from a note, so it is not something the "Existing notes" setting has an
+ * opinion about: a stale view of a schema that has moved on is no use to
+ * anyone, whatever the user chose for their notes. Both importers regenerate
+ * it, and neither reads duplicateHandling to decide.
+ *
+ * Where they differ is what they keep. Notion replaces the file. Airtable
+ * keeps any view the user added beside the imported ones, because a view is
+ * something a person makes rather than something the schema says.
+ */
+import '../shims/runtime';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import * as nodeFs from 'node:fs';
+import * as nodePath from 'node:path';
+
+import { parseYaml } from 'obsidian';
+
+import { createBaseFile } from '../../src/formats/notion-api/database-helpers';
+import { mergedBaseViews } from '../../src/formats/airtable-api/base-file';
+import { MemoryVault } from '../shims/vault';
+
+const SCHEMA = {
+	Name: { id: 'title', name: 'Name', type: 'title' },
+} as never;
+
+async function writeBase(vault: MemoryVault, name: string): Promise<string> {
+	return await createBaseFile({
+		vault: vault as never,
+		databaseName: name,
+		databaseFolderPath: 'Notion/Roadmap',
+		dataSourceProperties: SCHEMA,
+	});
+}
+
+test('Notion writes one .base for a database, however many times it is imported', async () => {
+	const vault = new MemoryVault();
+	await vault.createFolder('Notion');
+	await vault.createFolder('Notion/Roadmap');
+
+	const first = await writeBase(vault, 'Roadmap');
+	const second = await writeBase(vault, 'Roadmap');
+
+	assert.equal(first, 'Notion/Roadmap/Roadmap.base');
+	assert.equal(second, first, 'the second import writes the same file, not "Roadmap 1.base"');
+	assert.deepEqual(vault.paths().filter(path => path.endsWith('.base')), [first]);
+});
+
+test('and replaces what is in it with what the schema now says', async () => {
+	const vault = new MemoryVault();
+	await vault.createFolder('Notion');
+	await vault.createFolder('Notion/Roadmap');
+	const path = await writeBase(vault, 'Roadmap');
+
+	const generated = vault.contents.get(path);
+	await vault.adapter.write(path, 'views: []\n# edited by hand\n');
+	await writeBase(vault, 'Roadmap');
+
+	assert.equal(vault.contents.get(path), generated);
+});
+
+test('a view the import brings replaces the one of that name', () => {
+	const merged = mergedBaseViews(
+		[{ type: 'table', name: 'All books' } as never],
+		[{ type: 'cards', name: 'All books' } as never],
+	);
+
+	assert.deepEqual(merged, [{ type: 'cards', name: 'All books' }]);
+});
+
+test('a view the user added is kept beside the imported ones', () => {
+	const merged = mergedBaseViews(
+		[{ type: 'table', name: 'My shortlist' } as never],
+		[{ type: 'table', name: 'All books' } as never],
+	);
+
+	assert.deepEqual(merged.map(view => view.name), ['My shortlist', 'All books']);
+});
+
+test('and a .base with no views yet is simply the imported ones', () => {
+	const imported = [{ type: 'table', name: 'All books' } as never];
+
+	assert.deepEqual(mergedBaseViews([], imported), imported);
+});
+
+/** The code, without the prose around it. */
+function withoutComments(source: string): string {
+	return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+}
+
+// The policy in one assertion: no code path that writes a .base asks what the
+// user chose for their notes. Said here rather than left to be noticed, so
+// wiring the setting in has to be a decision rather than an accident.
+test('neither importer decides a .base by the duplicate mode', () => {
+	const sources = [
+		'src/formats/notion-api/database-helpers.ts',
+		'src/formats/airtable-api/base-file.ts',
+	];
+
+	for (const file of sources) {
+		const code = withoutComments(nodeFs.readFileSync(nodePath.join(__dirname, '../..', file), 'utf8'));
+		assert.doesNotMatch(code, /duplicateHandling|DuplicateHandling/, file);
+	}
+});
+
+test('a generated .base is readable YAML', async () => {
+	const vault = new MemoryVault();
+	await vault.createFolder('Notion');
+	await vault.createFolder('Notion/Roadmap');
+	const path = await writeBase(vault, 'Roadmap');
+
+	assert.ok(parseYaml(String(vault.contents.get(path))));
+});

--- a/tests/write/base-files.test.ts
+++ b/tests/write/base-files.test.ts
@@ -11,6 +11,7 @@
  * keeps any view the user added beside the imported ones, because a view is
  * something a person makes rather than something the schema says.
  */
+import '../shims/dom';
 import '../shims/runtime';
 
 import { test } from 'node:test';
@@ -18,11 +19,13 @@ import assert from 'node:assert/strict';
 import * as nodeFs from 'node:fs';
 import * as nodePath from 'node:path';
 
-import { parseYaml } from 'obsidian';
+import { parseYaml, stringifyYaml } from 'obsidian';
 
 import { createBaseFile } from '../../src/formats/notion-api/database-helpers';
 import { mergedBaseViews } from '../../src/formats/airtable-api/base-file';
-import { MemoryVault } from '../shims/vault';
+import { AirtableAPIImporter } from '../../src/formats/airtable-api';
+import { DuplicateHandling } from '../../src/format-importer';
+import { MemoryVault, memoryApp } from '../shims/vault';
 
 const SCHEMA = {
 	Name: { id: 'title', name: 'Name', type: 'title' },
@@ -94,6 +97,73 @@ test('a .base edited into something unreadable is simply regenerated', () => {
 
 	for (const existing of [null, undefined, 'not a config', 42, {}, { views: 'nope' }, { views: [null, { type: 'table' }] }]) {
 		assert.deepEqual(mergedBaseViews(existing, imported), imported, JSON.stringify(existing));
+	}
+});
+
+/** The Airtable writer itself, rather than the merge it delegates to. */
+class WritingBases extends AirtableAPIImporter {
+	write(viewNames = ['All books']): Promise<Map<string, string>> {
+		return this.createBaseFile({
+			tableFolderPath: 'Airtable/Books',
+			tableName: 'Books',
+			views: viewNames.map((name, nth) => ({ id: `viw00000000000000${nth}`, name, type: 'grid' })) as never,
+			fields: [{ id: 'fldName0000000001', name: 'Name', type: 'singleLineText' } as never],
+			primaryFieldId: 'fldName0000000001',
+			formulas: new Map(),
+		});
+	}
+}
+
+async function airtableBase(vault: MemoryVault, mode: DuplicateHandling): Promise<WritingBases> {
+	const subject = new WritingBases(memoryApp(vault), { sourceEl: null, optionsEl: null } as never);
+	subject.duplicateHandling = mode;
+	subject.indexImportedNotes();
+
+	return subject;
+}
+
+// Beside the table's folder, not inside it, which is where buildBaseFile puts it.
+const BASE_PATH = 'Airtable/Books.base';
+
+test('Airtable writes one .base for a table, in every mode', async () => {
+	for (const mode of [DuplicateHandling.CreateCopy, DuplicateHandling.Skip, DuplicateHandling.Update]) {
+		const vault = new MemoryVault();
+		await vault.createFolder('Airtable');
+		await vault.createFolder('Airtable/Books');
+
+		const subject = await airtableBase(vault, mode);
+		await subject.write();
+		await subject.write();
+
+		assert.deepEqual(vault.paths().filter(path => path.endsWith('.base')), [BASE_PATH], mode);
+	}
+});
+
+// The setting is about notes. Whichever the user picked, the .base is brought
+// up to date and the view they added themselves survives it.
+test('and keeps the user\'s own view in every mode, including "Skip"', async () => {
+	for (const mode of [DuplicateHandling.CreateCopy, DuplicateHandling.Skip, DuplicateHandling.Update]) {
+		const vault = new MemoryVault();
+		await vault.createFolder('Airtable');
+		await vault.createFolder('Airtable/Books');
+
+		const subject = await airtableBase(vault, mode);
+		await subject.write();
+
+		const mine = parseYaml(String(vault.contents.get(BASE_PATH)));
+		mine.views.push({ type: 'table', name: 'My shortlist' });
+		await vault.adapter.write(BASE_PATH, stringifyYaml(mine));
+
+		// The table has gained a view since. The .base has to show it, which is
+		// what says the file was regenerated rather than simply left alone.
+		await subject.write(['All books', 'By author']);
+
+		const after = parseYaml(String(vault.contents.get(BASE_PATH)));
+		assert.deepEqual(
+			(after.views as { name: string }[]).map(view => view.name).sort(),
+			['All books', 'By author', 'My shortlist'],
+			mode
+		);
 	}
 });
 

--- a/tests/write/plan-note.test.ts
+++ b/tests/write/plan-note.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Planning a note before its markdown exists.
+ *
+ * writeNote decides everything at the moment it writes, which is fine for an
+ * importer holding a converted note already. An importer reading an API needs
+ * the answer earlier: where the note goes settles where its attachments and
+ * links point, and whether the source has moved on settles whether converting
+ * it is worth doing at all.
+ *
+ * write-note.test.ts covers the rules themselves. This covers reaching them in
+ * two steps rather than one.
+ */
+import '../shims/runtime';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { DuplicateHandling, FormatImporter, NoteDisposition, PlannedNote } from '../../src/format-importer';
+import { ImportContext } from '../../src/import-context';
+import { MemoryVault, memoryApp } from '../shims/vault';
+
+class PlanningImporter extends FormatImporter {
+	init(): void {}
+	async import(_ctx: ImportContext): Promise<void> {}
+
+	preflight(ctx: ImportContext, planned: PlannedNote, sourceMtime?: number): NoteDisposition {
+		return this.preflightNote(ctx, planned, sourceMtime);
+	}
+}
+
+function importer(duplicateHandling: DuplicateHandling, idProperty?: string) {
+	const vault = new MemoryVault();
+	const subject = new PlanningImporter(memoryApp(vault), { sourceEl: null, optionsEl: null } as never);
+	subject.duplicateHandling = duplicateHandling;
+	subject.idProperty = idProperty ?? null;
+	subject.indexImportedNotes();
+
+	return { vault, subject, ctx: new ImportContext() };
+}
+
+test('a name nothing holds is planned as itself', () => {
+	const { vault, subject } = importer(DuplicateHandling.Update);
+
+	const planned = subject.planNote(vault.root, 'Note');
+
+	assert.equal(planned.desiredPath, 'Note.md');
+	assert.equal(planned.targetPath, 'Note.md');
+	assert.equal(planned.file, null);
+});
+
+test('two notes planned before either is written are given different names', () => {
+	const { vault, subject } = importer(DuplicateHandling.Update);
+
+	const first = subject.planNote(vault.root, 'Note');
+	const second = subject.planNote(vault.root, 'Note');
+
+	assert.equal(first.targetPath, 'Note.md');
+	assert.equal(second.targetPath, 'Note 1.md', 'the second should not be handed a name the first is holding');
+});
+
+test('a note the user moved is planned where it now is, not where it would have gone', async () => {
+	const { vault, subject } = importer(DuplicateHandling.Update, 'notion-id');
+	await vault.createFolder('Archive');
+	await vault.create('Archive/Note.md', '---\nnotion-id: abc\n---\nmoved\n');
+	subject.indexImportedNotes();
+
+	const planned = subject.planNote(vault.root, 'Note', 'abc');
+
+	assert.equal(planned.desiredPath, 'Note.md');
+	assert.equal(planned.targetPath, 'Archive/Note.md');
+	assert.equal(planned.file?.path, 'Archive/Note.md');
+});
+
+test('what preflight makes of a note nothing matches', () => {
+	const { vault, subject, ctx } = importer(DuplicateHandling.Update);
+
+	assert.equal(subject.preflight(ctx, subject.planNote(vault.root, 'Note')), 'create');
+	assert.deepEqual(ctx.skipped, []);
+});
+
+test('"Create a copy" over a name already taken plans a copy', async () => {
+	const { vault, subject, ctx } = importer(DuplicateHandling.CreateCopy);
+	await vault.create('Note.md', 'already here');
+
+	const planned = subject.planNote(vault.root, 'Note');
+
+	assert.equal(planned.targetPath, 'Note 1.md');
+	assert.equal(subject.preflight(ctx, planned), 'copy');
+});
+
+test('the source time decides, and says why', async () => {
+	const cases: [number, NoteDisposition, number][] = [
+		[2_000, 'unchanged', 1],
+		[1_000, 'preserve', 1],
+		[3_000, 'update', 0],
+	];
+
+	for (const [sourceMtime, expected, skipped] of cases) {
+		const { vault, subject, ctx } = importer(DuplicateHandling.Update);
+		await vault.create('Note.md', 'here', { mtime: 2_000 });
+
+		const disposition = subject.preflight(ctx, subject.planNote(vault.root, 'Note'), sourceMtime);
+
+		assert.equal(disposition, expected, `mtime ${sourceMtime}`);
+		assert.equal(ctx.skipped.length, skipped, `mtime ${sourceMtime} should ${skipped ? '' : 'not '}report`);
+	}
+});
+
+test('with no source time there is nothing to decide on yet', async () => {
+	const { vault, subject, ctx } = importer(DuplicateHandling.Update);
+	await vault.create('Note.md', 'here');
+
+	assert.equal(subject.preflight(ctx, subject.planNote(vault.root, 'Note')), 'compare-content');
+	assert.deepEqual(ctx.skipped, [], 'nothing has been decided, so nothing should be reported');
+});
+
+test('"Skip" settles it at preflight, so the markdown need never be made', async () => {
+	const { vault, subject, ctx } = importer(DuplicateHandling.Skip);
+	await vault.create('Note.md', 'here');
+
+	assert.equal(subject.preflight(ctx, subject.planNote(vault.root, 'Note')), 'skip');
+	assert.deepEqual(ctx.skipped, ['Note']);
+});
+
+test('an answer preflight already gave is acted on rather than asked again', async () => {
+	const { vault, subject, ctx } = importer(DuplicateHandling.Update);
+	await vault.create('Note.md', 'here', { mtime: 2_000 });
+
+	const planned = subject.planNote(vault.root, 'Note');
+	const disposition = subject.preflight(ctx, planned, 2_000);
+	const { written, outcome } = await subject.writePlannedNote(ctx, planned, 'converted anyway', { disposition });
+
+	assert.equal(written, false);
+	assert.equal(outcome, 'unchanged');
+	assert.equal(vault.contents.get('Note.md'), 'here');
+	assert.equal(ctx.skipped.length, 1, 'preflight reported it, so the write should not report it again');
+});
+
+test('every outcome a write can end in', async () => {
+	const created = importer(DuplicateHandling.Update);
+	assert.equal((await created.subject.writePlannedNote(
+		created.ctx, created.subject.planNote(created.vault.root, 'Note'), 'body')).outcome, 'created');
+
+	const updated = importer(DuplicateHandling.Update);
+	await updated.vault.create('Note.md', 'old', { mtime: 1_000 });
+	assert.equal((await updated.subject.writePlannedNote(
+		updated.ctx, updated.subject.planNote(updated.vault.root, 'Note'), 'new', { mtime: 2_000 })).outcome, 'updated');
+
+	const skipped = importer(DuplicateHandling.Skip);
+	await skipped.vault.create('Note.md', 'old');
+	assert.equal((await skipped.subject.writePlannedNote(
+		skipped.ctx, skipped.subject.planNote(skipped.vault.root, 'Note'), 'new')).outcome, 'skipped');
+
+	const unchanged = importer(DuplicateHandling.Update);
+	await unchanged.vault.create('Note.md', 'old', { mtime: 2_000 });
+	assert.equal((await unchanged.subject.writePlannedNote(
+		unchanged.ctx, unchanged.subject.planNote(unchanged.vault.root, 'Note'), 'new', { mtime: 2_000 })).outcome, 'unchanged');
+
+	const preserved = importer(DuplicateHandling.Update);
+	await preserved.vault.create('Note.md', 'edited by hand', { mtime: 3_000 });
+	assert.equal((await preserved.subject.writePlannedNote(
+		preserved.ctx, preserved.subject.planNote(preserved.vault.root, 'Note'), 'new', { mtime: 2_000 })).outcome, 'preserved');
+	assert.equal(preserved.vault.contents.get('Note.md'), 'edited by hand');
+});

--- a/tests/write/plan-note.test.ts
+++ b/tests/write/plan-note.test.ts
@@ -71,24 +71,73 @@ test('a note the user moved is planned where it now is, not where it would have 
 	assert.equal(planned.file?.path, 'Archive/Note.md');
 });
 
-test('the first of several ids is the one written onto the note', async () => {
+const KNOWN_AS = { id: 'appBase:rec1', formerly: ['rec1'] };
+
+test('the id written onto a note is the one it is known by now', async () => {
 	const { vault, subject, ctx } = importer(DuplicateHandling.Update, 'airtable-id');
 
-	const planned = subject.planNote(vault.root, 'Note', ['appBase:rec1', 'rec1']);
+	const planned = subject.planNote(vault.root, 'Note', KNOWN_AS);
 	await subject.writePlannedNote(ctx, planned, 'body');
 
 	assert.match(String(vault.contents.get('Note.md')), /airtable-id: appBase:rec1/);
 });
 
-test('but a note carrying any of them is recognised as the same note', async () => {
+test('a note carrying the id it used to be known by is recognised where it was left', async () => {
+	const { vault, subject } = importer(DuplicateHandling.Update, 'airtable-id');
+	await vault.create('Note.md', '---\nairtable-id: rec1\n---\nwritten by an older version\n');
+	subject.indexImportedNotes();
+
+	const planned = subject.planNote(vault.root, 'Note', KNOWN_AS);
+
+	assert.equal(planned.file?.path, 'Note.md');
+});
+
+test('and rewriting it is what stops it being known by the ambiguous one', async () => {
+	const { vault, subject, ctx } = importer(DuplicateHandling.Update, 'airtable-id');
+	await vault.create('Note.md', '---\nairtable-id: rec1\n---\nwritten by an older version\n');
+	subject.indexImportedNotes();
+
+	const planned = subject.planNote(vault.root, 'Note', KNOWN_AS);
+	await subject.writePlannedNote(ctx, planned, 'brought up to date');
+
+	assert.match(String(vault.contents.get('Note.md')), /airtable-id: appBase:rec1/);
+});
+
+// Two sources may each claim it: the id that was written is the one that
+// could not tell them apart. At the expected path there is nothing to be
+// wrong about, but a note that has moved could have come from either.
+test('but the same note moved away is left alone rather than guessed at', async () => {
 	const { vault, subject } = importer(DuplicateHandling.Update, 'airtable-id');
 	await vault.createFolder('Elsewhere');
 	await vault.create('Elsewhere/Note.md', '---\nairtable-id: rec1\n---\nwritten by an older version\n');
 	subject.indexImportedNotes();
 
-	const planned = subject.planNote(vault.root, 'Note', ['appBase:rec1', 'rec1']);
+	const planned = subject.planNote(vault.root, 'Note', KNOWN_AS);
 
-	assert.equal(planned.file?.path, 'Elsewhere/Note.md');
+	assert.equal(planned.file, null);
+	assert.equal(planned.targetPath, 'Note.md');
+});
+
+test('a note carrying the id in use is recognised wherever it went', async () => {
+	const { vault, subject } = importer(DuplicateHandling.Update, 'airtable-id');
+	await vault.createFolder('Elsewhere');
+	await vault.create('Elsewhere/Note.md', '---\nairtable-id: appBase:rec1\n---\nmoved\n');
+	subject.indexImportedNotes();
+
+	assert.equal(subject.planNote(vault.root, 'Note', KNOWN_AS).file?.path, 'Elsewhere/Note.md');
+});
+
+test('a note this run has already planned onto is not planned onto twice', async () => {
+	const { vault, subject } = importer(DuplicateHandling.Update, 'airtable-id');
+	await vault.create('Note.md', 'a note from before ids were recorded\n');
+	subject.indexImportedNotes();
+
+	const first = subject.planNote(vault.root, 'Note', { id: 'appBase:rec1' });
+	const second = subject.planNote(vault.root, 'Note', { id: 'appBase:rec2' });
+
+	assert.equal(first.file?.path, 'Note.md');
+	assert.equal(second.file, null, 'the second record cannot have the note the first took');
+	assert.equal(second.targetPath, 'Note 1.md');
 });
 
 test('what preflight makes of a note nothing matches', () => {

--- a/tests/write/plan-note.test.ts
+++ b/tests/write/plan-note.test.ts
@@ -71,69 +71,13 @@ test('a note the user moved is planned where it now is, not where it would have 
 	assert.equal(planned.file?.path, 'Archive/Note.md');
 });
 
-const KNOWN_AS = { id: 'appBase:rec1', formerly: ['rec1'] };
-
-test('the id written onto a note is the one it is known by now', async () => {
-	const { vault, subject, ctx } = importer(DuplicateHandling.Update, 'airtable-id');
-
-	const planned = subject.planNote(vault.root, 'Note', KNOWN_AS);
-	await subject.writePlannedNote(ctx, planned, 'body');
-
-	assert.match(String(vault.contents.get('Note.md')), /airtable-id: appBase:rec1/);
-});
-
-test('a note carrying the id it used to be known by is recognised where it was left', async () => {
-	const { vault, subject } = importer(DuplicateHandling.Update, 'airtable-id');
-	await vault.create('Note.md', '---\nairtable-id: rec1\n---\nwritten by an older version\n');
-	subject.indexImportedNotes();
-
-	const planned = subject.planNote(vault.root, 'Note', KNOWN_AS);
-
-	assert.equal(planned.file?.path, 'Note.md');
-});
-
-test('and rewriting it is what stops it being known by the ambiguous one', async () => {
-	const { vault, subject, ctx } = importer(DuplicateHandling.Update, 'airtable-id');
-	await vault.create('Note.md', '---\nairtable-id: rec1\n---\nwritten by an older version\n');
-	subject.indexImportedNotes();
-
-	const planned = subject.planNote(vault.root, 'Note', KNOWN_AS);
-	await subject.writePlannedNote(ctx, planned, 'brought up to date');
-
-	assert.match(String(vault.contents.get('Note.md')), /airtable-id: appBase:rec1/);
-});
-
-// Two sources may each claim it: the id that was written is the one that
-// could not tell them apart. At the expected path there is nothing to be
-// wrong about, but a note that has moved could have come from either.
-test('but the same note moved away is left alone rather than guessed at', async () => {
-	const { vault, subject } = importer(DuplicateHandling.Update, 'airtable-id');
-	await vault.createFolder('Elsewhere');
-	await vault.create('Elsewhere/Note.md', '---\nairtable-id: rec1\n---\nwritten by an older version\n');
-	subject.indexImportedNotes();
-
-	const planned = subject.planNote(vault.root, 'Note', KNOWN_AS);
-
-	assert.equal(planned.file, null);
-	assert.equal(planned.targetPath, 'Note.md');
-});
-
-test('a note carrying the id in use is recognised wherever it went', async () => {
-	const { vault, subject } = importer(DuplicateHandling.Update, 'airtable-id');
-	await vault.createFolder('Elsewhere');
-	await vault.create('Elsewhere/Note.md', '---\nairtable-id: appBase:rec1\n---\nmoved\n');
-	subject.indexImportedNotes();
-
-	assert.equal(subject.planNote(vault.root, 'Note', KNOWN_AS).file?.path, 'Elsewhere/Note.md');
-});
-
 test('a note this run has already planned onto is not planned onto twice', async () => {
 	const { vault, subject } = importer(DuplicateHandling.Update, 'airtable-id');
 	await vault.create('Note.md', 'a note from before ids were recorded\n');
 	subject.indexImportedNotes();
 
-	const first = subject.planNote(vault.root, 'Note', { id: 'appBase:rec1' });
-	const second = subject.planNote(vault.root, 'Note', { id: 'appBase:rec2' });
+	const first = subject.planNote(vault.root, 'Note', 'rec1');
+	const second = subject.planNote(vault.root, 'Note', 'rec2');
 
 	assert.equal(first.file?.path, 'Note.md');
 	assert.equal(second.file, null, 'the second record cannot have the note the first took');

--- a/tests/write/plan-note.test.ts
+++ b/tests/write/plan-note.test.ts
@@ -84,6 +84,18 @@ test('a note this run has already planned onto is not planned onto twice', async
 	assert.equal(second.targetPath, 'Note 1.md');
 });
 
+// A note is planned before it is written, so the name it is holding is not
+// free even though the vault has nothing at it yet.
+test('an attachment is not given a name a note is waiting to be written under', async () => {
+	const { vault, subject } = importer(DuplicateHandling.Update);
+
+	const planned = subject.planNote(vault.root, 'notes');
+	const attachment = await subject.getAvailablePathForAttachment('notes.md', [], 'Somewhere.md');
+
+	assert.equal(planned.targetPath, 'notes.md');
+	assert.notEqual(attachment, 'notes.md');
+});
+
 test('what preflight makes of a note nothing matches', () => {
 	const { vault, subject, ctx } = importer(DuplicateHandling.Update);
 

--- a/tests/write/plan-note.test.ts
+++ b/tests/write/plan-note.test.ts
@@ -71,6 +71,26 @@ test('a note the user moved is planned where it now is, not where it would have 
 	assert.equal(planned.file?.path, 'Archive/Note.md');
 });
 
+test('the first of several ids is the one written onto the note', async () => {
+	const { vault, subject, ctx } = importer(DuplicateHandling.Update, 'airtable-id');
+
+	const planned = subject.planNote(vault.root, 'Note', ['appBase:rec1', 'rec1']);
+	await subject.writePlannedNote(ctx, planned, 'body');
+
+	assert.match(String(vault.contents.get('Note.md')), /airtable-id: appBase:rec1/);
+});
+
+test('but a note carrying any of them is recognised as the same note', async () => {
+	const { vault, subject } = importer(DuplicateHandling.Update, 'airtable-id');
+	await vault.createFolder('Elsewhere');
+	await vault.create('Elsewhere/Note.md', '---\nairtable-id: rec1\n---\nwritten by an older version\n');
+	subject.indexImportedNotes();
+
+	const planned = subject.planNote(vault.root, 'Note', ['appBase:rec1', 'rec1']);
+
+	assert.equal(planned.file?.path, 'Elsewhere/Note.md');
+});
+
 test('what preflight makes of a note nothing matches', () => {
 	const { vault, subject, ctx } = importer(DuplicateHandling.Update);
 

--- a/tests/write/write-note.test.ts
+++ b/tests/write/write-note.test.ts
@@ -88,6 +88,8 @@ test('"Update" does not write over work done in Obsidian since the import', asyn
 	assert.equal(vault.contents.get('Note.md'), 'edited by hand');
 });
 
+// Once per import, because a name written twice in one import is two source
+// notes sharing a title rather than one note being reconsidered.
 test('with no time to go on, "Update" compares the text instead', async () => {
 	const { vault, subject, ctx } = importer(DuplicateHandling.Update);
 	await vault.create('Note.md', 'same text');
@@ -95,6 +97,7 @@ test('with no time to go on, "Update" compares the text instead', async () => {
 	const unchanged = await subject.writeNote(ctx, vault.root, 'Note', 'same text');
 	assert.equal(unchanged.written, false);
 
+	subject.indexImportedNotes();
 	const changed = await subject.writeNote(ctx, vault.root, 'Note', 'different text');
 	assert.equal(changed.written, true);
 	assert.equal(vault.contents.get('Note.md'), 'different text');


### PR DESCRIPTION
Adds the **Update** option to the Notion and Airtable API importers.

Both importers now use the shared note-planning and writing path, while still choosing each note’s final path before conversion. This is required because Notion resolves links and attachments against that path, while Airtable plans record paths in advance for cross-record links.

## Behavior

### Notion

- Matches previously imported notes using `notion-id`, including notes the user moved or renamed.
- Uses Notion’s `last_edited_time` to distinguish:
  - unchanged source pages;
  - pages changed in Notion;
  - notes edited locally since the previous import.
- Updates notes in place without moving them back to their original import location.
- Avoids downloading page attachments when a note is being skipped.
- Gives synced-block notes stable source identity and applies the same duplicate-handling protections as regular pages.
- Recovers notes and unresolved placeholders left by interrupted imports.
- Prevents repeated imports from accumulating numbered synced-block notes.

### Airtable

- Matches records using a base-qualified identity: `baseId:recordId`.
- Continues recognizing notes written by older versions using the bare record ID.
- Updates moved or renamed record notes in place.
- Writes note `ctime` from Airtable’s `createdTime`.
- Reuses attachments already imported for the same record.

Airtable does not provide a reliable record modification time. Update therefore compares the rendered record with the existing note. This means it cannot distinguish a source change from a local edit: if the content differs, the note is rewritten. The setting description calls this limitation out explicitly.

## Shared implementation

Introduces a two-phase note-writing flow:

1. `planNote` determines the desired and actual path, matches prior imports, and claims the path for the run.
2. `preflightNote` decides whether conversion can be skipped.
3. `writePlannedNote` applies Create copy, Skip, Update, unchanged, and locally-preserved outcomes consistently.

The existing `writeNote` API now delegates to these primitives, keeping other importers on the same behavior.

## `.base` files

The **Existing notes** setting applies only to notes.

- Notion continues regenerating its `.base` files from the current database schema.
- Airtable regenerates imported views while retaining named views that are not present in the new import.