### PR TITLE
Normalize Obsidian list properties

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ Imports notes from other apps into an Obsidian vault.
 - `src/importer-setting-tab.ts` — The same flow, shown in Settings
 - `src/progress-ui.ts` — `ImportProgressUI`: the progress screen an `ImportContext` drives
 - `src/format-importer.ts` — Base class every importer extends: file pickers, output folder, attachment paths
+- `src/list-properties.ts` — Final normalization for Obsidian's built-in list properties
 - `src/formats/<name>.ts` — One importer per format; the vault-facing half
 - `src/formats/<name>/` — The conversion, extracted so it runs without a vault (see below)
 - `src/filesystem.ts` — The only place node modules are reached, and the seam tests inject through
@@ -160,6 +161,12 @@ shared tree does not represent, so it may require a format-specific parser.
 ## Fixtures and recorded output
 
 Every importer is tested by converting a real file and comparing against a recorded output committed beside it.
+
+Recordings describe the note that lands in the vault. Every Markdown note shown
+in preview or written by `FormatImporter` passes through
+`normalizeListProperties`; a conversion harness whose output is changed by that
+final step must apply it too, so its recording does not stop short of the write
+boundary.
 
 ```
 tests/notion/Export-xyz.zip              fixture

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -6,6 +6,8 @@ When **Save … ID** is enabled, Edit shows the importer ID as a managed propert
 
 Templates use the shared Knap language and the same [variable syntax](https://obsidian.md/help/web-clipper/variables), [filters](https://obsidian.md/help/web-clipper/filters), and [template logic](https://obsidian.md/help/web-clipper/logic) as Obsidian Web Clipper. Importers expose a different set of variables, documented below. The default template for most importers is `{{content}}`, which keeps the importer's generated Markdown unchanged.
 
+Before previewing or writing any imported Markdown note, Importer enforces Obsidian's built-in list types for `tags`, `aliases`, and `cssclasses`. This applies both to importer-generated frontmatter and properties produced by a custom template. Empty properties stay empty. Populated tags and CSS classes split on spaces or commas; aliases split on commas or newlines; leading `#` characters are removed from tags. A bracketed list can preserve a comma inside an alias, for example `["Doe, John", "John Doe"]`.
+
 The Files importer is excluded because it copies existing files without rewriting their contents.
 
 CSV generates a template from its headers. Each header becomes a variable and, by default, a frontmatter property. Its first row is used for the preview. The generated template uses bracket notation so punctuation in a header is safe, for example `{{source["Project: status"]}}`. It uses the shared `yaml` filter to serialize each cell as a YAML scalar, for example `Status: {{source["Status"] | yaml}}`. **Note title** and **Note location** are configured on this same template page and use Knap syntax, including filters and logic.

--- a/src/format-importer.ts
+++ b/src/format-importer.ts
@@ -5,6 +5,7 @@ import { AuthCallback, helpUrl } from './constants';
 import { FolderSuggest } from './folder-suggest';
 import { ImportContext } from './import-context';
 import { formatImportReport, importReportName } from './import-report';
+import { normalizeListProperties } from './list-properties';
 import { createMarkdown, formattedMarkdown, MarkdownFormatting, MarkdownLinkResolver, modifyMarkdown, standardizedMarkdown, standardizeMarkdownFile } from './markdown-output';
 import { i18n } from './i18n';
 import { NoteTemplateVariables, renderNoteTemplate, renderNoteTemplateResult } from './note-template';
