### PR TITLE
Notion speedup

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 	"dependencies": {
 		"@joplin/turndown-plugin-gfm": "1.0.62",
 		"@notionhq/client": "5.20.0",
-		"@obsidianmd/knap": "^0.1.0",
+		"knap": "^0.2.1",
 		"@zip.js/zip.js": "2.7.60",
 		"airtable": "^0.12.2",
 		"defuddle": "^0.19.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@notionhq/client':
         specifier: 5.20.0
         version: 5.20.0
-      '@obsidianmd/knap':
-        specifier: ^0.1.0
-        version: 0.1.0
       '@zip.js/zip.js':
         specifier: 2.7.60
         version: 2.7.60
@@ -29,6 +26,9 @@ importers:
       defuddle:
         specifier: ^0.19.2
         version: 0.19.2
+      knap:
+        specifier: ^0.2.1
+        version: 0.2.1
       mathml-to-latex:
         specifier: ^1.5.0
         version: 1.5.0
@@ -366,10 +366,6 @@ packages:
   '@notionhq/client@5.20.0':
     resolution: {integrity: sha512-MS0DFSfHPLZ0wi+e9mOP16gCCYbWAkaiMuu/rVK9KxDlKac4oAgHReOfTglcd77g/nlg78snp+KB7fNWP75bEw==}
     engines: {node: '>=18'}
-
-  '@obsidianmd/knap@0.1.0':
-    resolution: {integrity: sha512-DabTnAL+u/UcuwbtW8LccwxEYZGzBsazPIMWhV8QyG7zvldDDApZovfLK2WB6Ep5H19CDJBLOft3Av4/lf0WiQ==}
-    engines: {node: '>=20'}
 
   '@parcel/watcher-android-arm64@2.6.0':
     resolution: {integrity: sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==}
@@ -1354,6 +1350,10 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  knap@0.2.1:
+    resolution: {integrity: sha512-5Bd4lrgsMhPMe+Uv2EGMozoM6ne+/Q7DpN2eOCmRUuIba0Z6ktd/uUvzqsqd24hlLWoIc122ypXpmFtrw+35Qg==}
+    engines: {node: '>=20'}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -2042,10 +2042,6 @@ snapshots:
   '@mixmark-io/domino@2.2.0': {}
 
   '@notionhq/client@5.20.0': {}
-
-  '@obsidianmd/knap@0.1.0':
-    dependencies:
-      dayjs: 1.11.23
 
   '@parcel/watcher-android-arm64@2.6.0':
     optional: true
@@ -3318,6 +3314,10 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  knap@0.2.1:
+    dependencies:
+      dayjs: 1.11.23
 
   levn@0.4.1:
     dependencies:

--- a/src/formats/notion-api.ts
+++ b/src/formats/notion-api.ts
@@ -31,16 +31,7 @@ const NOTION_REQUEST_RATE = 3;
 const NOTION_INITIAL_BURST = 100;
 const NOTION_SLOW_REQUEST_MS = 2_000;
 
-/**
- * Spend a modest burst before settling at Notion's documented average rate.
- *
- * Notion documents an average of three requests a second, with some bursts
- * allowed. Measured against a thousand-row database, short bursts completed
- * cleanly but sustained excess traffic eventually stopped receiving responses
- * instead of returning 429. A token bucket gets the useful part of both
- * behaviours: small imports can finish inside the burst, while long imports
- * converge on the documented rate before exhausting the server-side bucket.
- */
+/** Allows a short burst, then limits sustained traffic to Notion's documented rate. */
 export class NotionRequestScheduler {
 	private tail: Promise<void> = Promise.resolve();
 	private tokens: number;
@@ -101,14 +92,12 @@ export class NotionRequestScheduler {
 		}
 	}
 
-	/** A rate-limited response drains our local burst and honours Retry-After. */
 	rateLimited(retryAfter: string | undefined): void {
 		const seconds = retryAfter ? Number.parseInt(retryAfter, 10) : NaN;
 		this.overloaded(Number.isFinite(seconds) && seconds > 0 ? seconds * 1000 : 0);
 	}
 
-	/** A slow or timed-out request is the overload signal Notion often sends in
-	 * place of 429. Drain the burst globally so retries cannot keep piling on. */
+	/** Notion may stall instead of returning 429 when overloaded. */
 	overloaded(cooldownMs: number = 0): void {
 		this.tokens = 0;
 		const now = this.now();
@@ -121,17 +110,7 @@ export class NotionRequestScheduler {
 	}
 }
 
-/**
- * Keep one server-side budget across every SDK client made for a credential.
- *
- * The budget being spent is Notion's, held against the integration rather than
- * against anything this plugin owns, so the scheduler has to outlive whatever
- * asks for it. An importer does not: finishing an import returns to the format
- * list, and choosing a format there builds a new importer. A coordinator any
- * shorter-lived than the plugin would hand the next import a fresh burst to
- * spend against a bucket the last one already emptied - the state that makes
- * Notion stop answering rather than reply 429.
- */
+/** Shares Notion's integration-level request budget across importer instances. */
 export class NotionRequestCoordinator {
 	private token: string | null = null;
 	private scheduler: NotionRequestScheduler | null = null;
@@ -146,12 +125,9 @@ export class NotionRequestCoordinator {
 	}
 }
 
-/** Every import shares one budget, for as long as the plugin is loaded. */
 const requestCoordinator = new NotionRequestCoordinator();
 
-/** A slow request drains the burst while the original request remains alive.
- * requestUrl has no AbortSignal support, so rejecting early would only start a
- * retry beside the request that was still occupying the connection. */
+/** Detects overload without abandoning a request that requestUrl cannot cancel. */
 export async function watchForNotionOverload<T>(
 	request: Promise<T>,
 	scheduler: NotionRequestScheduler,
@@ -557,8 +533,7 @@ export class NotionAPIImporter extends FormatImporter {
 		this.notionClient = new Client({
 			auth: this.notionToken,
 			notionVersion: NOTION_VERSION,
-			// makeNotionRequest owns retries so an overload signal can slow every
-			// endpoint before the next attempt starts.
+			// Keep retries behind the shared scheduler.
 			retry: false,
 			fetch: async (url: RequestInfo | URL, init?: RequestInit) => {
 				const urlString = url instanceof URL ? url.href : typeof url === 'string' ? url : url.url;
@@ -1056,13 +1031,9 @@ export class NotionAPIImporter extends FormatImporter {
 		let reportedName = i18n.importer.notionApi.labelPage({ id: pageId });
 
 		try {
-			// What a page is and what is on it are two reads that do not need
-			// each other, so a page reached on its own asks for both at once
-			// rather than paying a round trip for the title before starting on
-			// the blocks. A row arrives with both already in hand.
 			const blocksRequest = prefetchedBlocks
 				?? fetchAllBlocks(this.notionClient!, pageId, ctx);
-			// Metadata failing reports the page before the blocks are awaited.
+			// Avoid an unhandled rejection if metadata fails first.
 			void blocksRequest.catch(() => undefined);
 
 			// Fetch page metadata with rate limit handling

--- a/src/formats/notion-api.ts
+++ b/src/formats/notion-api.ts
@@ -121,7 +121,17 @@ export class NotionRequestScheduler {
 	}
 }
 
-/** Keep one server-side budget across every SDK client made for a credential. */
+/**
+ * Keep one server-side budget across every SDK client made for a credential.
+ *
+ * The budget being spent is Notion's, held against the integration rather than
+ * against anything this plugin owns, so the scheduler has to outlive whatever
+ * asks for it. An importer does not: finishing an import returns to the format
+ * list, and choosing a format there builds a new importer. A coordinator any
+ * shorter-lived than the plugin would hand the next import a fresh burst to
+ * spend against a bucket the last one already emptied - the state that makes
+ * Notion stop answering rather than reply 429.
+ */
 export class NotionRequestCoordinator {
 	private token: string | null = null;
 	private scheduler: NotionRequestScheduler | null = null;
@@ -135,6 +145,9 @@ export class NotionRequestCoordinator {
 		return this.scheduler;
 	}
 }
+
+/** Every import shares one budget, for as long as the plugin is loaded. */
+const requestCoordinator = new NotionRequestCoordinator();
 
 /** A slow request drains the burst while the original request remains alive.
  * requestUrl has no AbortSignal support, so rejecting early would only start a
@@ -361,7 +374,6 @@ export class NotionAPIImporter extends FormatImporter {
 		return this.duplicateHandling !== DuplicateHandling.CreateCopy;
 	}
 	protected notionClient: Client | null = null;
-	private requestCoordinator = new NotionRequestCoordinator();
 	private processedPages: Set<string> = new Set();
 	private requestCount: number = 0;
 	// The total grows as databases and page blocks reveal more pages.
@@ -541,7 +553,7 @@ export class NotionAPIImporter extends FormatImporter {
 	 * Initialize Notion client if not already initialized
 	 */
 	private initializeNotionClient(): void {
-		const scheduler = this.requestCoordinator.forCredential(this.notionToken);
+		const scheduler = requestCoordinator.forCredential(this.notionToken);
 		this.notionClient = new Client({
 			auth: this.notionToken,
 			notionVersion: NOTION_VERSION,

--- a/src/formats/notion-api.ts
+++ b/src/formats/notion-api.ts
@@ -29,7 +29,6 @@ import { buildTree, collectItems, type NotionTreeNode } from './notion-api/disco
 
 const NOTION_REQUEST_RATE = 3;
 const NOTION_INITIAL_BURST = 100;
-const NOTION_REQUEST_TIMEOUT_MS = 10_000;
 const NOTION_SLOW_REQUEST_MS = 2_000;
 
 /**
@@ -117,8 +116,46 @@ export class NotionRequestScheduler {
 		this.lastRefill = Math.max(now, this.blockedUntil);
 	}
 
-	requestCompleted(durationMs: number): void {
-		if (durationMs >= NOTION_SLOW_REQUEST_MS) this.overloaded();
+	requestSlow(): void {
+		this.overloaded();
+	}
+}
+
+/** Keep one server-side budget across every SDK client made for a credential. */
+export class NotionRequestCoordinator {
+	private token: string | null = null;
+	private scheduler: NotionRequestScheduler | null = null;
+
+	forCredential(token: string): NotionRequestScheduler {
+		if (!this.scheduler || this.token !== token) {
+			this.token = token;
+			this.scheduler = new NotionRequestScheduler();
+		}
+
+		return this.scheduler;
+	}
+}
+
+/** A slow request drains the burst while the original request remains alive.
+ * requestUrl has no AbortSignal support, so rejecting early would only start a
+ * retry beside the request that was still occupying the connection. */
+export async function watchForNotionOverload<T>(
+	request: Promise<T>,
+	scheduler: NotionRequestScheduler,
+	timers: {
+		set: (callback: () => void, milliseconds: number) => number;
+		clear: (timer: number) => void;
+	} = {
+		set: (callback, milliseconds) => window.setTimeout(callback, milliseconds),
+		clear: timer => window.clearTimeout(timer),
+	},
+): Promise<T> {
+	const timer = timers.set(() => scheduler.requestSlow(), NOTION_SLOW_REQUEST_MS);
+	try {
+		return await request;
+	}
+	finally {
+		timers.clear(timer);
 	}
 }
 
@@ -324,6 +361,7 @@ export class NotionAPIImporter extends FormatImporter {
 		return this.duplicateHandling !== DuplicateHandling.CreateCopy;
 	}
 	protected notionClient: Client | null = null;
+	private requestCoordinator = new NotionRequestCoordinator();
 	private processedPages: Set<string> = new Set();
 	private requestCount: number = 0;
 	// The total grows as databases and page blocks reveal more pages.
@@ -503,7 +541,7 @@ export class NotionAPIImporter extends FormatImporter {
 	 * Initialize Notion client if not already initialized
 	 */
 	private initializeNotionClient(): void {
-		const scheduler = new NotionRequestScheduler();
+		const scheduler = this.requestCoordinator.forCredential(this.notionToken);
 		this.notionClient = new Client({
 			auth: this.notionToken,
 			notionVersion: NOTION_VERSION,
@@ -515,9 +553,7 @@ export class NotionAPIImporter extends FormatImporter {
 
 				try {
 					await scheduler.waitForTurn();
-					const started = Date.now();
-					let timeout: number | undefined;
-					const response = await Promise.race([
+					const response = await watchForNotionOverload(
 						requestUrl({
 							url: urlString,
 							method: init?.method || 'GET',
@@ -525,19 +561,8 @@ export class NotionAPIImporter extends FormatImporter {
 							body: init?.body as string | ArrayBuffer,
 							throw: false,
 						}),
-						new Promise<never>((_resolve, reject) => {
-							timeout = window.setTimeout(() => {
-								scheduler.overloaded(1000);
-								const error = Object.assign(new Error('Request to Notion API has timed out'), {
-									code: 'notionhq_client_request_timeout',
-								});
-								reject(error);
-							}, NOTION_REQUEST_TIMEOUT_MS);
-						}),
-					]).finally(() => {
-						if (timeout !== undefined) window.clearTimeout(timeout);
-					});
-					scheduler.requestCompleted(Date.now() - started);
+						scheduler,
+					);
 					if (response.status === 429 || response.status === 529) {
 						scheduler.rateLimited(response.headers['retry-after'] ?? response.headers['Retry-After']);
 					}

--- a/src/formats/notion-api.ts
+++ b/src/formats/notion-api.ts
@@ -27,7 +27,100 @@ import { DatabaseInfo, RelationPlaceholder, DatabaseProcessingContext, FetchAndI
 import { downloadAttachment } from './notion-api/attachment-helpers';
 import { buildTree, collectItems, type NotionTreeNode } from './notion-api/discovery';
 
+const NOTION_REQUEST_RATE = 3;
+const NOTION_INITIAL_BURST = 100;
+const NOTION_REQUEST_TIMEOUT_MS = 10_000;
+const NOTION_SLOW_REQUEST_MS = 2_000;
 
+/**
+ * Spend a modest burst before settling at Notion's documented average rate.
+ *
+ * Notion documents an average of three requests a second, with some bursts
+ * allowed. Measured against a thousand-row database, short bursts completed
+ * cleanly but sustained excess traffic eventually stopped receiving responses
+ * instead of returning 429. A token bucket gets the useful part of both
+ * behaviours: small imports can finish inside the burst, while long imports
+ * converge on the documented rate before exhausting the server-side bucket.
+ */
+export class NotionRequestScheduler {
+	private tail: Promise<void> = Promise.resolve();
+	private tokens: number;
+	private lastRefill: number;
+	private blockedUntil = 0;
+	private readonly rate: number;
+	private readonly capacity: number;
+	private readonly now: () => number;
+	private readonly sleep: (milliseconds: number) => Promise<void>;
+
+	constructor(options: {
+		rate?: number;
+		burst?: number;
+		now?: () => number;
+		sleep?: (milliseconds: number) => Promise<void>;
+	} = {}) {
+		this.rate = options.rate ?? NOTION_REQUEST_RATE;
+		this.capacity = options.burst ?? NOTION_INITIAL_BURST;
+		this.now = options.now ?? (() => Date.now());
+		this.sleep = options.sleep ?? (milliseconds => new Promise(resolve => window.setTimeout(resolve, milliseconds)));
+		this.tokens = this.capacity;
+		this.lastRefill = this.now();
+	}
+
+	async waitForTurn(): Promise<void> {
+		let release!: () => void;
+		const previous = this.tail;
+		this.tail = new Promise<void>(resolve => release = resolve);
+
+		await previous;
+		try {
+			while (true) {
+				const now = this.now();
+				const blockedFor = this.blockedUntil - now;
+				if (blockedFor > 0) {
+					await this.sleep(blockedFor);
+					continue;
+				}
+
+				const elapsed = Math.max(0, now - this.lastRefill);
+				this.tokens = Math.min(
+					this.capacity,
+					this.tokens + elapsed * this.rate / 1000,
+				);
+				this.lastRefill = now;
+
+				if (this.tokens >= 1) {
+					this.tokens--;
+					return;
+				}
+
+				const wait = (1 - this.tokens) * 1000 / this.rate;
+				await this.sleep(wait);
+			}
+		}
+		finally {
+			release();
+		}
+	}
+
+	/** A rate-limited response drains our local burst and honours Retry-After. */
+	rateLimited(retryAfter: string | undefined): void {
+		const seconds = retryAfter ? Number.parseInt(retryAfter, 10) : NaN;
+		this.overloaded(Number.isFinite(seconds) && seconds > 0 ? seconds * 1000 : 0);
+	}
+
+	/** A slow or timed-out request is the overload signal Notion often sends in
+	 * place of 429. Drain the burst globally so retries cannot keep piling on. */
+	overloaded(cooldownMs: number = 0): void {
+		this.tokens = 0;
+		const now = this.now();
+		this.blockedUntil = Math.max(this.blockedUntil, now + cooldownMs);
+		this.lastRefill = Math.max(now, this.blockedUntil);
+	}
+
+	requestCompleted(durationMs: number): void {
+		if (durationMs >= NOTION_SLOW_REQUEST_MS) this.overloaded();
+	}
+}
 
 function childPageIds(blocksCache: Map<string, { id: string, type: string }[]>): string[] {
 	const ids: string[] = [];
@@ -410,20 +503,44 @@ export class NotionAPIImporter extends FormatImporter {
 	 * Initialize Notion client if not already initialized
 	 */
 	private initializeNotionClient(): void {
+		const scheduler = new NotionRequestScheduler();
 		this.notionClient = new Client({
 			auth: this.notionToken,
 			notionVersion: NOTION_VERSION,
+			// makeNotionRequest owns retries so an overload signal can slow every
+			// endpoint before the next attempt starts.
+			retry: false,
 			fetch: async (url: RequestInfo | URL, init?: RequestInit) => {
 				const urlString = url instanceof URL ? url.href : typeof url === 'string' ? url : url.url;
 
 				try {
-					const response = await requestUrl({
-						url: urlString,
-						method: init?.method || 'GET',
-						headers: init?.headers as Record<string, string>,
-						body: init?.body as string | ArrayBuffer,
-						throw: false,
+					await scheduler.waitForTurn();
+					const started = Date.now();
+					let timeout: number | undefined;
+					const response = await Promise.race([
+						requestUrl({
+							url: urlString,
+							method: init?.method || 'GET',
+							headers: init?.headers as Record<string, string>,
+							body: init?.body as string | ArrayBuffer,
+							throw: false,
+						}),
+						new Promise<never>((_resolve, reject) => {
+							timeout = window.setTimeout(() => {
+								scheduler.overloaded(1000);
+								const error = Object.assign(new Error('Request to Notion API has timed out'), {
+									code: 'notionhq_client_request_timeout',
+								});
+								reject(error);
+							}, NOTION_REQUEST_TIMEOUT_MS);
+						}),
+					]).finally(() => {
+						if (timeout !== undefined) window.clearTimeout(timeout);
 					});
+					scheduler.requestCompleted(Date.now() - started);
+					if (response.status === 429 || response.status === 529) {
+						scheduler.rateLimited(response.headers['retry-after'] ?? response.headers['Retry-After']);
+					}
 
 					// Convert Obsidian response to fetch Response format
 					return new Response(response.arrayBuffer, {
@@ -866,8 +983,8 @@ export class NotionAPIImporter extends FormatImporter {
 					processedDatabases: this.processedDatabases,
 					relationPlaceholders: this.relationPlaceholders,
 					databasePropertyName: this.databasePropertyName,
-					importPageCallback: async (pageId: string, parentPath: string, databaseTag?: string, customFileName?: string) => {
-						await this.fetchAndImportPage({ ctx, pageId, parentPath, databaseTag, customFileName });
+					importPageCallback: async (pageId, parentPath, databaseTag, customFileName, page, blocks) => {
+						await this.fetchAndImportPage({ ctx, pageId, parentPath, databaseTag, customFileName, page, blocks });
 					},
 					onPagesDiscovered: pageIds => this.pagesDiscovered(ctx, pageIds)
 				},
@@ -885,7 +1002,7 @@ export class NotionAPIImporter extends FormatImporter {
 	 * Fetch and import a Notion page recursively
 	 */
 	protected async fetchAndImportPage(params: FetchAndImportPageParams): Promise<void> {
-		const { ctx, pageId, parentPath, databaseTag, customFileName } = params;
+		const { ctx, pageId, parentPath, databaseTag, customFileName, page: prefetchedPage, blocks: prefetchedBlocks } = params;
 
 		if (await ctx.shouldStop()) return;
 
@@ -902,8 +1019,17 @@ export class NotionAPIImporter extends FormatImporter {
 		let reportedName = i18n.importer.notionApi.labelPage({ id: pageId });
 
 		try {
+			// What a page is and what is on it are two reads that do not need
+			// each other, so a page reached on its own asks for both at once
+			// rather than paying a round trip for the title before starting on
+			// the blocks. A row arrives with both already in hand.
+			const blocksRequest = prefetchedBlocks
+				?? fetchAllBlocks(this.notionClient!, pageId, ctx);
+			// Metadata failing reports the page before the blocks are awaited.
+			void blocksRequest.catch(() => undefined);
+
 			// Fetch page metadata with rate limit handling
-			const page = await makeNotionRequest(
+			const page = prefetchedPage ?? await makeNotionRequest(
 				() => this.notionClient!.pages.retrieve({ page_id: pageId }) as Promise<PageObjectResponse>,
 				ctx
 			);
@@ -922,7 +1048,7 @@ export class NotionAPIImporter extends FormatImporter {
 			const blocksCache = new Map<string, any[]>();
 
 			// Fetch page blocks (content) with rate limit handling
-			const blocks = await fetchAllBlocks(this.notionClient!, pageId, ctx);
+			const blocks = await blocksRequest;
 			// Cache the root page blocks immediately
 			blocksCache.set(pageId, blocks);
 
@@ -1052,8 +1178,8 @@ export class NotionAPIImporter extends FormatImporter {
 					databasePropertyName: this.databasePropertyName, // Add database property name for child databases
 					blocksCache, // Pass blocks cache for recursive block search
 					// Callback to import database pages
-					importPageCallback: async (pageId: string, parentPath: string, databaseTag?: string, customFileName?: string) => {
-						await this.fetchAndImportPage({ ctx, pageId, parentPath, databaseTag, customFileName });
+					importPageCallback: async (pageId, parentPath, databaseTag, customFileName, page, blocks) => {
+						await this.fetchAndImportPage({ ctx, pageId, parentPath, databaseTag, customFileName, page, blocks });
 					},
 					onPagesDiscovered: pageIds => this.pagesDiscovered(ctx, pageIds)
 				}
@@ -1301,7 +1427,7 @@ export class NotionAPIImporter extends FormatImporter {
 						console.warn(`Could not find related page file: ${relatedPagePath}`);
 					}
 
-					const title = await this.relatedPageTitle(relatedPageId);
+					const title = await this.relatedPageTitle(relatedPageId, ctx);
 					if (title) {
 						replacements.set(relatedPageId, title);
 					}
@@ -1347,14 +1473,17 @@ export class NotionAPIImporter extends FormatImporter {
 		}
 	}
 
-	private async relatedPageTitle(pageId: string): Promise<string | null> {
+	private async relatedPageTitle(pageId: string, ctx: ImportContext): Promise<string | null> {
 		const cached = this.relatedPageTitles.get(pageId);
 		if (cached !== undefined) return cached;
 
 		let title: string | null = null;
 
 		try {
-			const page = await this.notionClient!.pages.retrieve({ page_id: pageId });
+			const page = await makeNotionRequest(
+				() => this.notionClient!.pages.retrieve({ page_id: pageId }),
+				ctx,
+			);
 			title = extractPageTitle(page as PageObjectResponse);
 		}
 		catch (error) {
@@ -1387,8 +1516,8 @@ export class NotionAPIImporter extends FormatImporter {
 				formulaStrategy: this.formulaStrategy,
 				processedDatabases: this.processedDatabases,
 				relationPlaceholders: this.relationPlaceholders,
-				importPageCallback: async (pageId: string, parentPath: string, databaseTag?: string, customFileName?: string) => {
-					await this.fetchAndImportPage({ ctx, pageId, parentPath, databaseTag, customFileName });
+				importPageCallback: async (pageId, parentPath, databaseTag, customFileName, page, blocks) => {
+					await this.fetchAndImportPage({ ctx, pageId, parentPath, databaseTag, customFileName, page, blocks });
 				},
 				// onPagesDiscovered callback not provided - not needed for unimported databases
 				databasePropertyName: this.databasePropertyName

--- a/src/formats/notion-api/block-converter.ts
+++ b/src/formats/notion-api/block-converter.ts
@@ -25,7 +25,7 @@ function attachmentTypeLabel(type: AttachmentType): string {
 			return i18n.importer.notionApi.labelAttachmentPdf();
 	}
 }
-import { getBlockChildren, processBlockChildren } from './api-helpers';
+import { getBlockChildren, makeNotionRequest, processBlockChildren } from './api-helpers';
 import { downloadAndFormatAttachment, extractAttachmentFromBlock, getCaptionFromBlock } from './attachment-helpers';
 import { BlockConversionContext, AttachmentType, AttachmentBlockConfig, BlockContext, HeaderContentWithRichTextAndColorResponse } from './types';
 import { createPlaceholder, extractPlaceholderIds, PlaceholderType } from './utils';
@@ -816,7 +816,10 @@ async function createSyncedBlockFile(
 	
 	try {
 		// Fetch the block to get its content
-		const retrievedBlock = await client.blocks.retrieve({ block_id: blockId });
+		const retrievedBlock = await makeNotionRequest(
+			() => client.blocks.retrieve({ block_id: blockId }),
+			ctx,
+		);
 		
 		// Check if it's a full block (not partial)
 		if (!('type' in retrievedBlock)) {

--- a/src/formats/notion-api/database-helpers.ts
+++ b/src/formats/notion-api/database-helpers.ts
@@ -15,7 +15,7 @@ import { ImportContext } from '../../import-context';
 import { sanitizeFileName, getUniqueFilePath, updatePropertyTypes } from '../../util';
 import { i18n } from '../../i18n';
 import { parseFilePath } from '../../filesystem';
-import { makeNotionRequest } from './api-helpers';
+import { fetchAllBlocks, makeNotionRequest } from './api-helpers';
 import { canConvertFormula, convertNotionFormulaToObsidian, getNotionFormulaExpression } from './formula-converter';
 import {
 	DatabaseInfo,
@@ -42,6 +42,54 @@ const OBSIDIAN_PROPERTY_TYPES = {
 	NUMBER: 'number',
 	TEXT: 'text',
 };
+
+/**
+ * How many rows ahead to start reading blocks for.
+ *
+ * Reading a row's blocks is the whole of the network cost of importing it, and
+ * a row cannot start converting until its own read lands, so the window is what
+ * decides how much of the import is spent waiting. A window of one is the
+ * serial import: every row pays a full round trip. On a measured 1,023-row
+ * source, four stayed clean for 86 seconds without the late timeout cliff seen
+ * with windows of eight and sixteen.
+ *
+ * It is a window rather than unbounded concurrency so that conversion and vault
+ * writes stay in row order - the note a row lands in, and the name it gets when
+ * two rows share a title, do not depend on which read came back first.
+ */
+export const DATABASE_PAGE_PREFETCH = 4;
+
+export async function importDatabasePages(
+	pages: PageObjectResponse[],
+	client: Client,
+	ctx: ImportContext,
+	parentPath: string,
+	databaseTag: string,
+	importPage: DatabaseProcessingContext['importPageCallback'],
+): Promise<void> {
+	const blocks = new Map<number, Promise<BlockObjectResponse[]>>();
+
+	const prefetch = (index: number): void => {
+		if (index >= pages.length || blocks.has(index)) return;
+
+		const request = fetchAllBlocks(client, pages[index].id, ctx);
+		// A stopped import may never consume the end of the window. Attach a
+		// rejection handler now while preserving the rejected promise for the page.
+		void request.catch(() => undefined);
+		blocks.set(index, request);
+	};
+
+	for (let index = 0; index < pages.length; index++) {
+		if (await ctx.shouldStop()) break;
+
+		for (let ahead = index; ahead < index + DATABASE_PAGE_PREFETCH; ahead++) prefetch(ahead);
+
+		const page = pages[index];
+		const prefetchedBlocks = blocks.get(index)!;
+		blocks.delete(index);
+		await importPage(page.id, parentPath, databaseTag, undefined, page, prefetchedBlocks);
+	}
+}
 
 /**
  * Convert a child_database block to Markdown
@@ -307,11 +355,17 @@ export async function importDatabaseCore(
 	const { basename: baseFileName } = parseFilePath(baseFilePath);
 	const baseFileTag = `${baseFileName}.base`;
 
-	// Import each database page with .base file tag
-	for (const page of databasePages) {
-		if (await ctx.shouldStop()) break;
-		await importPageCallback(page.id, databaseFolderPath, baseFileTag);
-	}
+	// The query already returned full page metadata. Reuse it instead of
+	// retrieving every row again, and start a small window of block reads while
+	// the preceding row is converted and written.
+	await importDatabasePages(
+		databasePages,
+		client,
+		ctx,
+		databaseFolderPath,
+		baseFileTag,
+		importPageCallback,
+	);
 
 	// Import database template pages (if any)
 	// Templates are stored in the same folder as database pages

--- a/src/formats/notion-api/database-helpers.ts
+++ b/src/formats/notion-api/database-helpers.ts
@@ -43,20 +43,7 @@ const OBSIDIAN_PROPERTY_TYPES = {
 	TEXT: 'text',
 };
 
-/**
- * How many rows ahead to start reading blocks for.
- *
- * Reading a row's blocks is the whole of the network cost of importing it, and
- * a row cannot start converting until its own read lands, so the window is what
- * decides how much of the import is spent waiting. A window of one is the
- * serial import: every row pays a full round trip. On a measured 1,023-row
- * source, four stayed clean for 86 seconds without the late timeout cliff seen
- * with windows of eight and sixteen.
- *
- * It is a window rather than unbounded concurrency so that conversion and vault
- * writes stay in row order - the note a row lands in, and the name it gets when
- * two rows share a title, do not depend on which read came back first.
- */
+/** Higher concurrency caused late request timeouts in large imports. */
 export const DATABASE_PAGE_PREFETCH = 4;
 
 export async function importDatabasePages(
@@ -73,8 +60,7 @@ export async function importDatabasePages(
 		if (index >= pages.length || blocks.has(index)) return;
 
 		const request = fetchAllBlocks(client, pages[index].id, ctx);
-		// A stopped import may never consume the end of the window. Attach a
-		// rejection handler now while preserving the rejected promise for the page.
+		// Prevent unhandled rejections if the import stops before consuming this request.
 		void request.catch(() => undefined);
 		blocks.set(index, request);
 	};
@@ -355,9 +341,6 @@ export async function importDatabaseCore(
 	const { basename: baseFileName } = parseFilePath(baseFilePath);
 	const baseFileTag = `${baseFileName}.base`;
 
-	// The query already returned full page metadata. Reuse it instead of
-	// retrieving every row again, and start a small window of block reads while
-	// the preceding row is converted and written.
 	await importDatabasePages(
 		databasePages,
 		client,

--- a/src/formats/notion-api/types.ts
+++ b/src/formats/notion-api/types.ts
@@ -160,9 +160,7 @@ export interface FetchAndImportPageParams {
 	parentPath: string;
 	databaseTag?: string;
 	customFileName?: string; // Custom file name (without .md extension) to override the page title
-	/** Page metadata already returned by a database query. */
 	page?: PageObjectResponse;
-	/** Root blocks started ahead of this page's ordered conversion. */
 	blocks?: Promise<BlockObjectResponse[]>;
 }
 

--- a/src/formats/notion-api/types.ts
+++ b/src/formats/notion-api/types.ts
@@ -43,7 +43,14 @@ export interface DatabaseProcessingContext {
 	formulaStrategy: FormulaImportStrategy;
 	processedDatabases: Map<string, DatabaseInfo>;
 	relationPlaceholders: RelationPlaceholder[];
-	importPageCallback: (pageId: string, parentPath: string, databaseTag?: string, customFileName?: string) => Promise<void>;
+	importPageCallback: (
+		pageId: string,
+		parentPath: string,
+		databaseTag?: string,
+		customFileName?: string,
+		page?: PageObjectResponse,
+		blocks?: Promise<BlockObjectResponse[]>,
+	) => Promise<void>;
 	onPagesDiscovered?: (pageIds: string[]) => void;
 	databasePropertyName?: string; // Property name for linking pages to their database .base file
 	blocksCache?: Map<string, BlockObjectResponse[]>; // Cache of fetched blocks for recursive search
@@ -153,6 +160,10 @@ export interface FetchAndImportPageParams {
 	parentPath: string;
 	databaseTag?: string;
 	customFileName?: string; // Custom file name (without .md extension) to override the page title
+	/** Page metadata already returned by a database query. */
+	page?: PageObjectResponse;
+	/** Root blocks started ahead of this page's ordered conversion. */
+	blocks?: Promise<BlockObjectResponse[]>;
 }
 
 export interface CreateBaseFileParams {

--- a/src/note-template.ts
+++ b/src/note-template.ts
@@ -5,8 +5,8 @@ import {
 	type TemplateFilter,
 	type TemplateResult,
 	type TemplateVariables,
-} from '@obsidianmd/knap';
-import { htmlFilters } from '@obsidianmd/knap/html';
+} from 'knap';
+import { htmlFilters } from 'knap/html';
 import { createMarkdownContent } from 'defuddle/full';
 
 export type NoteTemplateVariables = TemplateVariables;

--- a/tests/notion-api/database.test.ts
+++ b/tests/notion-api/database.test.ts
@@ -23,7 +23,8 @@ import * as nodePath from 'node:path';
 import { stringifyYaml } from 'obsidian';
 
 import { extractFrontMatter, extractPageTitle } from '../../src/formats/notion-api/api-helpers';
-import { processRelationProperties, replaceRelationValue, yamlScalar } from '../../src/formats/notion-api/database-helpers';
+import { DATABASE_PAGE_PREFETCH, importDatabasePages, processRelationProperties, replaceRelationValue, yamlScalar } from '../../src/formats/notion-api/database-helpers';
+import { ImportContext } from '../../src/import-context';
 import type { RelationPlaceholder } from '../../src/formats/notion-api/types';
 import { expectFile, expectedFor, type Fixture } from '../helpers';
 
@@ -39,6 +40,60 @@ interface DatabaseFixture {
 }
 
 const fixture = JSON.parse(nodeFs.readFileSync(FIXTURE.path, 'utf8')) as DatabaseFixture;
+
+test('database rows read a window ahead but import in order', async () => {
+	const total = DATABASE_PAGE_PREFETCH + 3;
+	const pages = Array.from({ length: total }, (_, index) => ({
+		object: 'page',
+		id: `row-${index}`,
+		properties: {},
+	})) as never[];
+	const requested: string[] = [];
+	const requestedWhenImported: string[][] = [];
+	const imported: string[] = [];
+	const client = {
+		blocks: {
+			children: {
+				list: async ({ block_id }: { block_id: string }) => {
+					requested.push(block_id);
+					return { results: [], has_more: false, next_cursor: null };
+				},
+			},
+		},
+	} as never;
+
+	await importDatabasePages(
+		pages,
+		client,
+		new ImportContext(),
+		'Notion/Database',
+		'Database.base',
+		async (pageId, parentPath, databaseTag, customFileName, page, blocks) => {
+			requestedWhenImported.push([...requested]);
+			assert.equal(parentPath, 'Notion/Database');
+			assert.equal(databaseTag, 'Database.base');
+			assert.equal(customFileName, undefined);
+			assert.equal(page, pages[Number(pageId.slice(4))]);
+			assert.deepEqual(await blocks, []);
+			imported.push(pageId);
+		},
+	);
+
+	const row = (index: number) => `row-${index}`;
+	assert.deepEqual(imported, Array.from({ length: total }, (_, index) => row(index)));
+
+	// Reading row n starts every row up to the end of the window, and no more.
+	assert.deepEqual(
+		requestedWhenImported,
+		Array.from({ length: total }, (_, index) =>
+			Array.from(
+				{ length: Math.min(index + DATABASE_PAGE_PREFETCH, total) },
+				(_, ahead) => row(ahead),
+			)),
+	);
+	assert.equal(requestedWhenImported[0].length, DATABASE_PAGE_PREFETCH);
+	assert.deepEqual(requested, Array.from({ length: total }, (_, index) => row(index)));
+});
 
 test('the fixture has a relation that stays in the import and one that leaves it', () => {
 	const relations = Object.entries(fixture.properties).filter(([, p]) => p.type === 'relation');

--- a/tests/notion-api/database.test.ts
+++ b/tests/notion-api/database.test.ts
@@ -82,7 +82,6 @@ test('database rows read a window ahead but import in order', async () => {
 	const row = (index: number) => `row-${index}`;
 	assert.deepEqual(imported, Array.from({ length: total }, (_, index) => row(index)));
 
-	// Reading row n starts every row up to the end of the window, and no more.
 	assert.deepEqual(
 		requestedWhenImported,
 		Array.from({ length: total }, (_, index) =>

--- a/tests/notion-api/progress.test.ts
+++ b/tests/notion-api/progress.test.ts
@@ -37,6 +37,16 @@ class CountingImporter extends NotionAPIImporter {
 		return this.fetchAndImportPage({ ctx, pageId, parentPath: 'Notion' });
 	}
 
+	importPrefetchedPage(ctx: ImportContext, page: any, blocks: Promise<any[]>) {
+		return this.fetchAndImportPage({
+			ctx,
+			pageId: page.id,
+			parentPath: 'Notion',
+			page,
+			blocks,
+		});
+	}
+
 	discover(ctx: ImportContext, pageIds: string[]) {
 		(this as unknown as { pagesDiscovered(c: ImportContext, ids: string[]): void }).pagesDiscovered(ctx, pageIds);
 	}
@@ -61,6 +71,33 @@ test('a page nobody ticked in the tree still counts', async () => {
 
 	assert.equal(ctx.progressTotal, 1);
 	assert.equal(remaining(ctx), 0);
+});
+
+test('a database row reuses prefetched metadata and blocks', async () => {
+	const { subject, ctx } = await importer();
+	let metadataReads = 0;
+	let blockReads = 0;
+	(subject as any).notionClient = {
+		pages: { retrieve: async () => { metadataReads++; throw new Error('metadata was fetched again'); } },
+		blocks: { children: { list: async () => { blockReads++; throw new Error('blocks were fetched again'); } } },
+	};
+
+	const page = {
+		object: 'page',
+		id: 'row-1',
+		created_time: '2025-01-01T00:00:00.000Z',
+		last_edited_time: '2025-01-01T00:00:00.000Z',
+		properties: {
+			Name: { type: 'title', title: [{ plain_text: 'Row one' }] },
+		},
+	};
+
+	await subject.importPrefetchedPage(ctx, page, Promise.resolve([]));
+
+	assert.equal(metadataReads, 0);
+	assert.equal(blockReads, 0);
+	assert.equal(ctx.notes, 1);
+	assert.deepEqual(ctx.failed, []);
 });
 
 test('a database raises the total by the rows it turned out to hold', async () => {

--- a/tests/notion-api/scheduler.test.ts
+++ b/tests/notion-api/scheduler.test.ts
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { NotionRequestScheduler } from '../../src/formats/notion-api';
+
+function scheduler() {
+	let now = 0;
+	const waits: number[] = [];
+	const subject = new NotionRequestScheduler({
+		rate: 2,
+		burst: 2,
+		now: () => now,
+		sleep: async milliseconds => {
+			waits.push(milliseconds);
+			now += milliseconds;
+		},
+	});
+
+	return { subject, waits };
+}
+
+test('the scheduler spends its burst before settling at the average rate', async () => {
+	const { subject, waits } = scheduler();
+
+	await subject.waitForTurn();
+	await subject.waitForTurn();
+	assert.deepEqual(waits, []);
+
+	await subject.waitForTurn();
+	assert.deepEqual(waits, [500]);
+});
+
+test('an overload drains the burst and applies a global cooldown', async () => {
+	const { subject, waits } = scheduler();
+
+	subject.overloaded(1000);
+	await subject.waitForTurn();
+
+	assert.deepEqual(waits, [1000, 500]);
+});
+
+test('a slow response switches the scheduler to its sustained rate', async () => {
+	const { subject, waits } = scheduler();
+
+	subject.requestCompleted(2000);
+	await subject.waitForTurn();
+
+	assert.deepEqual(waits, [500]);
+});

--- a/tests/notion-api/scheduler.test.ts
+++ b/tests/notion-api/scheduler.test.ts
@@ -1,7 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { NotionRequestScheduler } from '../../src/formats/notion-api';
+import {
+	NotionRequestCoordinator,
+	NotionRequestScheduler,
+	watchForNotionOverload,
+} from '../../src/formats/notion-api';
 
 function scheduler() {
 	let now = 0;
@@ -39,11 +43,38 @@ test('an overload drains the burst and applies a global cooldown', async () => {
 	assert.deepEqual(waits, [1000, 500]);
 });
 
-test('a slow response switches the scheduler to its sustained rate', async () => {
+test('the same credential keeps one scheduler across client initialization', () => {
+	const coordinator = new NotionRequestCoordinator();
+	const first = coordinator.forCredential('first');
+
+	assert.equal(coordinator.forCredential('first'), first);
+	assert.notEqual(coordinator.forCredential('second'), first);
+});
+
+test('a slow response switches the scheduler to its sustained rate without abandoning it', async () => {
 	const { subject, waits } = scheduler();
+	let resolve!: (value: string) => void;
+	const request = new Promise<string>(done => resolve = done);
+	let watchdog!: () => void;
+	const cleared: number[] = [];
+	let settled = false;
+	const watched = watchForNotionOverload(request, subject, {
+		set: callback => {
+			watchdog = callback;
+			return 7;
+		},
+		clear: timer => cleared.push(timer),
+	});
+	void watched.then(() => settled = true);
 
-	subject.requestCompleted(2000);
+	watchdog();
+	await Promise.resolve();
+	assert.equal(settled, false);
+
 	await subject.waitForTurn();
-
 	assert.deepEqual(waits, [500]);
+
+	resolve('finished');
+	assert.equal(await watched, 'finished');
+	assert.deepEqual(cleared, [7]);
 });


### PR DESCRIPTION
Speeds up Notion API imports by reusing database page metadata, prefetching block requests with bounded concurrency, and sharing adaptive request pacing across imports. This reduces redundant API calls while preventing overload stalls and overlapping retries.