### PR TITLE
Refine import template documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ Import guides are hosted on the [official Obsidian Help site](https://obsidian.m
 - Import from Apple Journal (HTML export)
 - Import from Tomboy/Gnote (.note)
 
-See [Import templates](/docs/templates.md) for the shared template variables
-and the additional values provided by each importer.
+See [Import templates](/docs/templates.md) for the shared template variables and the additional values provided by each importer.
 
 ## Developers
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,41 +1,18 @@
 # Import templates
 
-Every note importer has a Markdown template preview step. The importer starts
-with a generated template, so a template file is not required. The rendered
-preview shows how imported notes will appear, including their Properties panel
-and any source ID property enabled in the importer's output settings. Previous
-and Next switch between up to ten examples from the user's selection. Previewing
-does not write or place attachments; formats that cannot fully resolve an
-attachment or nested remote item show the source link or a placeholder instead.
-An existing Markdown (`.md`) template in the current vault can replace the
-generated template for this import.
+Every note importer has a Markdown template preview step. The importer starts with a generated template, so a template file is not required. The rendered preview shows how imported notes will appear, including their Properties panel and any source ID property enabled in the importer's output settings. Previous and Next switch between up to ten examples from the user's selection. Previewing does not write or place attachments; formats that cannot fully resolve an attachment or nested remote item show the source link or a placeholder instead. An existing Markdown (`.md`) template in the current vault can replace the generated template for this import.
 
-When **Save … ID** is enabled, Edit shows the importer ID as a managed property,
-for example `bear-id: {{id}}`. The property name is editable and remembered;
-the `{{id}}` value is disabled because the importer supplies it for each note.
-The managed row is applied during import rather than written into the selected
-template file.
+When **Save … ID** is enabled, Edit shows the importer ID as a managed property, for example `bear-id: {{id}}`. The property name is editable and remembered; the `{{id}}` value is disabled because the importer supplies it for each note. The managed row is applied during import rather than written into the selected template file.
 
-Templates use the shared Knap language, including filters, conditionals, loops,
-and assignments. The default template for most importers is `{{content}}`, which
-keeps the importer's generated Markdown unchanged.
+Templates use the shared Knap language and the same [variable syntax](https://obsidian.md/help/web-clipper/variables), [filters](https://obsidian.md/help/web-clipper/filters), and [template logic](https://obsidian.md/help/web-clipper/logic) as Obsidian Web Clipper. Importers expose a different set of variables, documented below. The default template for most importers is `{{content}}`, which keeps the importer's generated Markdown unchanged.
 
-The Files importer is excluded because it copies existing files without
-rewriting their contents.
+The Files importer is excluded because it copies existing files without rewriting their contents.
 
-CSV generates a template from its headers. Each header becomes a variable and,
-by default, a frontmatter property. Its first row is used for the preview. The
-generated template uses bracket notation so punctuation in a header is safe,
-for example `{{source["Project: status"]}}`. It uses the shared `yaml` filter
-to serialize each cell as a YAML scalar, for example
-`Status: {{source["Status"] | yaml}}`. **Note title** and **Note location** are
-configured on this same template page and use Knap syntax, including filters
-and logic.
+CSV generates a template from its headers. Each header becomes a variable and, by default, a frontmatter property. Its first row is used for the preview. The generated template uses bracket notation so punctuation in a header is safe, for example `{{source["Project: status"]}}`. It uses the shared `yaml` filter to serialize each cell as a YAML scalar, for example `Status: {{source["Status"] | yaml}}`. **Note title** and **Note location** are configured on this same template page and use Knap syntax, including filters and logic.
 
 ## Importer filters
 
-All importers can use the standard Knap and HTML filters, plus these
-Importer-provided filters:
+In addition to the standard Web Clipper filters, importers provide these filters:
 
 | Filter | Description |
 | --- | --- |
@@ -65,12 +42,9 @@ These variables are available to every note importer.
 | `{{date}}` | Current date and time when the template is rendered, as an ISO 8601 timestamp. |
 | `{{time}}` | Alias for `{{date}}`. |
 
-Generated frontmatter properties and importer-specific values are also exposed
-as top-level variables for convenience. Shared names take precedence. A source
-value that collides with a shared name remains available below `{{source}}`.
+Generated frontmatter properties and importer-specific values are also exposed as top-level variables for convenience. Shared names take precedence. A source value that collides with a shared name remains available below `{{source}}`.
 
-For example, a source property named `content` is available as
-`{{source.content}}`, while `{{content}}` remains the complete generated note.
+For example, a source property named `content` is available as `{{source.content}}`, while `{{content}}` remains the complete generated note.
 
 ## Importer-specific variables
 
@@ -84,15 +58,9 @@ For example, a source property named `content` is available as
 | Apple Notes | `originalTitle`, containing the title stored by Apple Notes before note-title templating or filename sanitization. Shared `ctime`, `mtime`, and `sourceId` provide its creation time, modification time, and identifier. |
 | Apple Journal, Bear, Evernote, Markdown, Notion, OneNote, Roam, and Textbundle | No additional stable variables. Any properties generated by the importer are available directly and below `properties` and `source`. |
 
-CSV and Airtable variable names depend on the imported table. Defuddle can add
-extractor-specific HTML variables—for example, a transcript when the selected
-extractor returns one—so that set can grow independently of Importer releases.
+CSV and Airtable variable names depend on the imported table. Defuddle can add extractor-specific HTML variables—for example, a transcript when the selected extractor returns one—so that set can grow independently of Importer releases.
 
-Apple Notes also has a **Note title** setting on the template page. It uses the
-same Knap syntax, so `{{title}}`, `{{date}} {{title}}`, and
-`{{ctime | date:"YYYY-MM-DD"}} {{title}}` are all valid. The default is
-`{{title}}`. A saved filename date prefix from an earlier importer version is
-automatically converted to the equivalent `ctime` expression.
+Apple Notes also has a **Note title** setting on the template page. It uses the same Knap syntax, so `{{title}}`, `{{date}} {{title}}`, and `{{ctime | date:"YYYY-MM-DD"}} {{title}}` are all valid. The default is `{{title}}`. A saved filename date prefix from an earlier importer version is automatically converted to the equivalent `ctime` expression.
 
 ## Examples
 

--- a/locale/README.md
+++ b/locale/README.md
@@ -19,9 +19,7 @@ run. To add or edit one by hand:
 A regional code falls back to its base language, so `pt-BR` is used for a reader
 set to `pt-BR`, and `pt` covers the rest.
 
-A file is named the way Help names the language, which is the app's code but for
-Khmer: Help and ISO 639 spell it `km`, while Obsidian's own table is `kh`. The
-plugin translates the one into the other, so `km.txt` is the file to edit.
+A file is named the way Help names the language, which is the app's code but for Khmer: Help and ISO 639 spell it `km`, while Obsidian's own table is `kh`. The plugin translates the one into the other, so `km.txt` is the file to edit.
 
 ## Automated updates
 


### PR DESCRIPTION
- Remove hard wrapping from the new Markdown documentation.
- Link importer templates to the shared Web Clipper variable, filter, and logic references.
- Clarify that importers expose their own variable set.