@@ -552,6 +553,7 @@ export abstract class FormatImporter {
 		const result = await renderNoteTemplateResult(template, variables);
 		let content = this.withGeneratedProperties(result.output, sample.generatedProperties);
 		content = this.withSourceId(content, sample.sourceId);
+		content = normalizeListProperties(content);
 		return {
 			label: title,
 			path: targetPath,
@@ -1897,13 +1899,17 @@ export abstract class FormatImporter {
 	}
 
 	async createMarkdown(path: string, content: string, options?: DataWriteOptions): Promise<TFile> {
-		const file = await createMarkdown(this.vault, path, content, options, this.markdownFormatting);
+		const file = await createMarkdown(
+			this.vault, path, normalizeListProperties(content), options, this.markdownFormatting
+		);
 		this.trackMarkdownFile(file);
 		return file;
 	}
 
 	async modifyMarkdown(file: TFile, content: string, options?: DataWriteOptions): Promise<void> {
-		await modifyMarkdown(this.vault, file, content, options, this.markdownFormatting);
+		await modifyMarkdown(
+			this.vault, file, normalizeListProperties(content), options, this.markdownFormatting
+		);
 		this.trackMarkdownFile(file);
 	}
 

--- a/src/list-properties.ts
+++ b/src/list-properties.ts
@@ -1,0 +1,114 @@
+import { parseFrontMatterBlock, serializeFrontMatter } from './util';
+
+type ListProperty = 'aliases' | 'cssclasses' | 'tags';
+
+function unquoteListItem(value: string): string {
+	const trimmed = value.trim();
+	if (trimmed.length < 2 || trimmed[0] !== trimmed.at(-1)) return trimmed;
+	if (trimmed.startsWith('\'')) return trimmed.slice(1, -1).replace(/''/gu, '\'');
+	if (!trimmed.startsWith('"')) return trimmed;
+	try {
+		const parsed: unknown = JSON.parse(trimmed);
+		return typeof parsed === 'string' ? parsed : trimmed;
+	}
+	catch {
+		return trimmed.slice(1, -1).replace(/\\(["\\])/gu, '$1');
+	}
+}
+
+function splitFlowList(body: string): string[] | null {
+	const items: string[] = [];
+	let start = 0;
+	let quote = '';
+	let escaped = false;
+	let itemStart = true;
+	for (let index = 0; index < body.length; index++) {
+		const character = body[index];
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+		if (quote) {
+			if (quote === '"' && character === '\\') escaped = true;
+			else if (character === quote) {
+				if (quote === '\'' && body[index + 1] === '\'') index++;
+				else quote = '';
+			}
+			continue;
+		}
+		if (itemStart && (character === '"' || character === '\'')) {
+			quote = character;
+			itemStart = false;
+		}
+		else if (character === ',') {
+			items.push(unquoteListItem(body.slice(start, index)));
+			start = index + 1;
+			itemStart = true;
+		}
+		else if (!/\s/u.test(character)) itemStart = false;
+	}
+	if (quote) return null;
+	items.push(unquoteListItem(body.slice(start)));
+	return items;
+}
+
+function stringList(value: string, property: ListProperty): string[] {
+	const trimmed = value.trim();
+	if (!trimmed) return [];
+	const flowBody = trimmed.startsWith('[') && trimmed.endsWith(']')
+		? trimmed.slice(1, -1)
+		: null;
+	const flowValues = flowBody === null ? null : splitFlowList(flowBody);
+	let values = flowValues
+		?? (flowBody ?? trimmed).split(property === 'aliases' ? /[\n,]+/u : /[\s,]+/u);
+	if (flowValues && property !== 'aliases') {
+		values = values.flatMap(item => item.split(/[\s,]+/u));
+	}
+	return values;
+}
+
+function listPropertyValues(value: unknown, property: ListProperty): string[] | null {
+	let values: string[];
+	if (typeof value === 'string') values = stringList(value, property);
+	else if (Array.isArray(value)) {
+		if (value.some(item => item !== null && typeof item === 'object')) return null;
+		values = value.filter(item => item !== null && item !== undefined).map(String);
+		if (property !== 'aliases') values = values.flatMap(item => item.split(/[\s,]+/u));
+	}
+	else if (value === null || value === undefined) values = [];
+	else if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+		values = [String(value)];
+	}
+	else return null;
+
+	return values
+		.map(item => item.trim())
+		.map(item => property === 'tags' ? item.replace(/^#+/u, '') : item)
+		.filter(Boolean);
+}
+
+function isSameStringList(value: unknown, normalized: string[]): boolean {
+	return Array.isArray(value)
+		&& value.length === normalized.length
+		&& value.every((item, index) => item === normalized[index]);
+}
+
+/** Enforce Obsidian's built-in list-property types on a complete Markdown note. */
+export function normalizeListProperties(content: string): string {
+	const parsed = parseFrontMatterBlock(content);
+	if (!parsed) return content;
+
+	const frontMatter = { ...parsed.frontMatter };
+	let changed = false;
+	for (const [key, value] of Object.entries(frontMatter)) {
+		const property = key.toLowerCase();
+		if (property !== 'aliases' && property !== 'cssclasses' && property !== 'tags') continue;
+		if (value === null || value === undefined) continue;
+		const normalized = listPropertyValues(value, property);
+		if (normalized === null || isSameStringList(value, normalized)) continue;
+		frontMatter[key] = normalized;
+		changed = true;
+	}
+
+	return changed ? serializeFrontMatter(frontMatter) + parsed.body : content;
+}

--- a/tests/apple-notes/duplicates.test.ts
+++ b/tests/apple-notes/duplicates.test.ts
@@ -9,6 +9,7 @@ import * as nodeZlib from 'node:zlib';
 
 import { provideNodeModules } from '../../src/filesystem';
 import { DuplicateHandling } from '../../src/format-importer';
+import { parseFrontMatterBlock } from '../../src/util';
 import { importing } from './importing';
 import { NoteSpec } from './store';
 
@@ -63,6 +64,22 @@ test('and not written unless it was asked for', async () => {
 		finally {
 			run.close();
 		}
+	}
+});
+
+test('template list properties are normalized in the Apple Notes write path', async () => {
+	const run = await importing([SAME_TITLE[0]], DuplicateHandling.CreateCopy, {
+		inlineTemplate: '---\ntags: "#groceries #errands"\n---\n{{content}}',
+	});
+	try {
+		const file = await run.resolve(run.notePks[0]);
+		const content = String(run.vault.contents.get(file!.path));
+
+		assert.deepEqual(parseFrontMatterBlock(content)?.frontMatter.tags, ['groceries', 'errands']);
+		assert.match(content, /Milk/u);
+	}
+	finally {
+		run.close();
 	}
 });
 

--- a/tests/apple-notes/importing.ts
+++ b/tests/apple-notes/importing.ts
@@ -12,6 +12,12 @@ import { descriptor } from '../../src/formats/apple-notes/descriptor';
 import { MemoryVault } from '../shims/vault';
 import { buildStore, NoteSpec } from './store';
 
+class TestingAppleNotesImporter extends AppleNotesImporter {
+	useInlineTemplate(template: string): void {
+		this.inlineTemplate = template;
+	}
+}
+
 export function reporter() {
 	const skipped: string[] = [];
 	return {
@@ -29,13 +35,17 @@ export function reporter() {
 	};
 }
 
-export async function importing(notes: NoteSpec[], mode: DuplicateHandling, options: { saveSourceId?: boolean } = {}) {
+export async function importing(
+	notes: NoteSpec[],
+	mode: DuplicateHandling,
+	options: { inlineTemplate?: string; saveSourceId?: boolean } = {},
+) {
 	const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'importer-apple-notes-'));
 	const store = buildStore(nodePath.join(dir, 'NoteStore.sqlite'), { notes });
 
 	const vault = new MemoryVault();
 	const { ctx, skipped } = reporter();
-	const subject = new AppleNotesImporter(
+	const subject = new TestingAppleNotesImporter(
 		{ vault, loadLocalStorage: () => null, saveLocalStorage: () => {} } as never,
 		{ sourceEl: null, optionsEl: null } as never
 	);
@@ -46,6 +56,7 @@ export async function importing(notes: NoteSpec[], mode: DuplicateHandling, opti
 	subject.protobufRoot = Root.fromJSON(descriptor);
 	subject.duplicateHandling = mode;
 	subject.saveSourceId = options.saveSourceId ?? false;
+	if (options.inlineTemplate !== undefined) subject.useInlineTemplate(options.inlineTemplate);
 	subject.keys = Object.fromEntries(
 		(await store.database.all`SELECT z_ent, z_name FROM z_primarykey`).map(k => [k.Z_NAME, k.Z_ENT])
 	);

--- a/tests/csv/convert.test.ts
+++ b/tests/csv/convert.test.ts
@@ -13,6 +13,8 @@
  * newline inside a field, a doubled quote meaning one. comprehensive-test.csv
  * is built around exactly that, so its notes pin the behaviour.
  */
+import '../shims/runtime';
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import * as nodeFs from 'node:fs';
@@ -21,9 +23,10 @@ import * as nodePath from 'node:path';
 
 import { convertRow, defaultNoteTemplate, defaultTemplateConfig, sanitizeYAMLKey } from '../../src/formats/csv/convert';
 import { parseCSV, parseCSVLine, splitCSVLines } from '../../src/formats/csv/parse';
-import { sanitizeFileName } from '../../src/util';
+import { parseFrontMatterBlock, sanitizeFileName } from '../../src/util';
 import { renderNoteTemplate } from '../../src/note-template';
 import { applyTemplate } from '../../src/template';
+import { normalizeListProperties } from '../../src/list-properties';
 import { expectedFor, expectTree, fixtures } from '../helpers';
 
 const FIXTURES = __dirname;
@@ -36,14 +39,39 @@ test('there are fixtures to convert', () => {
 
 test('generates a Markdown template from CSV headers', () => {
 	assert.equal(defaultNoteTemplate(
-		['Name', 'Project: status', ''],
+		['Name', 'Project: status', 'Tags', 'ALIASES', 'cssclasses', ''],
 		sanitizeYAMLKey,
 	), [
 		'---',
 		'Name: {{source["Name"] | yaml}}',
 		'Project status: {{source["Project: status"] | yaml}}',
+		'Tags: {{source["Tags"] | yaml}}',
+		'ALIASES: {{source["ALIASES"] | yaml}}',
+		'cssclasses: {{source["cssclasses"] | yaml}}',
 		'---',
 	].join('\n'));
+});
+
+test('CSV defaults render Obsidian list properties as lists', async () => {
+	const headers = ['Title', 'Tags', 'Aliases', 'cssclasses'];
+	const source = {
+		Title: 'Example',
+		Tags: '#travel, #wishlist #reference',
+		Aliases: '["Doe, John", "John Doe"]',
+		cssclasses: 'wide, dashboard compact',
+	};
+
+	const rendered = await renderNoteTemplate(defaultNoteTemplate(headers, sanitizeYAMLKey), {
+		...source,
+		source,
+	});
+	const parsed = parseFrontMatterBlock(normalizeListProperties(rendered));
+	assert.deepEqual(parsed?.frontMatter, {
+		Title: 'Example',
+		Tags: ['travel', 'wishlist', 'reference'],
+		Aliases: ['Doe, John', 'John Doe'],
+		cssclasses: ['wide', 'dashboard', 'compact'],
+	});
 });
 
 test('CSV defaults resolve safe source expressions for punctuated headers', async () => {
@@ -75,11 +103,14 @@ for (const file of files) {
 				const note = convertRow(row, config);
 				if (!note.title.trim()) continue; // the importer skips these
 
-				// Written the way the importer would: through the same
-				// sanitiser, under the location the template produced.
+				// Written the way the importer would: through the shared final normalization
+				// and sanitiser, under the location the template produced.
 				const dir = note.location ? nodePath.join(produced, note.location) : produced;
 				nodeFs.mkdirSync(dir, { recursive: true });
-				nodeFs.writeFileSync(nodePath.join(dir, `${sanitizeFileName(note.title)}.md`), note.content);
+				nodeFs.writeFileSync(
+					nodePath.join(dir, `${sanitizeFileName(note.title)}.md`),
+					normalizeListProperties(note.content),
+				);
 			}
 
 			expectTree(produced, expectedFor(file, nodePath.basename(file.name, '.csv')), file.name);

--- a/tests/csv/expected/comprehensive-test/Boolean Test.md
+++ b/tests/csv/expected/comprehensive-test/Boolean Test.md
@@ -1,14 +1,16 @@
 ---
-Title: "Boolean Test"
-Category: "Settings"
-Subcategory: "Config"
-Author: 
-Date: "2024-01-22"
-Priority: "Medium"
+Title: Boolean Test
+Category: Settings
+Subcategory: Config
+Author:
+Date: 2024-01-22
+Priority: Medium
 Completed: false
 Rating: 5
-Tags: "config settings"
-Content: "Testing boolean values in various columns."
-Notes: 
+Tags:
+  - config
+  - settings
+Content: Testing boolean values in various columns.
+Notes:
 ---
 

--- a/tests/csv/expected/comprehensive-test/Meeting Notes.md
+++ b/tests/csv/expected/comprehensive-test/Meeting Notes.md
@@ -1,14 +1,20 @@
 ---
-Title: "Meeting Notes"
-Category: "Work"
-Subcategory: "Meetings"
-Author: "John Doe"
-Date: "2024-01-15"
-Priority: "High"
+Title: Meeting Notes
+Category: Work
+Subcategory: Meetings
+Author: John Doe
+Date: 2024-01-15
+Priority: High
 Completed: true
 Rating: 8.5
-Tags: "meeting planning"
-Content: "Discussed Q1 goals and objectives. Key points:\n- Revenue targets\n- Team expansion\n- New product launch"
-Notes: "Follow up next week"
+Tags:
+  - meeting
+  - planning
+Content: |-
+  Discussed Q1 goals and objectives. Key points:
+  - Revenue targets
+  - Team expansion
+  - New product launch
+Notes: Follow up next week
 ---
 

--- a/tests/csv/expected/comprehensive-test/Multi-line Content.md
+++ b/tests/csv/expected/comprehensive-test/Multi-line Content.md
@@ -1,14 +1,19 @@
 ---
-Title: "Multi-line Content"
-Category: "Work"
-Subcategory: "Documentation"
-Author: "Writer"
-Date: "2024-01-23"
-Priority: "High"
+Title: Multi-line Content
+Category: Work
+Subcategory: Documentation
+Author: Writer
+Date: 2024-01-23
+Priority: High
 Completed: true
 Rating: 9
-Tags: "docs"
-Content: "This is a multi-line\ncontent field that spans\nmultiple lines to test\nproper CSV parsing."
-Notes: "Important"
+Tags:
+  - docs
+Content: |-
+  This is a multi-line
+  content field that spans
+  multiple lines to test
+  proper CSV parsing.
+Notes: Important
 ---
 

--- a/tests/csv/expected/comprehensive-test/Note with quotes.md
+++ b/tests/csv/expected/comprehensive-test/Note with quotes.md
@@ -1,14 +1,16 @@
 ---
-Title: "Note with \"quotes\""
-Category: "Personal"
-Subcategory: "Misc"
-Author: "Test User"
-Date: "2024-01-17"
-Priority: "Low"
+Title: Note with "quotes"
+Category: Personal
+Subcategory: Misc
+Author: Test User
+Date: 2024-01-17
+Priority: Low
 Completed: true
 Rating: 7.5
-Tags: "test special"
-Content: "Content with \"escaped quotes\" inside."
-Notes: "Watch for edge cases"
+Tags:
+  - test
+  - special
+Content: Content with "escaped quotes" inside.
+Notes: Watch for edge cases
 ---
 

--- a/tests/csv/expected/comprehensive-test/Numbers Test.md
+++ b/tests/csv/expected/comprehensive-test/Numbers Test.md
@@ -1,14 +1,16 @@
 ---
-Title: "Numbers Test"
-Category: "Data"
-Subcategory: "Analysis"
-Author: 
-Date: "2024-01-21"
-Priority: "High"
+Title: Numbers Test
+Category: Data
+Subcategory: Analysis
+Author:
+Date: 2024-01-21
+Priority: High
 Completed: true
 Rating: 10
-Tags: "numbers data"
-Content: "Testing numeric values and dates."
-Notes: "Score is 10"
+Tags:
+  - numbers
+  - data
+Content: Testing numeric values and dates.
+Notes: Score is 10
 ---
 

--- a/tests/csv/expected/comprehensive-test/Project Plan.md
+++ b/tests/csv/expected/comprehensive-test/Project Plan.md
@@ -1,14 +1,23 @@
 ---
-Title: "Project Plan"
-Category: "Work"
-Subcategory: "Projects"
-Author: "Jane Smith"
-Date: "2024-01-16"
-Priority: "High"
+Title: Project Plan
+Category: Work
+Subcategory: Projects
+Author: Jane Smith
+Date: 2024-01-16
+Priority: High
 Completed: false
 Rating: 9
-Tags: "planning strategy"
-Content: "# Project Overview\n\nThis is a detailed project plan with markdown content.\n\n## Goals\n1. Complete phase 1\n2. Start phase 2"
-Notes: "Budget approved"
+Tags:
+  - planning
+  - strategy
+Content: |-
+  # Project Overview
+
+  This is a detailed project plan with markdown content.
+
+  ## Goals
+  1. Complete phase 1
+  2. Start phase 2
+Notes: Budget approved
 ---
 

--- a/tests/csv/expected/comprehensive-test/Simple Note.md
+++ b/tests/csv/expected/comprehensive-test/Simple Note.md
@@ -1,14 +1,15 @@
 ---
-Title: "Simple Note"
-Category: "Personal"
-Subcategory: "Ideas"
-Author: "Bob Wilson"
-Date: "2024-01-18"
-Priority: "Medium"
+Title: Simple Note
+Category: Personal
+Subcategory: Ideas
+Author: Bob Wilson
+Date: 2024-01-18
+Priority: Medium
 Completed: false
 Rating: 6
-Tags: "ideas"
-Content: "Just a simple note without complications."
-Notes: 
+Tags:
+  - ideas
+Content: Just a simple note without complications.
+Notes:
 ---
 

--- a/tests/csv/expected/comprehensive-test/Special Chars.md
+++ b/tests/csv/expected/comprehensive-test/Special Chars.md
@@ -1,14 +1,16 @@
 ---
-Title: "Special Chars"
-Category: "Tech"
-Subcategory: "Testing"
-Author: 
-Date: "2024-01-24"
-Priority: "Low"
+Title: Special Chars
+Category: Tech
+Subcategory: Testing
+Author:
+Date: 2024-01-24
+Priority: Low
 Completed: false
 Rating: 7
-Tags: "test special"
+Tags:
+  - test
+  - special
 Content: "Content with special characters: !@#$%^&*()_+-=[]{}|;:',.<>?"
-Notes: "Need validation"
+Notes: Need validation
 ---
 

--- a/tests/csv/expected/comprehensive-test/Unicode Test.md
+++ b/tests/csv/expected/comprehensive-test/Unicode Test.md
@@ -1,14 +1,16 @@
 ---
-Title: "Unicode Test"
-Category: "Work"
-Subcategory: "Testing"
-Author: "Test User"
-Date: "2024-01-19"
-Priority: "Low"
+Title: Unicode Test
+Category: Work
+Subcategory: Testing
+Author: Test User
+Date: 2024-01-19
+Priority: Low
 Completed: true
 Rating: 8
-Tags: "test unicode"
+Tags:
+  - test
+  - unicode
 Content: "Content with unicode: 你好世界 🌟 café"
-Notes: 
+Notes:
 ---
 

--- a/tests/csv/expected/sample/My First Note.md
+++ b/tests/csv/expected/sample/My First Note.md
@@ -1,10 +1,12 @@
 ---
-Title: "My First Note"
-Category: "Work"
-Tags: "project planning"
-Content: "This is the content of my first note."
-Date: "2024-01-15"
-Priority: 
+Title: My First Note
+Category: Work
+Tags:
+  - project
+  - planning
+Content: This is the content of my first note.
+Date: 2024-01-15
+Priority:
 Completed: true
 ---
 

--- a/tests/csv/expected/sample/Note with, comma.md
+++ b/tests/csv/expected/sample/Note with, comma.md
@@ -1,10 +1,11 @@
 ---
-Title: "Note with, comma"
-Category: "Work"
-Tags: "urgent"
-Content: "Content with special characters."
-Date: "2024-01-17"
-Priority: "Low"
+Title: Note with, comma
+Category: Work
+Tags:
+  - urgent
+Content: Content with special characters.
+Date: 2024-01-17
+Priority: Low
 Completed: true
 ---
 

--- a/tests/csv/expected/sample/Planning Document.md
+++ b/tests/csv/expected/sample/Planning Document.md
@@ -1,10 +1,15 @@
 ---
-Title: "Planning Document"
-Category: "Work"
-Tags: "planning strategy"
-Content: "Multi-line\ncontent goes\nhere."
-Date: "2024-01-18"
-Priority: "High"
+Title: Planning Document
+Category: Work
+Tags:
+  - planning
+  - strategy
+Content: |-
+  Multi-line
+  content goes
+  here.
+Date: 2024-01-18
+Priority: High
 Completed: false
 ---
 

--- a/tests/csv/expected/sample/Second Note.md
+++ b/tests/csv/expected/sample/Second Note.md
@@ -1,10 +1,12 @@
 ---
-Title: "Second Note"
-Category: "Personal"
-Tags: "ideas thoughts"
-Content: "Another note with some content here."
-Date: "2024-01-16"
-Priority: "Medium"
+Title: Second Note
+Category: Personal
+Tags:
+  - ideas
+  - thoughts
+Content: Another note with some content here.
+Date: 2024-01-16
+Priority: Medium
 Completed: false
 ---
 

--- a/tests/csv/expected/sample/Simple Note.md
+++ b/tests/csv/expected/sample/Simple Note.md
@@ -1,10 +1,11 @@
 ---
-Title: "Simple Note"
-Category: "Personal"
-Tags: "misc"
-Content: "Just a simple note."
-Date: "2024-01-19"
-Priority: "Medium"
+Title: Simple Note
+Category: Personal
+Tags:
+  - misc
+Content: Just a simple note.
+Date: 2024-01-19
+Priority: Medium
 Completed: true
 ---
 

--- a/tests/template/render.test.ts
+++ b/tests/template/render.test.ts
@@ -3,7 +3,9 @@ import '../shims/dom';
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
+import { normalizeListProperties } from '../../src/list-properties';
 import { renderNoteTemplate } from '../../src/note-template';
+import { parseFrontMatterBlock } from '../../src/util';
 
 test('registers Knap standard filters', async () => {
 	assert.equal(await renderNoteTemplate(
@@ -47,6 +49,46 @@ test('renders CSV values as YAML scalars', async () => {
 		'SKU: "0x1F"',
 		'Exponent: "1e5"',
 	].join('\n'));
+});
+
+test('normalizes Obsidian list properties after rendering', async () => {
+	const rendered = await renderNoteTemplate(
+		[
+			'---',
+			'Tags: {{tags | yaml}}',
+			'Aliases: {{aliases | yaml}}',
+			'cssclasses: {{classes | yaml}}',
+			'Other: {{other | yaml}}',
+			'---',
+		].join('\n'),
+		{
+			tags: '[#travel, #wishlist, 007]',
+			aliases: '[Don\'t, "Doe, John", Note: draft, 007]',
+			classes: 'wide, dashboard compact',
+			other: '[007, 2024]',
+		},
+	);
+	const parsed = parseFrontMatterBlock(normalizeListProperties(rendered));
+	assert.deepEqual(parsed?.frontMatter, {
+		Tags: ['travel', 'wishlist', '007'],
+		Aliases: ["Don't", 'Doe, John', 'Note: draft', '007'],
+		cssclasses: ['wide', 'dashboard', 'compact'],
+		Other: '[007, 2024]',
+	});
+});
+
+test('leaves empty Obsidian list properties byte-identical', () => {
+	const content = [
+		'---',
+		'Title: "Empty lists"',
+		'tags:',
+		'aliases:',
+		'cssclasses:',
+		'---',
+		'Body',
+	].join('\n');
+
+	assert.equal(normalizeListProperties(content), content);
 });
 
 test('resolves exact variable names before treating dots as nested paths', async () => {

--- a/tests/write/write-note.test.ts
+++ b/tests/write/write-note.test.ts
@@ -5,6 +5,7 @@ import assert from 'node:assert/strict';
 
 import { DuplicateHandling, FormatImporter } from '../../src/format-importer';
 import { ImportContext } from '../../src/import-context';
+import { parseFrontMatterBlock } from '../../src/util';
 import { MemoryVault, memoryApp } from '../shims/vault';
 
 class WritingImporter extends FormatImporter {
@@ -189,6 +190,45 @@ test('an inline template renders importer-specific source values', async () => {
 		'---',
 		'# Roadmap',
 	].join('\n'));
+});
+
+test('written notes automatically normalize Obsidian list properties', async () => {
+	const { vault, subject, ctx } = importer(DuplicateHandling.CreateCopy);
+	const { file } = await subject.writeNote(ctx, vault.root, 'Lists', [
+		'---',
+		'tags: "#travel, #wishlist 007"',
+		'aliases: "Ada Lovelace, Countess of Lovelace"',
+		'cssclasses: "wide dashboard"',
+		'ordinary: "one, two"',
+		'---',
+		'Body',
+	].join('\n'));
+	const parsed = parseFrontMatterBlock(String(vault.contents.get(file.path)));
+
+	assert.deepEqual(parsed?.frontMatter, {
+		tags: ['travel', 'wishlist', '007'],
+		aliases: ['Ada Lovelace', 'Countess of Lovelace'],
+		cssclasses: ['wide', 'dashboard'],
+		ordinary: 'one, two',
+	});
+	assert.equal(parsed?.body, 'Body');
+});
+
+test('template previews automatically normalize Obsidian list properties', async () => {
+	const { subject } = importer(DuplicateHandling.CreateCopy);
+	const preview = await subject.preview([
+		'---',
+		'tags: "#one #two"',
+		'aliases: "One, Two"',
+		'---',
+		'Body',
+	].join('\n'));
+	const parsed = parseFrontMatterBlock(preview.content);
+
+	assert.deepEqual(parsed?.frontMatter, {
+		tags: ['one', 'two'],
+		aliases: ['One', 'Two'],
+	});
 });
 
 test('the shared title template names the imported file with Knap variables and filters', async () => {


### PR DESCRIPTION
Automatically normalize tags, aliases, and cssclasses at preview and Markdown write boundaries. Preserve empty properties and cover CSV and Apple Notes output.

Closes #641 